### PR TITLE
SearchResults container idea

### DIFF
--- a/caproto/_utils.py
+++ b/caproto/_utils.py
@@ -792,12 +792,15 @@ class ThreadsafeCounter:
     '''
     MAX_ID = 2 ** 16
 
-    def __init__(self, *, initial_value=-1, dont_clash_with=None):
+    def __init__(self, *, initial_value=-1, dont_clash_with=None, lock=None):
         if dont_clash_with is None:
             dont_clash_with = set()
 
+        if lock is None:
+            lock = threading.RLock()
+
         self.value = initial_value
-        self.lock = threading.RLock()
+        self.lock = lock
         self.dont_clash_with = dont_clash_with
 
     def __call__(self):

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -705,3 +705,18 @@ def test_time_since_last_heard(context, ioc):
     assert address == pv.circuit_manager.circuit.address
     assert 0 < t < 10
     pv.time_since_last_heard() - t < 10  # wide tolerance here for slow CI
+
+
+def test_cancel(context):
+    name = 'does_not_exist'
+    context.get_pvs(name)
+    assert context.broadcaster.search_results._searches_by_name
+    assert context.broadcaster.search_results._searches
+    assert context.broadcaster.search_results._unanswered_searches
+    context.broadcaster.cancel(name)
+    assert context.broadcaster.search_results._searches
+    assert not context.broadcaster.search_results._unanswered_searches
+    assert not context.broadcaster.search_results._searches_by_name
+
+    # This should not raise.
+    context.broadcaster.cancel('never searched for this in the first place')

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -306,6 +306,23 @@ class SearchResults:
 
         1. `SearchResults()[name] -> [time, address]`
         2. `name in SearchResults()`
+
+    Attributes
+    ----------
+    name_to_addr : dict
+        Holds search results.
+        Maps name -> (time, address)
+    addr_to_name : dict
+        Holds search results.
+        Maps address -> {name1, name2, ...}
+    _unanswered_searches : dict
+        Holds pending searches
+        Maps search_id -> [name, results_queue, retirement_deadline]
+    _lock : threading.RLock
+        Lock for internal updates to SearchResults status
+    _search_id_counter : ThreadsafeCounter
+        Counter for new searches. This will be kept in sync with
+        _unanswered_searches such that there is no overlap in keys.
     '''
 
     def __init__(self):

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -786,7 +786,6 @@ class SharedBroadcaster:
                 continue
 
             queues.clear()
-            now = time.monotonic()
             for command in commands:
                 if isinstance(command, ca.Beacon):
                     now = time.monotonic()

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1176,11 +1176,10 @@ class Context:
             pvs.append(pv)
             name, _ = key
             names.append(name)
-            # If there is a cached search result for this name, expire it.
 
-            # TODO: search lock
-            # self.broadcaster.search_results.mark_channel_disconnected(
-            #     name, pv.address)
+            # If there is a cached search result for this name, expire it.
+            self.broadcaster.search_results.mark_channel_disconnected(
+                name, pv.channel.circuit.address)
 
             with self.pv_cache_lock:
                 self.pvs_needing_circuits[name].add(pv)

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -572,7 +572,6 @@ class SharedBroadcaster:
         # PVs (via Context.get_pvs).
         self._search_now = threading.Event()
 
-        self.results = SearchResults()
         self.server_protocol_versions = {}  # map address to protocol version
 
         self.listeners = weakref.WeakSet()

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -469,8 +469,8 @@ class SharedBroadcaster:
                         # A valid connection exists in one of our clients, so
                         # ignore the stale result status
                         with self._search_lock:
+                            address = cm.circuit.address
                             self.search_results[name] = (address, time.monotonic())
-                        # TODO verify that addr matches address
                         return address
 
             with self._search_lock:

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -27,7 +27,7 @@ import weakref
 
 from queue import Queue, Empty
 from inspect import Parameter, Signature
-from collections import defaultdict, deque
+from collections import defaultdict
 import caproto as ca
 from .._constants import (MAX_ID, STALE_SEARCH_EXPIRATION,
                           SEARCH_MAX_DATAGRAM_BYTES, RESPONSIVENESS_TIMEOUT)

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -377,11 +377,8 @@ class SearchResults:
         :meth:`get_pvs` is called again.
         """
         for name in names:
-            try:
-                cid = self._searches_by_name[name]
-            except KeyError:
-                ...
-            else:
+            cid = self._searches_by_name.pop(name, None)
+            if cid is not None:
                 self._unanswered_searches.pop(cid, None)
 
     def __contains__(self, name):

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -40,9 +40,17 @@ from .._utils import (batch_requests, CaprotoError, ThreadsafeCounter,
 CIRCUIT_DEATH_ATTEMPTS = 3
 
 # sentinels used as default values for arguments
-CONTEXT_DEFAULT_TIMEOUT = object()
-PV_DEFAULT_TIMEOUT = object()
-VALID_CHANNEL_MARKER = object()
+
+def _sentinel(name):
+    class Sentinel:
+        def __repr__(self):
+            return name
+    return Sentinel()
+
+
+CONTEXT_DEFAULT_TIMEOUT = _sentinel('CONTEXT_DEFAULT_TIMEOUT')
+PV_DEFAULT_TIMEOUT = _sentinel('PV_DEFAULT_TIMEOUT')
+VALID_CHANNEL_MARKER = _sentinel('VALID_CHANNEL_MARKER')
 
 
 class DeadCircuitError(CaprotoError):

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -512,18 +512,13 @@ class SearchResults:
         'Search for names, adding items to results_queue'
         # Search requests that are past their retirement deadline with no
         # results will be searched for less frequently.
-        new_searches = dict(
-            (self._search_id_counter(),
-             [name, results_queue, 0, retirement_deadline]
-             )
-            for name in names)
+        for name in names:
+            id_ = self._search_id_counter()
+            item = [name, results_queue, 0, retirement_deadline]
 
-        self._unanswered_searches.update(new_searches)
-        self._searches.update(new_searches)
-
-        for id, info in new_searches.items():
-            name, *_ = info
-            self._searches_by_name[name] = info
+            self._unanswered_searches[id_] = item
+            self._searches[id_] = item
+            self._searches_by_name[name] = item
 
     @_locked
     def check_cache(self, names):

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -418,8 +418,9 @@ class SearchResults:
     @_locked
     def mark_server_alive(self, addr):
         'Beacon from a server received'
+        now = time.monotonic()
         for name in self.addr_to_names[addr]:
-            self.name_to_addrs[name][addr] = time.monotonic()
+            self.name_to_addrs[name][addr] = now
 
     @_locked
     def mark_server_disconnected(self, addr):
@@ -454,9 +455,10 @@ class SearchResults:
         entry = self.name_to_addrs[name]
         result_addr = None
         result_timestamp = None
+        now = time.monotonic()
         for addr, timestamp in list(entry.items()):
             if ((timestamp is VALID_CHANNEL_MARKER) or
-                    (time.monotonic() - timestamp) < threshold):
+                    (now - timestamp) < threshold):
                 if result_timestamp is not VALID_CHANNEL_MARKER:
                     result_addr = addr
                     result_timestamp = timestamp

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -402,10 +402,15 @@ class SearchResults:
         Any PV instances that were awaiting these results will be stuck until
         :meth:`get_pvs` is called again.
         """
+        items = []
         for name in names:
-            cid = self._searches_by_name.pop(name, None)
-            if cid is not None:
-                self._unanswered_searches.pop(cid, None)
+            item = self._searches_by_name.pop(name, None)
+            if item is not None:
+                items.append(item)
+        if items:
+            for search_id, item in list(self._unanswered_searches.items()):
+                if item in items:
+                    del self._unanswered_searches[search_id]
 
     def __contains__(self, name):
         return bool(self.name_to_addrs.get(name, {}))

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -385,7 +385,8 @@ class SearchResults:
 
     @property
     def num_unanswered_searches(self):
-        'All unanswered searches'
+        'Number of unanswered searches'
+        # This is used in the Context's __repr__. Might be useful in general.
         return len(self._unanswered_searches)
 
     @_locked

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -335,9 +335,15 @@ class SearchResults:
     addr_to_name : dict
         Holds search results.
         Maps address -> {name1, name2, ...}
+    _searches : dict
+        Holds all searches, answered and unanswered
+        Maps search_id -> [name, results_queue, resend_deadline, retirement_deadline]
+    _searches_by_name : dict
+        Holds all searches, answered and unanswered
+        Maps name -> [name, results_queue, resend_deadline, retirement_deadline]
     _unanswered_searches : dict
         Holds pending searches
-        Maps search_id -> [name, results_queue, retirement_deadline]
+        Maps search_id -> [name, results_queue, resend_deadline, retirement_deadline]
     _lock : threading.RLock
         Lock for internal updates to SearchResults status
     _search_id_counter : ThreadsafeCounter

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -378,10 +378,9 @@ class SearchResults:
             item[-1] = retirement_deadline
 
     @property
-    @_locked
-    def unanswered_searches(self):
+    def num_unanswered_searches(self):
         'All unanswered searches'
-        return dict(self._unanswered_searches)
+        return len(self._unanswered_searches)
 
     @_locked
     def cancel(self, *names):
@@ -1118,7 +1117,7 @@ class Context:
 
     def __repr__(self):
         return (f"<Context "
-                f"searches_pending={len(self.broadcaster.search_results.unanswered_searches)} "
+                f"searches_pending={self.broadcaster.search_results.num_unanswered_searches} "
                 f"circuits={len(self.circuit_managers)} "
                 f"pvs={len(self.pvs)} "
                 f"idle={len([1 for pv in self.pvs.values() if pv._idle])}>")

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -27,7 +27,6 @@ import weakref
 
 from queue import Queue, Empty
 from inspect import Parameter, Signature
-from functools import partial
 from collections import defaultdict, deque
 import caproto as ca
 from .._constants import (MAX_ID, STALE_SEARCH_EXPIRATION,
@@ -90,7 +89,7 @@ def ensure_connected(func):
             pv._usages += 1
 
         try:
-            for i in range(CIRCUIT_DEATH_ATTEMPTS):
+            for _ in range(CIRCUIT_DEATH_ATTEMPTS):
                 # On each iteration, subtract the time we already spent on any
                 # previous attempts.
                 if timeout is not None:

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -38,9 +38,6 @@ from .._utils import (batch_requests, CaprotoError, ThreadsafeCounter,
                       CaprotoKeyError, CaprotoNetworkError)
 
 
-print = partial(print, flush=True)
-
-
 CIRCUIT_DEATH_ATTEMPTS = 3
 
 # sentinels used as default values for arguments

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -39,9 +39,9 @@ from .._utils import (batch_requests, CaprotoError, ThreadsafeCounter,
 
 CIRCUIT_DEATH_ATTEMPTS = 3
 
-# sentinels used as default values for arguments
 
 def _sentinel(name):
+    "Sentinels are used as default values for arguments."
     class Sentinel:
         def __repr__(self):
             return name


### PR DESCRIPTION
Here's a thought (a currently non-working one):
Break out search result storage and thread-safe updating into its own class

Advantages:
* Easier to keep locking logic in your head
* Locking can be done separately from broadcaster class state
* Could write some tests directly against the search results (maybe even fuzzing); to verify its functionality
*  (@danielballan noted below) Potential re-use in all clients
*  (@danielballan noted below) Much more easily tweakable, allowing for further customization as in #452

In my usual poor form, this got confused with another attempt at removing an awkward loop I had previously tagged with a `TODO`. For the meat of this PR, look at the latest commit.