### PR TITLE
CI: Fix typo in doctr deploy command.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,5 +108,5 @@ script:
   # Upload the docs to gh-pages.
   - if [[ $PUBLISH_DOCS ]]; then
         doctr deploy --deploy-repo NSLS-II/NSLS-II.github.io --deploy-branch-name master caproto;
-        doctr deploy --deploy-repo bluesky/bluesky.github.io --deploy-branch-name master caproto;
+        doctr deploy --deploy-repo caproto/caproto.github.io --deploy-branch-name master caproto;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,11 +103,8 @@ script:
   # Run a CA Repeater for the docs examples to use.
   - caproto-repeater &
   # Build the docs.
-  - pushd doc
-  - make html
-  - popd
+  - make -C doc html
   - flake8
-
   # Upload the docs to gh-pages.
   - if [[ $PUBLISH_DOCS ]]; then
         doctr deploy --deploy-repo NSLS-II/NSLS-II.github.io --deploy-branch-name master caproto;


### PR DESCRIPTION
Correction to #479. Once it was merged and tried to publish the docs, we can
see that [it failed](https://travis-ci.org/caproto/caproto/jobs/530885729)
becauasethe token was (correctly) set up for caproto.github.io
but the command to push tries (incorrectly) to publish to bluesky.github.io.