### PR TITLE
Scrub more NSLS-II -> caproto.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ The following have been tested on an Ubuntu 16.04 LTS VM.
 1. Clone the repository.
 
 ```bash
-git clone https://github.com/NSLS-II/caproto
+git clone https://github.com/caproto/caproto
 cd caproto
 ```
 

--- a/doc/source/command-line-client.rst
+++ b/doc/source/command-line-client.rst
@@ -338,7 +338,7 @@ provided by its counterparts in EPICS' reference implementation, epics-base:
 ``caget``, ``caput``, ``camonitor``, and ``caRepeater``. It is our goal to make
 caproto's variants safe to use as drop-in replacements. As yet, some arguments
 related to string formatting are not yet implemented (`Code contributions
-welcome!  <https://github.com/NSLS-II/caproto/issues/147>`_) but similar
+welcome!  <https://github.com/caproto/caproto/issues/147>`_) but similar
 functionality is available via ``--format``.
 
 caproto-get

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -50,7 +50,7 @@ Development Installation
 
 .. code-block:: bash
 
-    git clone https://github.com/NSLS-II/caproto
+    git clone https://github.com/caproto/caproto
     cd caproto
     pip install -e .
 

--- a/doc/source/iocs.rst
+++ b/doc/source/iocs.rst
@@ -396,7 +396,7 @@ More...
 -------
 
 Take a look around
-`the ioc_examples subpackage <https://github.com/NSLS-II/caproto/tree/master/caproto/ioc_examples>`_ for more examples not covered here.
+`the ioc_examples subpackage <https://github.com/caproto/caproto/tree/master/caproto/ioc_examples>`_ for more examples not covered here.
 
 .. ipython:: python
     :suppress:

--- a/doc/source/protocol-compliance.rst
+++ b/doc/source/protocol-compliance.rst
@@ -7,7 +7,7 @@ the feature parity of caproto's clients and servers with the reference
 implementations in epics-base. We aim for 100% compliance and feature parity.
 
 For more details, see our
-`issue tracker on GitHub <https://github.com/NSLS-II/caproto/issues>`_
+`issue tracker on GitHub <https://github.com/caproto/caproto/issues>`_
 
 Core protocol support
 =====================

--- a/doc/source/release-notes.rst
+++ b/doc/source/release-notes.rst
@@ -294,16 +294,16 @@ Features
   `catvs <https://github.com/mdavidsaver/catvs>`_. This has generated several
   fixes improving protocol compliance, list a section below. There are a small
   number of known failures wherein the best/correct behavior is arguable; see
-  `caproto#327 on GitHub <https://github.com/NSLS-II/caproto/pull/327>`_ for
+  `caproto#327 on GitHub <https://github.com/caproto/caproto/pull/327>`_ for
   discussion. There may be more progress on these in future releases of
   caproto.
 * Added ``pvproperty.scan``. See
-  the `mini_beamline example IOC <https://github.com/NSLS-II/caproto/blob/master/caproto/ioc_examples/mini_beamline.py>`_
+  the `mini_beamline example IOC <https://github.com/caproto/caproto/blob/master/caproto/ioc_examples/mini_beamline.py>`_
   for a usage example.
 * Add a server-side data source for ``ChannelType.INT`` (a.k.a SHORT) data.
 * The default printed output of the ``caproto-monitor`` CLI utility now
   includes microseconds.
-* There are several new `IOC examples <https://github.com/NSLS-II/caproto/tree/master/caproto/ioc_examples>`_.
+* There are several new `IOC examples <https://github.com/caproto/caproto/tree/master/caproto/ioc_examples>`_.
 
 Breaking Changes
 ----------------


### PR DESCRIPTION
Found all the remaining carryovers of `NSLS-II` in the codebase using `grep`.