### PR TITLE
Put clients under a section with some context.

### DIFF
--- a/doc/source/clients.rst
+++ b/doc/source/clients.rst
@@ -1,0 +1,34 @@
+*******
+Clients
+*******
+
+Caproto implements several clients, all built on the same core. This page aims
+to help you choose which one is best for your application.
+
+The :doc:`sync-client` is simplistic but functional, easy to read and
+understand what happens with a single operation. It is perfectly fine to
+use directly, but should generally not be used to build larger programs. It
+opts for simplicity over performance.
+
+The :doc:`threading-client` is a high-performance client and the one with the
+most features and tesitng behind it. We generally recommend this one.
+
+The :doc:`pyepics-compat-client` should only be used if you want to have
+compatibility with some existing pyepics-based code.
+
+The :doc:`async-clients` are experimental, not as robust or as feature-complete
+as the threading client. They may be reworked and built out in the future.
+
+The :doc:`command-line-client` provides commandline tools (``caproto-get``,
+``caproto-put``, ...) that are drop-in replacements for their analogues in
+EPICS' reference implementation (``caget``, ``caput``, ...). They are backed by
+the synchronous client.
+
+.. toctree::
+   :maxdepth: 2
+
+   command-line-client
+   sync-client
+   threading-client
+   pyepics-compat-client
+   async-clients

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -145,11 +145,7 @@ learning exercises.
    :maxdepth: 2
    :caption: EPICS Clients and Servers
 
-   command-line-client
-   sync-client
-   threading-client
-   pyepics-compat-client
-   async-clients
+   clients
    iocs
    mock-records
    servers


### PR DESCRIPTION
Put all the clients' documentation under a landing page that gives an overview.
This important context is currently scattered across each client's respective
documentation page. It would be good to have it all together here.

Closes #517

Language adapted from @klauer's comment in that issue.