### PR TITLE
Allow setting a global timeout via CAPROTO_TIMEOUT env var

### DIFF
--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -910,8 +910,9 @@ class Context:
         If None is specified, a fresh one is instantiated.
     timeout : number or None, optional
         Number of seconds before a CaprotoTimeoutError is raised. This default
-        can be overridden at the PV level or for any given operation. If
-        unset, the default is 2 seconds. If None, never timeout.
+        can be overridden at the PV level or for any given operation. If unset,
+        the default is 2 seconds. If None, never timeout. A global timeout can
+        be specified via an environment variable ``CAPROTO_TIMEOUT``.
     host_name : string, optional
         uses value of ``socket.gethostname()`` by default
     client_name : string, optional
@@ -935,7 +936,7 @@ class Context:
         if broadcaster is None:
             broadcaster = SharedBroadcaster()
         self.broadcaster = broadcaster
-        self.timeout = timeout
+        self.timeout = float(os.environ.get('CAPROTO_TIMEOUT', timeout))
         if host_name is None:
             host_name = socket.gethostname()
         self.host_name = host_name

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -47,6 +47,7 @@ CIRCUIT_DEATH_ATTEMPTS = 3
 # sentinels used as default values for arguments
 CONTEXT_DEFAULT_TIMEOUT = object()
 PV_DEFAULT_TIMEOUT = object()
+GLOBAL_DEFAULT_TIMEOUT = os.environ.get("CAPROTO_DEFAULT_TIMEOUT", 2)
 
 
 class DeadCircuitError(CaprotoError):
@@ -912,7 +913,7 @@ class Context:
         Number of seconds before a CaprotoTimeoutError is raised. This default
         can be overridden at the PV level or for any given operation. If unset,
         the default is 2 seconds. If None, never timeout. A global timeout can
-        be specified via an environment variable ``CAPROTO_TIMEOUT``.
+        be specified via an environment variable ``CAPROTO_DEFAULT_TIMEOUT``.
     host_name : string, optional
         uses value of ``socket.gethostname()`` by default
     client_name : string, optional
@@ -931,12 +932,12 @@ class Context:
         value from 1.
     """
     def __init__(self, broadcaster=None, *,
-                 timeout=2,
+                 timeout=GLOBAL_DEFAULT_TIMEOUT,
                  host_name=None, client_name=None, max_workers=1):
         if broadcaster is None:
             broadcaster = SharedBroadcaster()
         self.broadcaster = broadcaster
-        self.timeout = float(os.environ.get('CAPROTO_TIMEOUT', timeout))
+        self.timeout = timeout
         if host_name is None:
             host_name = socket.gethostname()
         self.host_name = host_name


### PR DESCRIPTION
This is based on the discussion in the [Nikea Slack](https://nikea.slack.com/archives/C7QGYD0KW/p1568722811013200). The proposed update allows setting a global timeout via an environment variable `CAPROTO_TIMEOUT`.