### PR TITLE
ENH: add precision to motor_ph in mini_beamline

### DIFF
--- a/caproto/ioc_examples/mini_beamline.py
+++ b/caproto/ioc_examples/mini_beamline.py
@@ -21,7 +21,7 @@ class _JitterDetector(PVGroup):
     async def det(self, instance):
         return (await self._read(instance))
 
-    mtr = pvproperty(value=0, dtype=float)
+    mtr = pvproperty(value=0, dtype=float, precision=3)
     exp = pvproperty(value=1, dtype=float)
 
     @exp.putter


### PR DESCRIPTION
At the NSLS-II User Meeting'19 participants of the [Bluesky tutorial](https://usersmeeting.ps.bnl.gov/workshops/workshop.aspx?year=2019&id=160) complained about the integer positions in the scan reported by the [`motor_ph`](https://github.com/bluesky/tutorial/blob/f3442674f0ee381c4e9fe23756d15604b83b574d/scripts/beamline_configuration.py#L155-L156) motor. The precision for that motor is set to `0`:
![20190520_140059](https://user-images.githubusercontent.com/13209176/58047672-ac328600-7b16-11e9-8ae1-7c6186a295dd.jpg)

This PR attempts to resolve it.