### PR TITLE
MNT: make enum field on scalars_and_arrays mock a bi record

### DIFF
--- a/caproto/ioc_examples/scalars_and_arrays.py
+++ b/caproto/ioc_examples/scalars_and_arrays.py
@@ -27,7 +27,7 @@ class ArrayIOC(PVGroup):
                       max_length=10)
     # ENUM should not be used as an array type:
     enum = pvproperty(value='no', enum_strings=['no', 'yes'],
-                      dtype=ChannelType.ENUM)
+                      dtype=ChannelType.ENUM, mock_record='bi')
 
     @scalar_int.scan(period=1)
     async def scalar_int(self, instance, async_lib):


### PR DESCRIPTION
This was sitting in a stash on my laptop, I think this will make the
example IOC play nicer with viewers.