### PR TITLE
MNT: Bind to PORT 0

### DIFF
--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -48,6 +48,7 @@ def recv(circuit):
 def search(pv_name, udp_sock, timeout, *, max_retries=2):
     # Set Broadcaster log level to match our logger.
     b = ca.Broadcaster(our_role=ca.CLIENT)
+    udp_sock.bind(('', 0))
     b.our_address = udp_sock.getsockname()[:2]
 
     # Send registration request to the repeater

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -48,8 +48,7 @@ def recv(circuit):
 def search(pv_name, udp_sock, timeout, *, max_retries=2):
     # Set Broadcaster log level to match our logger.
     b = ca.Broadcaster(our_role=ca.CLIENT)
-    udp_sock.bind(('', 0))
-    b.our_address = udp_sock.getsockname()[:2]
+    b.our_address = None
 
     # Send registration request to the repeater
     logger.debug('Registering with the Channel Access repeater.')
@@ -61,6 +60,8 @@ def search(pv_name, udp_sock, timeout, *, max_retries=2):
             udp_sock.sendto(bytes_to_send, (host, repeater_port))
         except OSError as exc:
             raise ca.CaprotoNetworkError(f"Failed to send to {host}:{repeater_port}") from exc
+        else:
+            b.our_address = udp_sock.getsockname()[:2]
 
     logger.debug("Searching for '%s'....", pv_name)
     bytes_to_send = b.send(

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -340,7 +340,7 @@ class SharedBroadcaster:
         self.listeners = weakref.WeakSet()
 
         self.broadcaster = ca.Broadcaster(our_role=ca.CLIENT)
-        self.broadcaster.client_address = None
+        self.broadcaster.our_address = None
         self.log = logging.LoggerAdapter(
             self.broadcaster.log, {'role': 'CLIENT'})
         self.search_log = logging.LoggerAdapter(
@@ -457,8 +457,8 @@ class SharedBroadcaster:
                     f'{host}:{specified_port}') from ex
             else:
                 tags['their_address'] = (host, specified_port)
-                self.broadcaster.client_address = self.udp_sock.getsockname()[:2]
-                tags['our_address'] = self.broadcaster.client_address,
+                self.broadcaster.our_address = self.udp_sock.getsockname()[:2]
+                tags['our_address'] = self.broadcaster.our_address,
                 self.broadcaster.log.debug(
                     '%d commands %dB',
                     len(commands), len(bytes_to_send), extra=tags)
@@ -672,7 +672,7 @@ class SharedBroadcaster:
                                             name, cid, *accepted_address, *new_address,
                                             extra={'pv': name,
                                                    'their_address': accepted_address,
-                                                   'our_address': self.broadcaster.client_address})
+                                                   'our_address': self.broadcaster.our_address})
                     else:
                         results_by_cid.append((cid, name))
                         address = ca.extract_address(command)
@@ -765,7 +765,7 @@ class SharedBroadcaster:
                     checking[address] = now + RESPONSIVENESS_TIMEOUT
                     tags = {'role': 'CLIENT',
                             'their_address': address,
-                            'our_address': self.broadcaster.client_address,
+                            'our_address': self.broadcaster.our_address,
                             'direction': '--->>>'}
 
                     self.broadcaster.log.debug(
@@ -1101,7 +1101,7 @@ class Context:
                 search_logger.debug('Connecting %s on circuit with %s:%d', name, *address,
                                     extra={'pv': name,
                                            'their_address': address,
-                                           'our_address': self.broadcaster.broadcaster.client_address,
+                                           'our_address': self.broadcaster.broadcaster.our_address,
                                            'direction': '--->>>',
                                            'role': 'CLIENT'})
                 # There could be multiple PVs with the same name and

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -462,7 +462,7 @@ class SharedBroadcaster:
                 self.broadcaster.log.debug(
                     '%d commands %dB',
                     len(commands), len(bytes_to_send), extra=tags)
-                
+
     def get_cached_search_result(self, name, *,
                                  threshold=STALE_SEARCH_EXPIRATION):
         'Returns address if found, raises KeyError if missing or stale.'

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -340,6 +340,7 @@ class SharedBroadcaster:
         self.listeners = weakref.WeakSet()
 
         self.broadcaster = ca.Broadcaster(our_role=ca.CLIENT)
+        self.udp_sock.bind(('', 0))
         self.broadcaster.our_address = self.udp_sock.getsockname()[:2]
         self.log = logging.LoggerAdapter(
             self.broadcaster.log, {'role': 'CLIENT'})

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -672,7 +672,7 @@ class SharedBroadcaster:
                                             name, cid, *accepted_address, *new_address,
                                             extra={'pv': name,
                                                    'their_address': accepted_address,
-                                                   'our_address': self.udp_sock.getsockname()[:2]})
+                                                   'our_address': self.broadcaster.client_address})
                     else:
                         results_by_cid.append((cid, name))
                         address = ca.extract_address(command)
@@ -765,7 +765,7 @@ class SharedBroadcaster:
                     checking[address] = now + RESPONSIVENESS_TIMEOUT
                     tags = {'role': 'CLIENT',
                             'their_address': address,
-                            'our_address': self.udp_sock.getsockname()[:2],
+                            'our_address': self.broadcaster.client_address,
                             'direction': '--->>>'}
 
                     self.broadcaster.log.debug(
@@ -1101,7 +1101,7 @@ class Context:
                 search_logger.debug('Connecting %s on circuit with %s:%d', name, *address,
                                     extra={'pv': name,
                                            'their_address': address,
-                                           'our_address': self.broadcaster.udp_sock.getsockname()[:2],
+                                           'our_address': self.broadcaster.broadcaster.client_address,
                                            'direction': '--->>>',
                                            'role': 'CLIENT'})
                 # There could be multiple PVs with the same name and


### PR DESCRIPTION
**Goal**
This PR is trying to solve #540 and #514 related socket error only reported on windows. 

**Solution**
It looks like Linux and Mac will assign `('0.0.0.0', 0)` to socket, if we didn't explicit `bind`.

`bind` argument in this PR is based on 
- https://eklitzke.org/binding-on-port-zero (I also have  same concern mentioned in this article)
- https://docs.python.org/3/library/socket.html#socket.create_connection

**Test**
This PR solved scenario in those two issues(#540, #514) but may need further tests.