### PR TITLE
FIX: Handle case where filter_ is None or empty.

### DIFF
--- a/caproto/_utils.py
+++ b/caproto/_utils.py
@@ -618,6 +618,9 @@ def parse_channel_filter(filter_text):
     "Parse and validate filter_text into a ChannelFilter."
     # https://epics.anl.gov/base/R3-15/5-docs/filters.html
 
+    if not filter_text:
+        return ChannelFilter(ts=False, dbnd=None, sync=None, arr=None)
+
     # If there is a shorthand array filter, that is the only filter allowed, so
     # we parse that and return, shortcircuiting the rest.
     if filter_text.startswith('[') and filter_text.endswith(']'):


### PR DESCRIPTION
Attempt to fix a bug reported on the Nikea Slack where `filter_` is `None`:

```python
        modifiers = parse_record_field(name).modifiers
        if modifiers is not None:
            self.channel_filter = parse_channel_filter(modifiers.filter_)
```