### PR TITLE
ENH: allow init kwargs to pass through to SubGroups

### DIFF
--- a/caproto/ioc_examples/subgroups.py
+++ b/caproto/ioc_examples/subgroups.py
@@ -23,10 +23,16 @@ class RecordLike(PVGroup):
 
 class MySubGroup(PVGroup):
     'Example group of PVs, where the prefix is defined on instantiation'
+
+    def __init__(self, *args, max_value, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.max_value = max_value
+
     # PV: {prefix}random - defaults to dtype of int
     @pvproperty
     async def random(self, instance):
-        return random.randint(1, 100)
+        print('Picking a random value from 1 to', self.max_value)
+        return random.randint(1, self.max_value)
 
 
 class MyPVGroup(PVGroup):
@@ -44,9 +50,9 @@ class MyPVGroup(PVGroup):
     recordlike2 = SubGroup(RecordLike)
 
     # PV: {prefix}group1:random
-    group1 = SubGroup(MySubGroup)
+    group1 = SubGroup(MySubGroup, max_value=5)
     # PV: {prefix}group2-random
-    group2 = SubGroup(MySubGroup, prefix='group2-')
+    group2 = SubGroup(MySubGroup, prefix='group2-', max_value=20)
 
     # PV: {prefix}group3_prefix:random
     @SubGroup(prefix='group3_prefix:')

--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -716,7 +716,7 @@ class SubGroup:
             self.attr_separator = attr_separator
         self.base = (PVGroup, ) if base is None else base
         self.__doc__ = doc
-        self.init_kwargs = dict(init_kwargs) if init_kwargs else {}
+        self.init_kwargs = init_kwargs
         # Set last with setter
         self.group = group
 

--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -734,20 +734,6 @@ class SubGroup:
             assert inspect.isclass(group), 'Group should be dict or SubGroup'
             assert issubclass(group, PVGroup)
             self.group_cls = group
-            valid_init_kw = {
-                key
-                for cls in inspect.getmro(self.group_cls)
-                for key in inspect.signature(cls).parameters.keys()
-            }
-            invalid_kwargs = [kw
-                              for kw in self.init_kwargs
-                              if kw not in valid_init_kw
-                              ]
-            if invalid_kwargs:
-                raise RuntimeError(
-                    f'Invalid kwargs used for class {group.__name__}: '
-                    f'{invalid_kwargs}'
-                )
         else:
             self.group_dict = None
             self.group_cls = None


### PR DESCRIPTION
TODO/refactor: `valid_init_kw` is copy/pasted in a few places here