### PR TITLE
FIX: add a lock to sending over a VirtualCircuit

### DIFF
--- a/caproto/curio/server.py
+++ b/caproto/curio/server.py
@@ -66,6 +66,7 @@ class VirtualCircuit(_VirtualCircuit):
 
     def __init__(self, circuit, client, context):
         super().__init__(circuit, client, context)
+        self._raw_lock = curio.Lock()
         self.QueueFull = QueueFull
         self.command_queue = QueueWithFullError(ca.MAX_COMMAND_BACKLOG)
         self.new_command_condition = curio.Condition()

--- a/caproto/ioc_examples/big_image_noisy_neighbor.py
+++ b/caproto/ioc_examples/big_image_noisy_neighbor.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import time
+from caproto.server import pvproperty, PVGroup, ioc_arg_parser, run
+import numpy as np
+
+image_shape = (3960, 3960)
+
+
+class IOInterruptIOC(PVGroup):
+    t1 = pvproperty(value=2.0)
+    image = pvproperty(
+        value=np.random.randint(0, 256, image_shape).flatten(), dtype=float
+    )
+
+    @t1.startup
+    async def t1(self, instance, async_lib):
+        # Loop and grab items from the queue one at a time
+        while True:
+            await self.t1.write(time.monotonic())
+            await async_lib.library.sleep(0.1)
+
+
+if __name__ == "__main__":
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix="big_image:",
+        desc="Run an IOC that updates via I/O interrupt on key-press events.",
+    )
+
+    ioc = IOInterruptIOC(**ioc_options)
+    print(ioc.image)
+    run(ioc.pvdb, **run_options)

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -96,7 +96,8 @@ class VirtualCircuit:
         if self.connected:
             buffers_to_send = self.circuit.send(*commands)
             # send bytes over the wire using some caproto utilities
-            await ca.async_send_all(buffers_to_send, self.client.sendmsg)
+            async with self._raw_lock:
+                await ca.async_send_all(buffers_to_send, self.client.sendmsg)
 
     async def recv(self):
         """

--- a/caproto/tests/test_examples.py
+++ b/caproto/tests/test_examples.py
@@ -520,5 +520,30 @@ def test_enum_linking(request, prefix):
         assert string_read(f'{pv}.ONAM') == onam
 
         for value, expected in ([0, znam], [1, onam]):
+
             write(pv, [value], notify=True)
             assert string_read(pv) == expected
+
+
+@pytest.mark.parametrize('async_lib', ['curio', 'trio', 'asyncio'])
+def test_event_read_collision(request, prefix, async_lib):
+    # this is testing that monitors do not get pushed into
+    # the socket while a ReadResponse is being pushed in parts.
+    from .conftest import run_example_ioc
+    run_example_ioc('caproto.ioc_examples.big_image_noisy_neighbor',
+                    request=request,
+                    args=['--prefix', prefix, '--async-lib', async_lib],
+                    pv_to_check=f'{prefix}t1')
+    from caproto.threading.pyepics_compat import get_pv, Context
+    cntx = Context()
+    image = get_pv(pvname=f'{prefix}image', context=cntx)
+    t1 = get_pv(pvname=f'{prefix}t1', context=cntx)
+    t1.add_callback(lambda value, **kwargs: None)
+
+    for j in range(4):
+        image.get(timeout=20)
+
+    image.disconnect()
+    t1.disconnect()
+
+    cntx.disconnect()

--- a/caproto/tests/test_examples.py
+++ b/caproto/tests/test_examples.py
@@ -541,7 +541,7 @@ def test_event_read_collision(request, prefix, async_lib):
     t1.add_callback(lambda value, **kwargs: None)
 
     for j in range(4):
-        image.get(timeout=20)
+        image.get(timeout=45)
 
     image.disconnect()
     t1.disconnect()

--- a/caproto/trio/server.py
+++ b/caproto/trio/server.py
@@ -65,6 +65,7 @@ class VirtualCircuit(_VirtualCircuit):
 
     def __init__(self, circuit, client, context):
         super().__init__(circuit, client, context)
+        self._raw_lock = trio.Lock()
         self.nursery = context.nursery
         self.QueueFull = trio.WouldBlock
 


### PR DESCRIPTION
This fixes a bug when:
 - there is a ReadResponse that `sock_sendall` can not send in on go
 - there is a monitor that will fire during that readout

Because the buffer for the ReadResponse is sent in parts, the bytes
for the AddEvent can get sent while the client still thinks it is
receiving the payload from the ReadResponse.  The tail of the payload
will then be read as the next message from the server.

 a) corrupt the read payload
 b) result is a bogus message

---

A minimal example to reproduce the problem is

server:

```python
#!/usr/bin/env python3

import time
from caproto.server import pvproperty, PVGroup, ioc_arg_parser, run
import numpy as np

image_shape = (3960, 3960)


class IOInterruptIOC(PVGroup):
    t1 = pvproperty(value=2.0)
    dt1 = pvproperty(value=0.9, dtype=float, precision=3)
    image = pvproperty(
        value=np.random.randint(0, 256, image_shape).flatten(), dtype=float
    )

    @t1.startup
    async def t1(self, instance, async_lib):
        # Loop and grab items from the queue one at a time
        while True:
            await self.t1.write(time.monotonic())
            await async_lib.library.sleep(0.1)


if __name__ == "__main__":
    ioc_options, run_options = ioc_arg_parser(
        default_prefix="big_image:",
        desc="Run an IOC that updates via I/O interrupt on key-press events.",
    )

    ioc = IOInterruptIOC(**ioc_options)
    print(ioc.image)
    run(ioc.pvdb, **run_options)

```

client:
```python
#!/usr/bin/env python3
# -*- coding: utf-8 -*-
"""

"""
import epics

# import caproto.threading.pyepics_compat as epics

default_prefix = "big_image:"

image = epics.PV(pvname=default_prefix + "image")
t1 = epics.PV(pvname=default_prefix + "t1")
t1.add_callback(lambda value, **kwargs: print(f"t1: {value}"))

for j in range(42):
    img = image.get(timeout=20)
    print(img.shape)

```

Not sure we want to put in a CI test for this as in is a _bit_ flaky and definitely slow.

----

attn @vstadnytskyi