### PR TITLE
Add an option to perform a write without running the user's put method.

### DIFF
--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -477,11 +477,14 @@ class ChannelData:
 
         return (await self.write(value, flags=flags, **metadata_dict))
 
-    async def write(self, value, *, flags=0, **metadata):
+    async def write(self, value, *, flags=0, with_callback=True, **metadata):
         '''Set data from native Python types'''
         try:
             value = self.preprocess_value(value)
-            modified_value = await self.verify_value(value)
+            if with_callback:
+                modified_value = await self.verify_value(value)
+            else:
+                modified_value = None
         except GeneratorExit:
             raise
         except Exception:

--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -477,11 +477,11 @@ class ChannelData:
 
         return (await self.write(value, flags=flags, **metadata_dict))
 
-    async def write(self, value, *, flags=0, with_callback=True, **metadata):
+    async def write(self, value, *, flags=0, verify_value=True, **metadata):
         '''Set data from native Python types'''
         try:
             value = self.preprocess_value(value)
-            if with_callback:
+            if verify_value:
                 modified_value = await self.verify_value(value)
             else:
                 modified_value = None


### PR DESCRIPTION
This PR adds a new option called 'with_callback' to `ChannelData.write()` that lets you choose whether to run the user-defined put method.