### PR TITLE
Add a worker thread example with put-completion.

### DIFF
--- a/caproto/asyncio/server.py
+++ b/caproto/asyncio/server.py
@@ -51,6 +51,7 @@ def _get_asyncio_queue(loop):
 class AsyncioAsyncLayer(AsyncLibraryLayer):
     name = 'asyncio'
     ThreadsafeQueue = None
+    Event = asyncio.Event
     library = asyncio
 
     def __init__(self, loop=None):

--- a/caproto/curio/server.py
+++ b/caproto/curio/server.py
@@ -56,6 +56,7 @@ class QueueWithFullError(curio.Queue):
 class CurioAsyncLayer(AsyncLibraryLayer):
     name = 'curio'
     ThreadsafeQueue = UniversalQueue
+    Event = curio.UniversalEvent
     library = curio
 
 

--- a/caproto/ioc_examples/worker_thread_pc.py
+++ b/caproto/ioc_examples/worker_thread_pc.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+import threading
+import time
+
+from caproto.server import pvproperty, PVGroup, ioc_arg_parser, run
+
+
+def worker(request_queue):
+    while True:
+        event, request = request_queue.get()
+
+        # In this toy example, the "request" is some number of seconds to
+        # sleep for, but it could be any blocking task.
+        print(f'Sleeping for {request} seconds...')
+        time.sleep(request)
+        event.set()  # Event.set() is a synchronous method
+        print('Done')
+
+
+class WorkerThreadIOC(PVGroup):
+    request = pvproperty(value=0, max_length=1)
+
+    # NOTE the decorator used here:
+    @request.startup
+    async def request(self, instance, async_lib):
+        # This method will be called when the server starts up.
+        print('* request method called at server startup')
+        self.request_queue = async_lib.ThreadsafeQueue()
+        self.Event = async_lib.Event
+
+        # Start a separate thread that consumes requests.
+        thread = threading.Thread(target=worker,
+                                  daemon=True,
+                                  kwargs=dict(request_queue=self.request_queue))
+        thread.start()
+
+    @request.putter
+    async def request(self, instance, value):
+        print(f'Sending the request {value} to the worker.')
+        event = self.Event()
+        await self.request_queue.async_put((event, value))
+        # The worker calls Event.set() when the work is done.
+        await event.wait()
+        return value
+
+
+if __name__ == '__main__':
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix='wt:',
+        desc='Run an IOC that does blocking tasks on a worker thread.')
+
+    ioc = WorkerThreadIOC(**ioc_options)
+    run(ioc.pvdb, **run_options)

--- a/caproto/tests/test_examples.py
+++ b/caproto/tests/test_examples.py
@@ -368,6 +368,7 @@ def _test_ioc_examples(request, module_name, pvdb_class_name, class_kwargs,
      ('caproto.ioc_examples.startup_and_shutdown_hooks', 'StartupAndShutdown', {}),
      ('caproto.ioc_examples.subgroups', 'MyPVGroup', {}),
      ('caproto.ioc_examples.worker_thread', 'WorkerThreadIOC', {}),
+     ('caproto.ioc_examples.worker_thread_pc', 'WorkerThreadIOC', {}),
      ]
 )
 @pytest.mark.parametrize('async_lib', ['curio', 'trio', 'asyncio'])

--- a/caproto/trio/server.py
+++ b/caproto/trio/server.py
@@ -55,6 +55,7 @@ class TrioAsyncLayer(AsyncLibraryLayer):
 
     name = 'trio'
     ThreadsafeQueue = None
+    Event = Event
     library = trio
 
 


### PR DESCRIPTION
This is a follow-up to #508.

In #508, the ``wt:request`` is "complete" as soon as the request is sent to
the worker. Per past conversations with Andrew Johnson and others, the *proper*
behavior is for writes to "complete" when *all actions* resulting from that
write are done. Thus, the correct implementation of put-completion would be
for ``wt:request`` to "complete" the worker thread finishes processing the
request.

In this example, ``caproto-put ...`` waits for put-completion while the worker
processes the request to sleep.


```
$ caproto-put --timeout 10 --notify wt:request 3
Old : wt:request                                [0]
New : wt:request                                [3]
```

This makes this easier on the downstream (e.g. ophyd) side because you don't
need to coordinate between two PVs. There is no "response" PV in this example.
If all the worker needs to do is communicate that it is done with the request,
I think this is a strictly better approach. If the worker needs to communicate
some *value*, some computed result, back to the client, then something like
the approach in #508 is needed.

Note however that this approach makes some changes to caproto itself. It could
be done with just queues, but this seems like a good application for Events.