### PR TITLE
Add example with IOC that does work on a thread.

### DIFF
--- a/caproto/ioc_examples/worker_thread.py
+++ b/caproto/ioc_examples/worker_thread.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+import itertools
+import threading
+import time
+
+from caproto.server import pvproperty, PVGroup, ioc_arg_parser, run
+
+
+def worker(request_queue, response_queue):
+    i = itertools.count(1)
+    while True:
+        request = request_queue.get()
+
+        # In this toy example, the "request" is some number of seconds to
+        # sleep for, but it could be any blocking task.
+        print(f'Sleeping for {request} seconds...')
+        time.sleep(request)
+
+        # In this toy example, the "response" is just a counter of how many
+        # requests we have seen, but it could be anything.
+        counter_value = next(i)
+        response_queue.put(counter_value)
+        print('Done')
+
+
+class WorkerThreadIOC(PVGroup):
+    request = pvproperty(value=0, max_length=1)
+    response = pvproperty(value=0, max_length=1)
+
+    # NOTE the decorator used here:
+    @request.startup
+    async def request(self, instance, async_lib):
+        # This method will be called when the server starts up.
+        print('* request method called at server startup')
+        self.request_queue = async_lib.ThreadsafeQueue()
+        self.response_queue = async_lib.ThreadsafeQueue()
+
+        # Start a separate thread that consumes requests and sends responses.
+        thread = threading.Thread(target=worker,
+                                  daemon=True,
+                                  kwargs=dict(request_queue=self.request_queue,
+                                              response_queue=self.response_queue))
+        thread.start()
+
+        # Loop and grab items from the response queue one at a time
+        while True:
+            value = await self.response_queue.async_get()
+            print(f'Got a response from the worker: {value}')
+
+            # Propagate the keypress to the EPICS PV, triggering any monitors
+            # along the way
+            await self.response.write(value)
+
+    @request.putter
+    async def request(self, instance, value):
+        print(f'Sending the request {value} to the worker.')
+        await self.request_queue.async_put(value)
+        return value
+
+
+if __name__ == '__main__':
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix='wt:',
+        desc='Run an IOC that does blocking tasks on a worker thread.')
+
+    ioc = WorkerThreadIOC(**ioc_options)
+    run(ioc.pvdb, **run_options)

--- a/caproto/tests/test_examples.py
+++ b/caproto/tests/test_examples.py
@@ -367,6 +367,7 @@ def _test_ioc_examples(request, module_name, pvdb_class_name, class_kwargs,
      ('caproto.ioc_examples.simple', 'SimpleIOC', {}),
      ('caproto.ioc_examples.startup_and_shutdown_hooks', 'StartupAndShutdown', {}),
      ('caproto.ioc_examples.subgroups', 'MyPVGroup', {}),
+     ('caproto.ioc_examples.worker_thread', 'WorkerThreadIOC', {}),
      ]
 )
 @pytest.mark.parametrize('async_lib', ['curio', 'trio', 'asyncio'])


### PR DESCRIPTION
For @johnsinsheimer

Comments from others welcome -- there may be a smarter way to do this that I haven't thought of.

This IOC starts a worker thread at startup. When a client puts to the `wt:request` PV, the IOC sends a task the worker. When the worker completes the task, it notifies the IOC, and the IOC updates the `wt:response` PV, triggering any monitors to update.

In this toy example, the "request" to the worker is some number of seconds to sleep for, and the "response" is an incremented counter. Demo:

Client side:
```
09:39 $ caproto-put wt:request 3
Old : wt:request                                [0]
New : wt:request                                [3]
09:40 $ caproto-monitor wt:response
wt:response                               2019-08-30 09:40:53.370741 [0]
wt:response                               2019-08-30 09:41:00.657391 [1]
^C
09:41 $ caproto-put wt:request 5
Old : wt:request                                [3]
New : wt:request                                [5]
09:41 $ caproto-monitor wt:response
wt:response                               2019-08-30 09:41:00.657391 [1]
wt:response                               2019-08-30 09:41:11.604020 [2]
^C
```

Server logs:
```
$ python -m caproto.ioc_examples.worker_thread
[I 09:40:53.386          server:  161] Asyncio server starting up...
[I 09:40:53.386          server:  174] Listening on 0.0.0.0:5064
[I 09:40:53.386          server:  260] Server startup complete.
* request method called at server startup
[I 09:40:57.649          common:  967] Connected to new client at 127.0.0.1:43488 (total: 1).
Sending the request 3 to the worker.
Sleeping for 3 seconds...
[I 09:40:57.698          common:  982] Disconnected from client at 127.0.0.1:43488 (total: 0).
[I 09:40:59.584          common:  967] Connected to new client at 127.0.0.1:43516 (total: 1).
Got a response from the worker: 1
Done
[I 09:41:04.736          common:  982] Disconnected from client at 127.0.0.1:43516 (total: 0).
[I 09:41:06.595          common:  967] Connected to new client at 127.0.0.1:43614 (total: 1).
Sending the request 5 to the worker.
Sleeping for 5 seconds...
[I 09:41:06.641          common:  982] Disconnected from client at 127.0.0.1:43614 (total: 0).
[I 09:41:07.559          common:  967] Connected to new client at 127.0.0.1:43628 (total: 1).
Got a response from the worker: 2
Done
[I 09:41:13.664          common:  982] Disconnected from client at 127.0.0.1:43628 (total: 0).
```

One thing to notice about this example: the queue is bridging between the threading/pre-emptive concurrency world and the async/cooperative concurrency world. On the threading (worker) side, we use `get()` and `put(...)`, and on the async (IOC) side, we use `async_get()` and `async_put(...)`.