### PR TITLE
ENH: add an example that publishes a gamepad input to the network

### DIFF
--- a/caproto/ioc_examples/gamepad.py
+++ b/caproto/ioc_examples/gamepad.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+This example requires a gamepad and the Python library evdev.
+
+This only works on linux (as it uses the linux kernel input events).
+"""
+from caproto.server import pvproperty, PVGroup, template_arg_parser, run
+from evdev import InputDevice
+
+
+class GampadIOC(PVGroup):
+    def __init__(self, event_path, **kwargs):
+        super().__init__(**kwargs)
+        self._event_path = event_path
+
+    # normal buttons
+    a = pvproperty(value=0, max_length=1)
+    b = pvproperty(value=0, max_length=1)
+    x = pvproperty(value=0, max_length=1)
+    y = pvproperty(value=0, max_length=1)
+    lb = pvproperty(value=0, max_length=1)
+    rb = pvproperty(value=0, max_length=1)
+
+    # joysticks
+
+    # left joystick
+    lx = pvproperty(value=0, max_length=1)
+    ly = pvproperty(value=0, max_length=1)
+
+    # right joystick, always analog
+    rx = pvproperty(value=0, max_length=1)
+    ry = pvproperty(value=0, max_length=1)
+
+    # DPAD, depending on mode, may also come from left joystick
+    dx = pvproperty(value=0, max_length=1)
+    dy = pvproperty(value=0, max_length=1)
+
+    # Trigger buttons
+    lt = pvproperty(value=0, max_length=1)
+    rt = pvproperty(value=0, max_length=1)
+
+    # admin
+    sel = pvproperty(value=0, max_length=1)
+    back = pvproperty(value=0, max_length=1)
+
+    alive = pvproperty(value=0, max_length=1)
+
+    @alive.startup
+    async def alive(self, instance, async_lib):
+        await instance.write(value=1)
+        async for target, value in gp_driver(InputDevice(self._event_path)):
+            await getattr(self, target).write(value=value)
+        await instance.write(value=0)
+
+
+async def gp_driver(dev):
+    analog_mapping = {
+        # game pad
+        17: 'dy',
+        16: 'dx',
+        # left joystick
+        0: 'lx',
+        1: 'ly',
+        # triggers
+        2: 'lt',
+        5: 'rt',
+        # right joystick
+        4: 'ry',
+        3: 'rx',
+    }
+
+    digital_mapping = {
+        # main buttons
+        307: 'x',
+        308: 'y',
+        305: 'b',
+        304: 'a',
+        # the triggers
+        311: 'rb',
+        310: 'lb',
+
+        # admin
+        315: 'sel',
+        314: 'back',
+    }
+    with dev.grab_context():
+        async for ev in dev.async_read_loop():
+            if ev.type not in (1, 3):
+                continue
+
+            # TODO also yield the event timestamp
+            if ev.type == 1:
+                key = digital_mapping[ev.code]
+                yield key, ev.value
+            elif ev.type == 3:
+                key = analog_mapping[ev.code]
+                yield key, ev.value
+
+
+if __name__ == '__main__':
+    parser, split_args = template_arg_parser(
+        default_prefix='gp:',
+        desc='Run an IOC that updates when gamepad buttons are pressed.',
+        supported_async_libs=('asyncio',))
+
+    parser.add_argument('--event',
+                        help='The file descriptor in /dev/input to use',
+                        required=True, type=str)
+
+    args = parser.parse_args()
+    ioc_options, run_options = split_args(args)
+    ioc = GampadIOC(event_path=args.event, **ioc_options)
+    run(ioc.pvdb, **run_options)

--- a/caproto/ioc_examples/gamepad.py
+++ b/caproto/ioc_examples/gamepad.py
@@ -26,10 +26,12 @@ class GampadIOC(PVGroup):
     # left joystick
     lx = pvproperty(value=0, max_length=1)
     ly = pvproperty(value=0, max_length=1)
+    ld = pvproperty(value=0, max_length=1)
 
     # right joystick, always analog
     rx = pvproperty(value=0, max_length=1)
     ry = pvproperty(value=0, max_length=1)
+    rd = pvproperty(value=0, max_length=1)
 
     # DPAD, depending on mode, may also come from left joystick
     dx = pvproperty(value=0, max_length=1)
@@ -82,6 +84,10 @@ async def gp_driver(dev):
         # admin
         315: 'sel',
         314: 'back',
+
+        # joystick down
+        317: 'ld',
+        318: 'rd',
     }
     with dev.grab_context():
         async for ev in dev.async_read_loop():

--- a/caproto/ioc_examples/gamepad.py
+++ b/caproto/ioc_examples/gamepad.py
@@ -20,6 +20,7 @@ class GampadIOC(PVGroup):
     y = pvproperty(value=0)
     lb = pvproperty(value=0)
     rb = pvproperty(value=0)
+    home = pvproperty(value=0)
 
     # joysticks
 
@@ -85,6 +86,7 @@ async def gp_driver(dev):
         # admin
         315: 'sel',
         314: 'back',
+        316: 'home',
 
         # joystick down
         317: 'ld',

--- a/caproto/ioc_examples/gamepad.py
+++ b/caproto/ioc_examples/gamepad.py
@@ -14,38 +14,38 @@ class GampadIOC(PVGroup):
         self._event_path = event_path
 
     # normal buttons
-    a = pvproperty(value=0, max_length=1)
-    b = pvproperty(value=0, max_length=1)
-    x = pvproperty(value=0, max_length=1)
-    y = pvproperty(value=0, max_length=1)
-    lb = pvproperty(value=0, max_length=1)
-    rb = pvproperty(value=0, max_length=1)
+    a = pvproperty(value=0)
+    b = pvproperty(value=0)
+    x = pvproperty(value=0)
+    y = pvproperty(value=0)
+    lb = pvproperty(value=0)
+    rb = pvproperty(value=0)
 
     # joysticks
 
     # left joystick
-    lx = pvproperty(value=0, max_length=1)
-    ly = pvproperty(value=0, max_length=1)
-    ld = pvproperty(value=0, max_length=1)
+    lx = pvproperty(value=0)
+    ly = pvproperty(value=0)
+    ld = pvproperty(value=0)
 
     # right joystick, always analog
-    rx = pvproperty(value=0, max_length=1)
-    ry = pvproperty(value=0, max_length=1)
-    rd = pvproperty(value=0, max_length=1)
+    rx = pvproperty(value=0)
+    ry = pvproperty(value=0)
+    rd = pvproperty(value=0)
 
     # DPAD, depending on mode, may also come from left joystick
-    dx = pvproperty(value=0, max_length=1)
-    dy = pvproperty(value=0, max_length=1)
+    dx = pvproperty(value=0)
+    dy = pvproperty(value=0)
 
     # Trigger buttons
-    lt = pvproperty(value=0, max_length=1)
-    rt = pvproperty(value=0, max_length=1)
+    lt = pvproperty(value=0)
+    rt = pvproperty(value=0)
 
     # admin
-    sel = pvproperty(value=0, max_length=1)
-    back = pvproperty(value=0, max_length=1)
+    sel = pvproperty(value=0)
+    back = pvproperty(value=0)
 
-    alive = pvproperty(value=0, max_length=1)
+    alive = pvproperty(value=0)
 
     @alive.startup
     async def alive(self, instance, async_lib):

--- a/caproto/ioc_examples/gamepad.py
+++ b/caproto/ioc_examples/gamepad.py
@@ -97,13 +97,17 @@ async def gp_driver(dev):
             if ev.type not in (1, 3):
                 continue
 
-            # TODO also yield the event timestamp
-            if ev.type == 1:
-                key = digital_mapping[ev.code]
-                yield key, ev.value
-            elif ev.type == 3:
-                key = analog_mapping[ev.code]
-                yield key, ev.value
+            try:
+
+                # TODO also yield the event timestamp
+                if ev.type == 1:
+                    key = digital_mapping[ev.code]
+                    yield key, ev.value
+                elif ev.type == 3:
+                    key = analog_mapping[ev.code]
+                    yield key, ev.value
+            except KeyError:
+                print((ev.type, ev.code, ev.value))
 
 
 if __name__ == '__main__':

--- a/caproto/ioc_examples/gamepad.py
+++ b/caproto/ioc_examples/gamepad.py
@@ -13,7 +13,7 @@ class GampadIOC(PVGroup):
         super().__init__(**kwargs)
         self._event_path = event_path
 
-    # normal buttons
+    # normal buttons, digital values as [0, 1]
     a = pvproperty(value=0)
     b = pvproperty(value=0)
     x = pvproperty(value=0)
@@ -23,25 +23,26 @@ class GampadIOC(PVGroup):
 
     # joysticks
 
-    # left joystick
+    # left joystick, analog values as int16
     lx = pvproperty(value=0)
     ly = pvproperty(value=0)
     ld = pvproperty(value=0)
 
-    # right joystick, always analog
+    # right joystick, analog values as int16
     rx = pvproperty(value=0)
     ry = pvproperty(value=0)
     rd = pvproperty(value=0)
 
     # DPAD, depending on mode, may also come from left joystick
+    # "digital" values as {-1, 0, 1}
     dx = pvproperty(value=0)
     dy = pvproperty(value=0)
 
-    # Trigger buttons
+    # Triggers, analog values as uint8
     lt = pvproperty(value=0)
     rt = pvproperty(value=0)
 
-    # admin
+    # admin, digital values as [0, 1]
     sel = pvproperty(value=0)
     back = pvproperty(value=0)
 

--- a/caproto/ioc_examples/hardware_specific/gamepad.py
+++ b/caproto/ioc_examples/hardware_specific/gamepad.py
@@ -4,8 +4,9 @@ This example requires a gamepad and the Python library evdev.
 
 This only works on linux (as it uses the linux kernel input events).
 """
-from caproto.server import pvproperty, PVGroup, template_arg_parser, run
 from evdev import InputDevice
+
+from caproto.server import PVGroup, pvproperty, run, template_arg_parser
 
 
 class GampadIOC(PVGroup):
@@ -98,7 +99,6 @@ async def gp_driver(dev):
                 continue
 
             try:
-
                 # TODO also yield the event timestamp
                 if ev.type == 1:
                     key = digital_mapping[ev.code]


### PR DESCRIPTION
```
caproto-monitor    gp:a    gp:b    gp:x    gp:y    gp:lb    gp:rb    gp:lx    gp:ly    gp:rx    gp:ry    gp:dx    gp:dy    gp:lt    gp:rt    gp:sel    gp:back    gp:alive gp:ld gp:rd

```

Attn @oksanagit

Yesterday Oksana and I were talking about an IOC for controlling
motors via a game pad.  This IOC gets as far as publishing the state
of the gamepad to EPICS.