### PR TITLE
Document `data_type` more prominently.

### DIFF
--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -288,12 +288,36 @@ def read(pv_name, *, data_type=None, timeout=1, priority=0, notify=True,
 
     >>> from caproto import ChannelType
     >>> read('cat', data_type=ChannelType.CTRL_FLOAT).metadata
-    DBR_CTRL_FLOAT(status=<AlarmStatus.NO_ALARM: 0>, severity=<AlarmSeverity.NO_ALARM: 0>, upper_disp_limit=0.0, lower_disp_limit=0.0, upper_alarm_limit=0.0, upper_warning_limit=0.0, lower_warning_limit=0.0, lower_alarm_limit=0.0, upper_ctrl_limit=0.0, lower_ctrl_limit=0.0, precision=0, units=b'')
+    DBR_CTRL_FLOAT(
+        status=<AlarmStatus.NO_ALARM: 0>,
+        severity=<AlarmSeverity.NO_ALARM: 0>,
+        upper_disp_limit=0.0,
+        lower_disp_limit=0.0,
+        upper_alarm_limit=0.0,
+        upper_warning_limit=0.0,
+        lower_warning_limit=0.0,
+        lower_alarm_limit=0.0,
+        upper_ctrl_limit=0.0,
+        lower_ctrl_limit=0.0,
+        precision=0,
+        units=b'')
 
     or the corresponding integer identifer
 
     >>> read('cat', data_type=30).metadata
-    DBR_CTRL_FLOAT(status=<AlarmStatus.NO_ALARM: 0>, severity=<AlarmSeverity.NO_ALARM: 0>, upper_disp_limit=0.0, lower_disp_limit=0.0, upper_alarm_limit=0.0, upper_warning_limit=0.0, lower_warning_limit=0.0, lower_alarm_limit=0.0, upper_ctrl_limit=0.0, lower_ctrl_limit=0.0, precision=0, units=b'')
+    DBR_CTRL_FLOAT(
+    status=<AlarmStatus.NO_ALARM: 0>,
+    severity=<AlarmSeverity.NO_ALARM: 0>,
+    upper_disp_limit=0.0,
+    lower_disp_limit=0.0,
+    upper_alarm_limit=0.0,
+    upper_warning_limit=0.0,
+    lower_warning_limit=0.0,
+    lower_alarm_limit=0.0,
+    upper_ctrl_limit=0.0,
+    lower_ctrl_limit=0.0,
+    precision=0,
+    units=b'')
     """
     if repeater:
         # As per the EPICS spec, a well-behaved client should start a
@@ -598,7 +622,15 @@ def write(pv_name, data, *, notify=False, data_type=None, metadata=None,
 
     Request notification of completion ("put completion") and wait for it.
     >>> write('cat', 5, notify=True)  # blocks until complete, then returns:
-    WriteNotifyResponse(data_type=<ChannelType.LONG: 5>, data_count=1, status=CAStatusCode(name='ECA_NORMAL', code=0, code_with_severity=1, severity=<CASeverity.SUCCESS: 1>, success=1, defunct=False, description='Normal successful completion'), ioid=0)
+    WriteNotifyResponse(
+        data_type=<ChannelType.LONG: 5>,
+        data_count=1,
+        status=CAStatusCode(
+            name='ECA_NORMAL', code=0, code_with_severity=1,
+            severity=<CASeverity.SUCCESS: 1>,
+            success=1, defunct=False,
+            description='Normal successful completion'),
+        ioid=0)
     """
     if repeater:
         # As per the EPICS spec, a well-behaved client should start a

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -280,7 +280,7 @@ def read(pv_name, *, data_type=None, timeout=1, priority=0, notify=True,
     A convenience method is provided for access the timestamp as a Python
     datetime object.
 
-    >>> read('cat' data_type='time').stamp.as_datetime()
+    >>> read('cat' data_type='time').metadata.stamp.as_datetime()
     datetime.datetime(2019, 10, 9, 11, 58, 59, 42392)
 
     The requested data type may also been given as a specific Channel Access

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -627,14 +627,14 @@ def write(pv_name, data, *, notify=False, data_type=None, metadata=None,
     Request notification of completion ("put completion") and wait for it.
     >>> write('cat', 5, notify=True)  # blocks until complete, then returns:
     WriteNotifyResponse(
-        data_type=<ChannelType.LONG: 5>,
-        data_count=1,
-        status=CAStatusCode(
-        name='ECA_NORMAL', code=0, code_with_severity=1,
-        severity=<CASeverity.SUCCESS: 1>,
-        success=1, defunct=False,
-        description='Normal successful completion'),
-        ioid=0)
+    data_type=<ChannelType.LONG: 5>,
+    data_count=1,
+    status=CAStatusCode(
+    name='ECA_NORMAL', code=0, code_with_severity=1,
+    severity=<CASeverity.SUCCESS: 1>,
+    success=1, defunct=False,
+    description='Normal successful completion'),
+    ioid=0)
     """
     if repeater:
         # As per the EPICS spec, a well-behaved client should start a

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -243,6 +243,7 @@ def read(pv_name, *, data_type=None, timeout=1, priority=0, notify=True,
     Parameters
     ----------
     pv_name : str
+        The PV name to read from
     data_type : {'native', 'status', 'time', 'graphic', 'control'} or ChannelType or int ID, optional
         Request specific data type or a class of data types, matched to the
         channel's native data type. Default is Channel's native data type.
@@ -350,6 +351,7 @@ def subscribe(pv_name, priority=0, data_type=None, data_count=None,
     Parameters
     ----------
     pv_name : string
+        The PV name to subscribe to
     priority : integer, optional
         Used by the server to triage subscription responses when under high
         load. 0 is lowest; 99 is highest.
@@ -422,6 +424,7 @@ def block(*subscriptions, duration=None, timeout=1, force_int_enums=False,
     Parameters
     ----------
     *subscriptions : Subscriptions
+        The list of subscriptions.
     duration : float, optional
         How many seconds to run for. Run forever (None) by default.
     timeout : float, optional
@@ -593,6 +596,7 @@ def write(pv_name, data, *, notify=False, data_type=None, metadata=None,
     Parameters
     ----------
     pv_name : str
+        The PV name to write to
     data : str, int, or float or any Iterable of these
         Value(s) to write.
     notify : boolean, optional
@@ -626,10 +630,10 @@ def write(pv_name, data, *, notify=False, data_type=None, metadata=None,
         data_type=<ChannelType.LONG: 5>,
         data_count=1,
         status=CAStatusCode(
-            name='ECA_NORMAL', code=0, code_with_severity=1,
-            severity=<CASeverity.SUCCESS: 1>,
-            success=1, defunct=False,
-            description='Normal successful completion'),
+        name='ECA_NORMAL', code=0, code_with_severity=1,
+        severity=<CASeverity.SUCCESS: 1>,
+        success=1, defunct=False,
+        description='Normal successful completion'),
         ioid=0)
     """
     if repeater:
@@ -675,6 +679,7 @@ def read_write_read(pv_name, data, *, notify=False,
     Parameters
     ----------
     pv_name : str
+        The PV name to write/read/write
     data : str, int, or float or a list of these
         Value to write.
     notify : boolean, optional

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -266,9 +266,34 @@ def read(pv_name, *, data_type=None, timeout=1, priority=0, notify=True,
     Examples
     --------
 
-    Get the value of a Channel named 'cat'.
+    Get the value of a Channel named 'simple:A'.
 
-    >>> read('cat').data
+    >>> read('simple:A').data
+    array([1], dtype=int32)
+
+    Request a richer Channel Access data type that includes the timestamp, and
+    access the timestamp.
+
+    >>> read('cat', data_type='time').metadata.timestmap
+    1570622339.042392
+
+    A convenience method is provided for access the timestamp as a Python
+    datetime object.
+
+    >>> read('cat' data_type='time').stamp.as_datetime()
+    datetime.datetime(2019, 10, 9, 11, 58, 59, 42392)
+
+    The requested data type may also been given as a specific Channel Access
+    type
+
+    >>> from caproto import ChannelType
+    >>> read('cat', data_type=ChannelType.CTRL_FLOAT).metadata
+    DBR_CTRL_FLOAT(status=<AlarmStatus.NO_ALARM: 0>, severity=<AlarmSeverity.NO_ALARM: 0>, upper_disp_limit=0.0, lower_disp_limit=0.0, upper_alarm_limit=0.0, upper_warning_limit=0.0, lower_warning_limit=0.0, lower_alarm_limit=0.0, upper_ctrl_limit=0.0, lower_ctrl_limit=0.0, precision=0, units=b'')
+
+    or the corresponding integer identifer
+
+    >>> read('cat', data_type=30).metadata
+    DBR_CTRL_FLOAT(status=<AlarmStatus.NO_ALARM: 0>, severity=<AlarmSeverity.NO_ALARM: 0>, upper_disp_limit=0.0, lower_disp_limit=0.0, upper_alarm_limit=0.0, upper_warning_limit=0.0, lower_warning_limit=0.0, lower_alarm_limit=0.0, upper_ctrl_limit=0.0, lower_ctrl_limit=0.0, precision=0, units=b'')
     """
     if repeater:
         # As per the EPICS spec, a well-behaved client should start a
@@ -319,9 +344,9 @@ def subscribe(pv_name, priority=0, data_type=None, data_count=None,
     Examples
     --------
 
-    Define a subscription on the ``cat`` PV.
+    Define a subscription on the ``random_walk:x`` PV.
 
-    >>> sub = subscribe('cat')
+    >>> sub = subscribe('random_walk:x')
 
     Add one or more user-defined callbacks to process responses.
 
@@ -567,12 +592,13 @@ def write(pv_name, data, *, notify=False, data_type=None, metadata=None,
 
     Examples
     --------
-    Write the value 5 to a Channel named 'cat'.
+    Write the value 5 to a Channel named 'simple:A'.
 
-    >>> write('cat', 5)  # returns None
+    >>> write('simple:A', 5)  # returns None
 
     Request notification of completion ("put completion") and wait for it.
-    >>> write('cat', 5, notify=True)  # returns a WriteNotifyResponse
+    >>> write('cat', 5, notify=True)  # blocks until complete, then returns:
+    WriteNotifyResponse(data_type=<ChannelType.LONG: 5>, data_count=1, status=CAStatusCode(name='ECA_NORMAL', code=0, code_with_severity=1, severity=<CASeverity.SUCCESS: 1>, success=1, defunct=False, description='Normal successful completion'), ioid=0)
     """
     if repeater:
         # As per the EPICS spec, a well-behaved client should start a
@@ -648,7 +674,7 @@ def read_write_read(pv_name, data, *, notify=False,
     Examples
     --------
 
-    Write the value 5 to a Channel named 'cat'.
+    Write the value 5 to a Channel named 'simple:A'.
 
     >>> read_write_read('cat', 5)  # returns initial, None, final
 

--- a/doc/source/sync-client.rst
+++ b/doc/source/sync-client.rst
@@ -71,7 +71,6 @@ Use the ``data_type`` parameter to request a richer data type.
 
 .. ipython:: python
 
-
    richer_res = read('random_walk:dt', data_type='time')
    richer_res.metadata
    richer_res.metadata.timestamp

--- a/doc/source/sync-client.rst
+++ b/doc/source/sync-client.rst
@@ -75,9 +75,9 @@ Use the ``data_type`` parameter to request a richer data type.
    richer_res = read('random_walk:dt', data_type='time')
    richer_res.metadata
    richer_res.metadata.timestamp
-   richer_res.stamp.to_datetime()  # a convenience method
+   richer_res.metadata.stamp.as_datetime()  # a convenience method
 
-See :doc:`read` for more information on the values accepted by the
+See :func:`read` for more information on the values accepted by the
 ``data_type`` parameter.
 
 .. note::

--- a/doc/source/sync-client.rst
+++ b/doc/source/sync-client.rst
@@ -61,6 +61,25 @@ Access particular fields in the response using attribute ("dot") access on
 
     res.data
 
+By default, the client does not request any metadata
+
+.. ipython:: python
+
+   res.metadata
+
+Use the ``data_type`` parameter to request a richer data type.
+
+.. ipython:: python
+
+
+   richer_res = read('random_walk:dt', data_type='time')
+   richer_res.metadata
+   richer_res.metadata.timestamp
+   richer_res.stamp.to_datetime()  # a convenience method
+
+See :doc:`read` for more information on the values accepted by the
+``data_type`` parameter.
+
 .. note::
 
     **Performance Note**

--- a/doc/source/threading-client.rst
+++ b/doc/source/threading-client.rst
@@ -93,6 +93,25 @@ Access particular fields in the response using attribute ("dot") access on ``res
 
     res.data
 
+By default, the client does not request any metadata
+
+.. ipython:: python
+
+   res.metadata
+
+Use the ``data_type`` parameter to request a richer data type.
+
+.. ipython:: python
+
+
+   richer_res = pv.read(data_type='time')
+   richer_res.metadata
+   richer_res.metadata.timestamp
+   richer_res.metadata.stamp.to_datetime()  # a convenience method
+
+See :doc:`read` for more information on the values accepted by the
+``data_type`` parameter.
+
 .. note::
 
     **Performance Note**

--- a/doc/source/threading-client.rst
+++ b/doc/source/threading-client.rst
@@ -104,12 +104,12 @@ Use the ``data_type`` parameter to request a richer data type.
 .. ipython:: python
 
 
-   richer_res = pv.read(data_type='time')
+   richer_res = dt.read(data_type='time')
    richer_res.metadata
    richer_res.metadata.timestamp
-   richer_res.metadata.stamp.to_datetime()  # a convenience method
+   richer_res.metadata.stamp.as_datetime()  # a convenience method
 
-See :doc:`read` for more information on the values accepted by the
+See :meth:`PV.read` for more information on the values accepted by the
 ``data_type`` parameter.
 
 .. note::


### PR DESCRIPTION
In the narrative docs we don't mention how to read timestamps in the sync or
threading clients. There is just an oblique reference in the `read`'s
docstring. There is also no mention anywhere of the `to_datetime()` convenience
method, which I had actually forgotten about and would probably be quite useful.