### PR TITLE
Add support for caproto-put -S.

### DIFF
--- a/caproto/commandline/put.py
+++ b/caproto/commandline/put.py
@@ -68,6 +68,8 @@ def main():
                               "space"))
     parser.add_argument('--array-pad', type=int, default=0,
                         help=("Pad the array up to a specified length"))
+    parser.add_argument('-S', action='store_true',
+                        help=("Interpret `data` as a string of characters."))
     parser.add_argument('--no-color', action='store_true',
                         help="Suppress ANSI color codes in log messages.")
     parser.add_argument('--no-repeater', action='store_true',
@@ -84,8 +86,10 @@ def main():
         else:
             set_handler(color=not args.no_color, level='DEBUG')
     logger = logging.LoggerAdapter(logging.getLogger('caproto.ch'), {'pv': args.pv_name})
-
-    if args.array:
+    if args.S:
+        # interpret as string
+        data = args.data
+    elif args.array:
         data = [ast.literal_eval(val) for val in args.data.split(' ')]
         if args.array_pad > 0:
             if len(data) < args.array:

--- a/caproto/commandline/put.py
+++ b/caproto/commandline/put.py
@@ -68,7 +68,7 @@ def main():
                               "space"))
     parser.add_argument('--array-pad', type=int, default=0,
                         help=("Pad the array up to a specified length"))
-    parser.add_argument('-S', action='store_true',
+    parser.add_argument('-S', dest='as_string', action='store_true',
                         help=("Interpret `data` as a string of characters."))
     parser.add_argument('--no-color', action='store_true',
                         help="Suppress ANSI color codes in log messages.")
@@ -86,7 +86,7 @@ def main():
         else:
             set_handler(color=not args.no_color, level='DEBUG')
     logger = logging.LoggerAdapter(logging.getLogger('caproto.ch'), {'pv': args.pv_name})
-    if args.S:
+    if args.as_string:
         # interpret as string
         data = args.data
     elif args.array:


### PR DESCRIPTION
Previously there was no way to do something like:

```
caproto-put rpi:color 000000
```

where ``000000`` is a string. Now, we can do

```
caproto-put -S rpi:color 000000
```

and it works as intended.