### PR TITLE
ENH: link ZNAM and ONAM to the parent enum_strings

### DIFF
--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -748,6 +748,12 @@ class ChannelEnum(ChannelData):
         flags |= (SubscriptionType.DBE_LOG | SubscriptionType.DBE_VALUE)
         await super().write_from_dbr(*args, flags=flags, **kwargs)
 
+    async def write_metadata(self, enum_strings=None, **kwargs):
+        if enum_strings is not None:
+            self._data['enum_strings'] = tuple(enum_strings)
+
+        return await super().write_metadata(**kwargs)
+
 
 class ChannelNumeric(ChannelData):
     def __init__(self, *, value, units='',

--- a/caproto/ioc_examples/enums.py
+++ b/caproto/ioc_examples/enums.py
@@ -8,14 +8,13 @@ class EnumIOC(PVGroup):
     """
     An IOC with some enums
 
+    Each mock actual EPICS record fields and link the ZNAM and ONAM fields
+    appropriately.
+
     Scalar PVs
     ----------
-    A (int)
-    B (float)
-
-    Vectors PVs
-    -----------
-    C (vector of int)
+    bo (enum) - a mocked binary output record
+    bi (enum) - a mocked binary input record
     """
     bo = pvproperty(value='One Value',
                     enum_strings=['Zero Value', 'One Value'],

--- a/caproto/ioc_examples/enums.py
+++ b/caproto/ioc_examples/enums.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from caproto.server import pvproperty, PVGroup, ioc_arg_parser, run
+from caproto import ChannelType
+from textwrap import dedent
+
+
+class EnumIOC(PVGroup):
+    """
+    An IOC with some enums
+
+    Scalar PVs
+    ----------
+    A (int)
+    B (float)
+
+    Vectors PVs
+    -----------
+    C (vector of int)
+    """
+    bo = pvproperty(value='One Value',
+                    enum_strings=['Zero Value', 'One Value'],
+                    mock_record='bo',
+                    dtype=ChannelType.ENUM)
+    bi = pvproperty(value='a',
+                    enum_strings=['a', 'b'],
+                    mock_record='bi',
+                    dtype=ChannelType.ENUM)
+
+
+if __name__ == '__main__':
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix='enum:',
+        desc=dedent(EnumIOC.__doc__))
+    ioc = EnumIOC(**ioc_options)
+    run(ioc.pvdb, **run_options)

--- a/caproto/server/records.py
+++ b/caproto/server/records.py
@@ -38,6 +38,27 @@ def _link_parent_attribute(pvprop, parent_attr_name, *, read_only=False,
     return pvprop
 
 
+def _link_enum_strings(pvprop, index):
+    'Take a pvproperty and link its parent enum_strings[index]'
+
+    @pvprop.getter
+    async def getter(self, instance):
+        return self.parent.enum_strings[index]
+
+    @pvprop.putter
+    async def putter(self, instance, value):
+        enum_strings = list(self.parent.enum_strings)
+
+        old_enum = enum_strings[index]
+        enum_strings[index] = str(value)[:instance.max_length - 1]
+
+        await self.parent.write_metadata(enum_strings=enum_strings)
+        if self.parent.value in (old_enum, index):
+            await self.parent.write(value=index)
+
+    return pvprop
+
+
 def register_record(cls):
     'Register a record type to be used with pvproperty mock_record'
     assert issubclass(cls, PVGroup)
@@ -1272,6 +1293,9 @@ class BiFields(RecordFieldGroup):
         enum_strings=menus.menuAlarmSevr.get_string_tuple(),
         doc='Sim mode Alarm Svrty')
 
+    _link_enum_strings(zero_name, index=0)
+    _link_enum_strings(one_name, index=1)
+
 
 @register_record
 class BoFields(RecordFieldGroup):
@@ -1366,6 +1390,9 @@ class BoFields(RecordFieldGroup):
         name='OUT', dtype=ChannelType.STRING, doc='Output Specification')
     seconds_to_hold_high = pvproperty(
         name='HIGH', dtype=ChannelType.DOUBLE, doc='Seconds to Hold High')
+
+    _link_enum_strings(zero_name, index=0)
+    _link_enum_strings(one_name, index=1)
 
 
 @register_record
@@ -1463,6 +1490,9 @@ class BusyFields(RecordFieldGroup):
         name='OUT', dtype=ChannelType.STRING, doc='Output Specification')
     seconds_to_hold_high = pvproperty(
         name='HIGH', dtype=ChannelType.DOUBLE, doc='Seconds to Hold High')
+
+    _link_enum_strings(zero_name, index=0)
+    _link_enum_strings(one_name, index=1)
 
 
 @register_record

--- a/caproto/tests/test_examples.py
+++ b/caproto/tests/test_examples.py
@@ -501,3 +501,24 @@ def test_pvproperty_string_array(request, prefix):
     write(array_string_pv, ['array', 'of', 'strings'], notify=True)
     time.sleep(0.5)
     assert read(array_string_pv).data == [b'array', b'of', b'strings']
+
+
+def test_enum_linking(request, prefix):
+    from .conftest import run_example_ioc
+    run_example_ioc('caproto.ioc_examples.enums',
+                    request=request,
+                    args=['--prefix', prefix], pv_to_check=f'{prefix}bi')
+
+    from caproto.sync.client import read, write
+
+    def string_read(pv):
+        return b''.join(read(pv, data_type=ca.ChannelType.STRING).data)
+
+    for pv, znam, onam in [(f'{prefix}bi', b'a', b'b'),
+                           (f'{prefix}bo', b'Zero Value', b'One Value')]:
+        assert string_read(f'{pv}.ZNAM') == znam
+        assert string_read(f'{pv}.ONAM') == onam
+
+        for value, expected in ([0, znam], [1, onam]):
+            write(pv, [value], notify=True)
+            assert string_read(pv) == expected


### PR DESCRIPTION
Specify an enum in a `pvproperty`, and `ZNAM` and `ONAM` for mocked `bi`/`bo` records will be automatically linked.

Example IOC + test added.