### PR TITLE
ENH: pvproperty doc kwarg becomes DESC

### DIFF
--- a/caproto/ioc_examples/mocking_records.py
+++ b/caproto/ioc_examples/mocking_records.py
@@ -18,7 +18,8 @@ class RecordMockingIOC(PVGroup):
                    upper_ctrl_limit=3.0,
                    lower_ctrl_limit=-3.0,
                    units="mm",
-                   precision=3)
+                   precision=3,
+                   doc='The C pvproperty')
 
     @B.putter
     async def B(self, instance, value):

--- a/caproto/server/records.py
+++ b/caproto/server/records.py
@@ -208,6 +208,8 @@ class RecordFieldGroup(PVGroup):
     async def process_record(self, instance, value):
         await self.parent.write(self.parent.value)
 
+    _link_parent_attribute(description, '__doc__', use_setattr=True)
+
 
 class _Limits(PVGroup):
     high_alarm_limit = pvproperty(

--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -108,6 +108,7 @@ class PvpropertyData:
             self.field_inst = field_class(
                 prefix='', parent=self,
                 name=f'{self.name}.fields')
+
             self.fields = self.field_inst.pvdb
         else:
             self.field_inst = None


### PR DESCRIPTION
Something like this:
```python
    heartbeat = pvproperty(value=0, mock_record='bo', doc='The heartbeat signal')
```

Becomes:
```bash
$ caget -S heartbeat.RTYP
heartbeat.RTYP bo

$ caget -S heartbeat.DESC         # <----
heartbeat.DESC The heartbeat signal
```