### PR TITLE
WIP: Polish logging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ doc/source/_static
 caproto/__pycache__
 caproto.egg-info
 __pycache__/
+*.pyc
 doc/build
 .cache/
 .coverage

--- a/caproto/_broadcaster.py
+++ b/caproto/_broadcaster.py
@@ -59,7 +59,7 @@ class Broadcaster:
         )
         self.log = logging.getLogger("caproto.bcast")
         self.beacon_log = logging.getLogger('caproto.bcast.beacon')
-        self.search_log = logging.getLogger('caproto.bcast.beacon')
+        self.search_log = logging.getLogger('caproto.bcast.search')
 
     @property
     def our_addresses(self):

--- a/caproto/_broadcaster.py
+++ b/caproto/_broadcaster.py
@@ -97,7 +97,7 @@ class Broadcaster:
         tags = {'role': repr(self.our_role)}
         for i, command in enumerate(commands):
             tags['counter'] = (1 + i, total_commands)
-            if isinstance(command, SearchRequest):
+            if isinstance(command, (SearchRequest, SearchResponse)):
                 # Send to a particular logger, and include the PV name.
                 self.search_log.debug("%r", command,
                                       extra={'pv': command.name, **tags})

--- a/caproto/_broadcaster.py
+++ b/caproto/_broadcaster.py
@@ -98,9 +98,7 @@ class Broadcaster:
         for i, command in enumerate(commands):
             tags['counter'] = (1 + i, total_commands)
             if isinstance(command, (SearchRequest, SearchResponse)):
-                # Send to a particular logger, and include the PV name.
-                self.search_log.debug("%r", command,
-                                      extra={'pv': command.name, **tags})
+                self.search_log.debug("%r", command, extra=tags)
             else:
                 self.log.debug("%r", command, extra=tags)
             self._process_command(self.our_role, command, history=history)

--- a/caproto/_circuit.py
+++ b/caproto/_circuit.py
@@ -133,7 +133,7 @@ class VirtualCircuit:
     def __hash__(self):
         return hash((self.address, self.priority, self.our_role))
 
-    def send(self, *commands):
+    def send(self, *commands, extra=None):
         """
         Convert one or more high-level Commands into buffers of bytes that may
         be broadcast together in one TCP packet. Update our internal
@@ -154,6 +154,7 @@ class VirtualCircuit:
                 'our_address': self.our_address,
                 'direction': '--->>>',
                 'role': repr(self.our_role)}
+        tags.update(extra or {})
         for command in commands:
             self._process_command(self.our_role, command)
             if hasattr(command, 'name') and not isinstance(command, (ClientNameRequest, HostNameRequest)):

--- a/caproto/_circuit.py
+++ b/caproto/_circuit.py
@@ -158,7 +158,7 @@ class VirtualCircuit:
             self._process_command(self.our_role, command)
             if hasattr(command, 'name') and not isinstance(command, (ClientNameRequest, HostNameRequest)):
                 tags['pv'] = command.name
-            self.log.debug("(%dB) %r", len(command), command, extra=tags)
+            self.log.debug("%dB %r", len(command), command, extra=tags)
             buffers_to_send.append(memoryview(command.header))
             buffers_to_send.extend(command.buffers)
         return buffers_to_send
@@ -199,7 +199,7 @@ class VirtualCircuit:
              num_bytes_needed) = read_from_bytestream(self._data,
                                                       self.their_role)
             if command is not NEED_DATA:
-                self.log.debug("(%dB) %r", len(command), command, extra=tags)
+                self.log.debug("%dB %r", len(command), command, extra=tags)
                 commands.append(command)
             else:
                 # Less than a full command's worth of bytes are cached. Wait

--- a/caproto/_circuit.py
+++ b/caproto/_circuit.py
@@ -419,7 +419,7 @@ class VirtualCircuit:
                                                           self.priority))
             protocol_version = min(self.protocol_version, command.version)
             self.protocol_version = protocol_version
-            for cid, chan in self.channels.items():
+            for chan in self.channels.values():
                 chan.protocol_version = protocol_version
 
         if isinstance(command, VersionResponse):
@@ -432,7 +432,7 @@ class VirtualCircuit:
                 return
             protocol_version = min(self.protocol_version, command.version)
             self.protocol_version = protocol_version
-            for cid, chan in self.channels.items():
+            for chan in self.channels.values():
                 chan.protocol_version = protocol_version
 
     def disconnect(self):
@@ -468,9 +468,9 @@ class _BaseChannel:
     # methods for composing requests and repsponses, respectively. All of the
     # important code is here in the base class.
     def __init__(self, name, circuit, cid=None, string_encoding=STRING_ENCODING):
-        tags =  {'pv': name,
-                 'their_address': circuit.address,
-                 'role': repr(circuit.our_role)}
+        tags = {'pv': name,
+                'their_address': circuit.address,
+                'role': repr(circuit.our_role)}
         self.log = ComposableLogAdapter(logging.getLogger('caproto.ch'), tags)
         self.protocol_version = circuit.protocol_version
         self.name = name

--- a/caproto/_circuit.py
+++ b/caproto/_circuit.py
@@ -158,7 +158,8 @@ class VirtualCircuit:
             self._process_command(self.our_role, command)
             if hasattr(command, 'name') and not isinstance(command, (ClientNameRequest, HostNameRequest)):
                 tags['pv'] = command.name
-            self.log.debug("%dB %r", len(command), command, extra=tags)
+            tags['bytesize'] = len(command)
+            self.log.debug("%r", command, extra=tags)
             buffers_to_send.append(memoryview(command.header))
             buffers_to_send.extend(command.buffers)
         return buffers_to_send
@@ -199,7 +200,8 @@ class VirtualCircuit:
              num_bytes_needed) = read_from_bytestream(self._data,
                                                       self.their_role)
             if command is not NEED_DATA:
-                self.log.debug("%dB %r", len(command), command, extra=tags)
+                tags['bytesize'] = len(command)
+                self.log.debug("%r", command, extra=tags)
                 commands.append(command)
             else:
                 # Less than a full command's worth of bytes are cached. Wait

--- a/caproto/_commands.py
+++ b/caproto/_commands.py
@@ -81,7 +81,7 @@ __all__ = ('AccessRightsResponse', 'ClearChannelRequest',
            'ServerDisconnResponse', 'VersionRequest',
            'VersionResponse', 'WriteNotifyRequest',
            'WriteNotifyResponse', 'WriteRequest',
-           )
+           'Message')
 
 
 _MessageHeaderSize = ctypes.sizeof(MessageHeader)

--- a/caproto/_dbr.py
+++ b/caproto/_dbr.py
@@ -187,7 +187,7 @@ class DbrStringArray(collections.UserList):
 
         buf = bytes(buf)
         strings = cls()
-        for i in range(data_count):
+        for _ in range(data_count):
             strings.append(buf[:safely_find_eos()])
             buf = buf[MAX_STRING_SIZE:]
 

--- a/caproto/_log.py
+++ b/caproto/_log.py
@@ -344,7 +344,8 @@ def _set_handler_with_logger(logger_name='caproto', file=sys.stdout, datefmt='%H
         format = plain_log_format
     handler.setFormatter(
         LogFormatter(format, datefmt=datefmt))
-    logging.getLogger(logger_name).addHandler(handler)
+    logger = logging.getLogger(logger_name)
+    logger.addHandler(handler)
     if logger.getEffectiveLevel() > levelno:
         logger.setLevel(levelno)
 

--- a/caproto/_log.py
+++ b/caproto/_log.py
@@ -164,9 +164,6 @@ def color_logs(color):
     config_caproto_logging(color=color)
 
 
-logger = logging.getLogger('caproto')
-ch_logger = logging.getLogger('caproto.ch')
-search_logger = logging.getLogger('caproto.bcast.search')
 current_handler = None
 
 
@@ -408,6 +405,7 @@ def config_caproto_logging(file=sys.stdout, datefmt='%H:%M:%S', color=True, leve
         format = plain_log_format
     handler.setFormatter(
         LogFormatter(format, datefmt=datefmt))
+    logger = logging.getLogger('caproto')
     if current_handler in logger.handlers:
         logger.removeHandler(current_handler)
     logger.addHandler(handler)

--- a/caproto/_log.py
+++ b/caproto/_log.py
@@ -51,7 +51,7 @@ class LogFormatter(logging.Formatter):
 
     """
     DEFAULT_FORMAT = \
-        '%(color)s[%(levelname)1.1s %(asctime)s %(module)s:%(lineno)d]%(end_color)s %(message)s'
+        '%(color)s[%(levelname)1.1s %(asctime)s %(module)12s:%(lineno)d]%(end_color)s %(message)s'
     DEFAULT_DATE_FORMAT = '%y%m%d %H:%M:%S'
     DEFAULT_COLORS = {
         logging.DEBUG: 4,  # Blue
@@ -106,13 +106,13 @@ class LogFormatter(logging.Formatter):
     def format(self, record):
         message = []
         if hasattr(record, 'our_address'):
-            message.append('[%s]' % ':'.join(map(str, record.our_address)))
+            message.append('%s' % ':'.join(map(str, record.our_address)))
         if hasattr(record, 'direction'):
             message.append('%s' % record.direction)
         if hasattr(record, 'their_address'):
-            message.append('[%s]' % ':'.join(map(str, record.their_address)))
+            message.append('%s' % ':'.join(map(str, record.their_address)))
         if hasattr(record, 'pv'):
-            message.append('[%s]' % record.pv)
+            message.append('%s' % record.pv)
         message.append(record.getMessage())
         record.message = ' '.join(message)
         record.asctime = self.formatTime(record, self.datefmt)
@@ -133,9 +133,9 @@ class LogFormatter(logging.Formatter):
         return formatted.replace("\n", "\n    ")
 
 
-plain_log_format = "[%(levelname)1.1s %(asctime)s.%(msecs)03d %(module)15s:%(lineno)5d] %(message)s"
+plain_log_format = "[%(levelname)1.1s %(asctime)s.%(msecs)03d %(module)12s:%(lineno)5d] %(message)s"
 color_log_format = ("%(color)s[%(levelname)1.1s %(asctime)s.%(msecs)03d "
-                    "%(module)15s:%(lineno)5d]%(end_color)s %(message)s")
+                    "%(module)12s:%(lineno)5d]%(end_color)s %(message)s")
 
 
 def color_logs(color):

--- a/caproto/_log.py
+++ b/caproto/_log.py
@@ -127,7 +127,7 @@ class LogFormatter(logging.Formatter):
         if hasattr(record, 'counter'):
             message.append('(%d of %d)' % record.counter)
         if hasattr(record, 'pv'):
-            message.append('%s' % record.pv)
+            message.append(record.pv)
         message.append(record.getMessage())
         record.message = ' '.join(message)
         record.asctime = self.formatTime(record, self.datefmt)

--- a/caproto/_log.py
+++ b/caproto/_log.py
@@ -38,6 +38,17 @@ def _stderr_supports_color():
     return False
 
 
+class ComposableLogAdapter(logging.LoggerAdapter):
+    def process(self, msg, kwargs):
+        # The logging.LoggerAdapter siliently ignores `extra` in this usage:
+        # log_adapter.debug(msg, extra={...})
+        # and passes through log_adapater.extra instead. This subclass merges
+        # the extra passed via keyword argument with the extra in the
+        # attribute, giving precedence to the keyword argument.
+        kwargs["extra"] = {**self.extra, **kwargs.get('extra', {})}
+        return msg, kwargs
+
+
 class LogFormatter(logging.Formatter):
     """Log formatter for caproto records.
 

--- a/caproto/_log.py
+++ b/caproto/_log.py
@@ -121,9 +121,9 @@ class LogFormatter(logging.Formatter):
         if hasattr(record, 'direction'):
             message.append('%s' % record.direction)
         if hasattr(record, 'their_address'):
-            message.append('%s:%d'  % record.their_address)
+            message.append('%s:%d' % record.their_address)
         if hasattr(record, 'bytesize'):
-            message.append('%dB'  % record.bytesize)
+            message.append('%dB' % record.bytesize)
         if hasattr(record, 'counter'):
             message.append('(%d of %d)' % record.counter)
         if hasattr(record, 'pv'):

--- a/caproto/_log.py
+++ b/caproto/_log.py
@@ -106,11 +106,15 @@ class LogFormatter(logging.Formatter):
     def format(self, record):
         message = []
         if hasattr(record, 'our_address'):
-            message.append('%s' % ':'.join(map(str, record.our_address)))
+            message.append('%s:%d' % record.our_address)
         if hasattr(record, 'direction'):
             message.append('%s' % record.direction)
         if hasattr(record, 'their_address'):
-            message.append('%s' % ':'.join(map(str, record.their_address)))
+            message.append('%s:%d'  % record.their_address)
+        if hasattr(record, 'bytesize'):
+            message.append('%dB'  % record.bytesize)
+        if hasattr(record, 'counter'):
+            message.append('(%d of %d)' % record.counter)
         if hasattr(record, 'pv'):
             message.append('%s' % record.pv)
         message.append(record.getMessage())

--- a/caproto/asyncio/server.py
+++ b/caproto/asyncio/server.py
@@ -294,7 +294,7 @@ class Context(_Context):
                 sock.close()
             for sock in self.udp_socks.values():
                 sock.close()
-            for interface, sock in self.beacon_socks.values():
+            for _interface, sock in self.beacon_socks.values():
                 sock.close()
 
 

--- a/caproto/asyncio/server.py
+++ b/caproto/asyncio/server.py
@@ -169,13 +169,13 @@ class Context(_Context):
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.setblocking(False)
             s.bind((interface, port))
-            self.broadcaster._our_addresses.append(s.getsockname()[:2])
             return s
         self.port, self.tcp_sockets = await self._bind_tcp_sockets_with_consistent_port_number(
             make_socket)
         tasks = []
         for interface, sock in self.tcp_sockets.items():
             self.log.info("Listening on %s:%d", interface, self.port)
+            self.broadcaster.server_addresses.append((interface, self.port))
             tasks.append(self.loop.create_task(self.server_accept_loop(sock)))
 
         class BcastLoop(asyncio.Protocol):

--- a/caproto/curio/client.py
+++ b/caproto/curio/client.py
@@ -257,15 +257,19 @@ class SharedBroadcaster:
         Process a command and tranport it over the UDP socket.
         """
         bytes_to_send = self.broadcaster.send(*commands)
+        tags = {'role': 'CLIENT',
+                'our_address': self.broadcaster.client_address,
+                'direction': '--->>>'}
         for host in ca.get_address_list():
             if ':' in host:
                 host, _, port_as_str = host.partition(':')
                 specified_port = int(port_as_str)
             else:
                 specified_port = port
+            tags['their_address'] = (host, specified_port)
             self.broadcaster.log.debug(
-                'Sending %d bytes to %s:%d',
-                len(bytes_to_send), host, specified_port)
+                '%d commands %dB',
+                len(commands), len(bytes_to_send), extra=tags)
             try:
                 await self.udp_sock.sendto(bytes_to_send,
                                            (host, specified_port))

--- a/caproto/curio/server.py
+++ b/caproto/curio/server.py
@@ -194,7 +194,7 @@ class Context(_Context):
                 await sock.close()
             for sock in self.udp_socks.values():
                 await sock.close()
-            for interface, sock in self.beacon_socks.values():
+            for _interface, sock in self.beacon_socks.values():
                 await sock.close()
             self._task_group = None
 

--- a/caproto/curio/server.py
+++ b/caproto/curio/server.py
@@ -119,7 +119,7 @@ class Context(_Context):
     async def broadcaster_udp_server_loop(self):
         for interface in self.interfaces:
             udp_sock = ca.bcast_socket(socket)
-            self.broadcaster._our_addresses.append(udp_sock.getsockname()[:2])
+            self.broadcaster.server_addresses.append(udp_sock.getsockname()[:2])
             try:
                 udp_sock.bind((interface, self.ca_server_port))
             except Exception:

--- a/caproto/ioc_examples/dynamic_pvgroups.py
+++ b/caproto/ioc_examples/dynamic_pvgroups.py
@@ -47,7 +47,7 @@ def create_ioc(prefix, groups_a, groups_b, **ioc_options):
     for group_prefix in groups_b:
         groups[group_prefix] = GroupB(f'{prefix}{group_prefix}', ioc=ioc)
 
-    for prefix, group in groups.items():
+    for group in groups.values():
         ioc.pvdb.update(**group.pvdb)
 
     return ioc

--- a/caproto/server/__init__.py
+++ b/caproto/server/__init__.py
@@ -7,5 +7,5 @@ from . import records  # noqa
 def run(pvdb, *, module_name, **kwargs):
     from importlib import import_module  # to avoid leaking into module ns
     module = import_module(module_name)
-    run = getattr(module, 'run')
+    run = module.run
     return run(pvdb, **kwargs)

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -592,7 +592,7 @@ class VirtualCircuit:
         if isinstance(command, ca.Message):
             tags['bytesize'] = len(command)
             self.log.debug("%r", command, extra=tags)
-            return to_send
+        return to_send
 
 
 class Context:

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -413,17 +413,18 @@ class VirtualCircuit:
                 self.log.debug('Client requested invalid channel name: %s',
                                command.name)
                 to_send = [ca.CreateChFailResponse(cid=command.cid)]
+            else:
 
-            access = db_entry.check_access(self.client_hostname,
-                                           self.client_username)
+                access = db_entry.check_access(self.client_hostname,
+                                               self.client_username)
 
-            to_send = [ca.AccessRightsResponse(cid=command.cid,
-                                               access_rights=access),
-                       ca.CreateChanResponse(data_type=db_entry.data_type,
-                                             data_count=db_entry.max_length,
-                                             cid=command.cid,
-                                             sid=self.circuit.new_channel_id()),
-                       ]
+                to_send = [ca.AccessRightsResponse(cid=command.cid,
+                                                   access_rights=access),
+                           ca.CreateChanResponse(data_type=db_entry.data_type,
+                                                 data_count=db_entry.max_length,
+                                                 cid=command.cid,
+                                                 sid=self.circuit.new_channel_id()),
+                           ]
         elif isinstance(command, ca.HostNameRequest):
             self.client_hostname = command.name
             to_send = []

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -64,6 +64,11 @@ class VirtualCircuit:
         self.unexpired_updates = defaultdict(
             lambda: deque(maxlen=ca.MAX_SUBSCRIPTION_BACKLOG))
         self.most_recent_updates = {}
+        # This dict is passed to the loggers.
+        self._tags = {'their_address': self.circuit.address,
+                      'our_address': self.circuit.our_address,
+                      'direction': '<<<---',
+                      'role': repr(self.circuit.our_role)}
         # Subclasses are expected to define:
         # self.QueueFull = ...
         # self.command_queue = ...
@@ -378,23 +383,26 @@ class VirtualCircuit:
             chan = self.circuit.channels_sid[command.sid]
             db_entry = self.context[chan.name]
             return chan, db_entry
+        tags = self._tags
         if command is ca.DISCONNECTED:
             raise DisconnectedCircuit()
         elif isinstance(command, ca.VersionRequest):
-            return [ca.VersionResponse(ca.DEFAULT_PROTOCOL_VERSION)]
+            to_send = [ca.VersionResponse(ca.DEFAULT_PROTOCOL_VERSION)]
         elif isinstance(command, ca.SearchRequest):
             pv_name = command.name
             try:
                 self.context[pv_name]
             except KeyError:
                 if command.reply == ca.DO_REPLY:
-                    return [
+                    to_send = [
                         ca.NotFoundResponse(
                             version=ca.DEFAULT_PROTOCOL_VERSION,
                             cid=command.cid)
                     ]
+                else:
+                    to_send = []
             else:
-                return [
+                to_send = [
                     ca.SearchResponse(self.context.port, None, command.cid,
                                       ca.DEFAULT_PROTOCOL_VERSION)
                 ]
@@ -404,22 +412,24 @@ class VirtualCircuit:
             except KeyError:
                 self.log.debug('Client requested invalid channel name: %s',
                                command.name)
-                return [ca.CreateChFailResponse(cid=command.cid)]
+                to_send = [ca.CreateChFailResponse(cid=command.cid)]
 
             access = db_entry.check_access(self.client_hostname,
                                            self.client_username)
 
-            return [ca.AccessRightsResponse(cid=command.cid,
-                                            access_rights=access),
-                    ca.CreateChanResponse(data_type=db_entry.data_type,
-                                          data_count=db_entry.max_length,
-                                          cid=command.cid,
-                                          sid=self.circuit.new_channel_id()),
-                    ]
+            to_send = [ca.AccessRightsResponse(cid=command.cid,
+                                               access_rights=access),
+                       ca.CreateChanResponse(data_type=db_entry.data_type,
+                                             data_count=db_entry.max_length,
+                                             cid=command.cid,
+                                             sid=self.circuit.new_channel_id()),
+                       ]
         elif isinstance(command, ca.HostNameRequest):
             self.client_hostname = command.name
+            to_send = []
         elif isinstance(command, ca.ClientNameRequest):
             self.client_username = command.name
+            to_send = []
         elif isinstance(command, (ca.ReadNotifyRequest, ca.ReadRequest)):
             chan, db_entry = get_db_entry()
             try:
@@ -454,11 +464,11 @@ class VirtualCircuit:
                                                      for field, _ in time_type._fields_)))
             notify = isinstance(command, ca.ReadNotifyRequest)
             data_count = db_entry.calculate_length(data)
-            return [chan.read(data=data, data_type=command.data_type,
-                              data_count=data_count, status=1,
-                              ioid=command.ioid, metadata=metadata,
-                              notify=notify)
-                    ]
+            to_send = [chan.read(data=data, data_type=command.data_type,
+                                 data_count=data_count, status=1,
+                                 ioid=command.ioid, metadata=metadata,
+                                 notify=notify)
+                       ]
         elif isinstance(command, (ca.WriteRequest, ca.WriteNotifyRequest)):
             chan, db_entry = get_db_entry()
             client_waiting = isinstance(command, ca.WriteNotifyRequest)
@@ -504,6 +514,7 @@ class VirtualCircuit:
 
             self.write_event.clear()
             await self._start_write_task(handle_write)
+            to_send = []
         elif isinstance(command, ca.EventAddRequest):
             chan, db_entry = get_db_entry()
             # TODO no support for deprecated low/high/to
@@ -532,6 +543,7 @@ class VirtualCircuit:
 
             await db_entry.subscribe(self.context.subscription_queue, sub_spec,
                                      sub)
+            to_send = []
         elif isinstance(command, ca.EventCancelRequest):
             chan, db_entry = get_db_entry()
             removed = await self._cull_subscriptions(
@@ -542,9 +554,9 @@ class VirtualCircuit:
                 data_count = removed_sub.data_count
             else:
                 data_count = db_entry.length
-            return [chan.unsubscribe(command.subscriptionid,
-                                     data_type=command.data_type,
-                                     data_count=data_count)]
+            to_send = [chan.unsubscribe(command.subscriptionid,
+                                        data_type=command.data_type,
+                                        data_count=data_count)]
         elif isinstance(command, ca.EventsOnRequest):
             # Immediately send most recent updates for all subscriptions.
             most_recent_updates = list(self.most_recent_updates.values())
@@ -557,6 +569,7 @@ class VirtualCircuit:
                 await maybe_awaitable
             self.circuit.log.info("Client at %s:%d has turned events on.",
                                   *self.circuit.address)
+            to_send = []
         elif isinstance(command, ca.EventsOffRequest):
             # The client has signaled that it does not think it will be able to
             # catch up to the backlog. Clear all updates queued to be sent...
@@ -566,14 +579,19 @@ class VirtualCircuit:
             self.events_on.clear()
             self.circuit.log.info("Client at %s:%d has turned events off.",
                                   *self.circuit.address)
+            to_send = []
         elif isinstance(command, ca.ClearChannelRequest):
             chan, db_entry = get_db_entry()
             await self._cull_subscriptions(
                 db_entry,
                 lambda sub: sub.channel == command.sid)
-            return [chan.clear()]
+            to_send = [chan.clear()]
         elif isinstance(command, ca.EchoRequest):
-            return [ca.EchoResponse()]
+            to_send = [ca.EchoResponse()]
+        if isinstance(command, ca.Message):
+            tags['bytesize'] = len(command)
+            self.log.debug("%r", command, extra=tags)
+            return to_send
 
 
 class Context:

--- a/caproto/server/conversion.py
+++ b/caproto/server/conversion.py
@@ -158,7 +158,7 @@ def ophyd_device_to_caproto_ioc(dev, *, depth=0):
                                                dev=dev)
         if isinstance(cpt_lines, dict):
             # new device/sub-group, for now add it on
-            for new_dev, lines in cpt_lines.items():
+            for lines in cpt_lines.values():
                 dev_lines.extend(lines)
         else:
             dev_lines.extend(cpt_lines)
@@ -333,7 +333,7 @@ def record_to_field_dict_code(record_type, *, skip_fields=None):
     yield f"    kw['reported_record_type'] = '{record_type}'"
     yield f"    kw['alarm_group'] = alarm_group"
     yield '    return {'
-    for name, cls, kwargs, finfo in record_to_field_info(record_type):
+    for _name, cls, kwargs, finfo in record_to_field_info(record_type):
         kwarg_string = ', '.join(
             list(f'{k}={v}' for k, v in kwargs.items()) + ['**kw'])
         yield f"        '{finfo.field}': {cls.__name__}({kwarg_string}),"

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -212,12 +212,12 @@ def _read(chan, timeout, data_type, notify, force_int_enums):
         if time.monotonic() - t > timeout:
             raise CaprotoTimeoutError("Timeout while awaiting reading.")
 
+        tags = {'direction': '<<<---',
+                'our_address': chan.circuit.our_address,
+                'their_address': chan.circuit.address}
         for command in commands:
             if isinstance(command, ca.Message):
-                tags = {'direction': '<<<---',
-                        'bytesize': len(command),
-                        'our_address': chan.circuit.our_address,
-                        'their_address': chan.circuit.address}
+                tags['bytesize'] = len(command)
                 logger.debug("%r", command, extra=tags)
             if (isinstance(command, (ca.ReadResponse, ca.ReadNotifyResponse)) and
                     command.ioid == req.ioid):
@@ -505,7 +505,13 @@ def _write(chan, data, metadata, timeout, data_type, notify):
             if time.monotonic() - t > timeout:
                 raise CaprotoTimeoutError("Timeout while awaiting write reply.")
 
+            tags = {'direction': '<<<---',
+                    'our_address': chan.circuit.our_address,
+                    'their_address': chan.circuit.address}
             for command in commands:
+                if isinstance(command, ca.Message):
+                    tags['bytesize'] = len(command)
+                    logger.debug("%r", command, extra=tags)
                 if (isinstance(command, ca.WriteNotifyResponse) and
                         command.ioid == req.ioid):
                     response = command

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -177,12 +177,18 @@ def make_channel(pv_name, udp_sock, priority, timeout):
             except socket.timeout:
                 raise CaprotoTimeoutError("Timeout while awaiting channel "
                                           "creation.")
+            tags = {'direction': '<<<---',
+                    'our_address': chan.circuit.our_address,
+                    'their_address': chan.circuit.address}
+            for command in commands:
+                if isinstance(command, ca.Message):
+                    tags['bytesize'] = len(command)
+                    logger.debug("%r", command, extra=tags)
+                elif command is ca.DISCONNECTED:
+                    raise CaprotoError('Disconnected during initialization')
             if chan.states[ca.CLIENT] is ca.CONNECTED:
                 log.info("Channel connected.")
                 break
-            for command in commands:
-                if command is ca.DISCONNECTED:
-                    raise CaprotoError('Disconnected during initialization')
 
     except BaseException:
         sockets[chan.circuit].close()

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -178,7 +178,7 @@ def make_channel(pv_name, udp_sock, priority, timeout):
                 raise CaprotoTimeoutError("Timeout while awaiting channel "
                                           "creation.")
             if chan.states[ca.CLIENT] is ca.CONNECTED:
-                log.info('%s connected' % pv_name)
+                log.info("Channel connected.")
                 break
             for command in commands:
                 if command is ca.DISCONNECTED:

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -61,7 +61,7 @@ def search(pv_name, udp_sock, timeout, *, max_retries=2):
         except OSError as exc:
             raise ca.CaprotoNetworkError(f"Failed to send to {host}:{repeater_port}") from exc
 
-    logger.debug("Searching for '%s'....", pv_name)
+    logger.debug("Searching for %r....", pv_name)
     bytes_to_send = b.send(
         ca.VersionRequest(0, ca.DEFAULT_PROTOCOL_VERSION),
         ca.SearchRequest(pv_name, 0, ca.DEFAULT_PROTOCOL_VERSION))
@@ -78,7 +78,7 @@ def search(pv_name, udp_sock, timeout, *, max_retries=2):
             except OSError as exc:
                 host, port = dest
                 raise ca.CaprotoNetworkError(f"Failed to send to {host}:{port}") from exc
-            logger.debug('Search request sent to %r.', dest)
+            logger.debug('Search request sent to %s:%d.', *dest)
 
     def check_timeout():
         nonlocal retry_at
@@ -118,7 +118,7 @@ def search(pv_name, udp_sock, timeout, *, max_retries=2):
             for command in commands:
                 if isinstance(command, ca.SearchResponse) and command.cid == 0:
                     address = ca.extract_address(command)
-                    logger.debug('Found %s at %s', pv_name, address)
+                    logger.debug('Found %r at %s:%d', pv_name, *address)
                     return address
             else:
                 # None of the commands we have seen are a reply to our request.

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -456,7 +456,7 @@ def block(*subscriptions, duration=None, timeout=1, force_int_enums=False,
                     logger.debug("Interrupted via "
                                  "caproto.sync.client.interrupt().")
                     break
-                for selector_key, mask in events:
+                for selector_key, _ in events:
                     circuit = sock_to_circuit[selector_key.fileobj]
                     commands = recv(circuit)
                     for response in commands:

--- a/caproto/tests/conftest.py
+++ b/caproto/tests/conftest.py
@@ -121,7 +121,7 @@ def run_example_ioc(module_name, *, request, pv_to_check, args=None,
 def poll_readiness(pv_to_check, attempts=5, timeout=1):
     logger.debug(f'Checking PV {pv_to_check}')
     start_repeater()
-    for attempt in range(attempts):
+    for _attempt in range(attempts):
         try:
             read(pv_to_check, timeout=timeout, repeater=False)
         except (TimeoutError, ConnectionRefusedError):
@@ -140,7 +140,7 @@ def run_softioc(request, db, additional_db=None, **kwargs):
         db_text = '\n'.join((db_text, additional_db))
 
     err = None
-    for attempt in range(3):
+    for _attempt in range(3):
         ioc_handler = ca.benchmarking.IocHandler()
         ioc_handler.setup_ioc(db_text=db_text, max_array_bytes='10000000',
                               **kwargs)

--- a/caproto/tests/test_core.py
+++ b/caproto/tests/test_core.py
@@ -392,7 +392,7 @@ def test_ioid_exhaustion(circuit_pair):
     data_count = 1
 
     # if this is broken it will hang
-    for N in range(max_id + 10):
+    for _ in range(max_id + 10):
         # create a read request and serialize
         req = cli_channel.read()
         assert req.ioid < max_id

--- a/caproto/tests/test_examples.py
+++ b/caproto/tests/test_examples.py
@@ -317,7 +317,7 @@ def _test_ioc_examples(request, module_name, pvdb_class_name, class_kwargs,
 
     skip_pvs = [('ophyd', ':exit')]
 
-    def find_put_value(pv):
+    def find_put_value(pv, channeldata):
         'Determine value to write to pv'
         for skip_ioc, skip_suffix in skip_pvs:
             if skip_ioc in module_name:
@@ -332,7 +332,7 @@ def _test_ioc_examples(request, module_name, pvdb_class_name, class_kwargs,
                             f'{channeldata.__class__}')
 
     for pv, channeldata in pvdb.items():
-        value = find_put_value(pv)
+        value = find_put_value(pv, channeldata)
         if value is None:
             print(f'Skipping write to {pv}')
             continue
@@ -540,7 +540,7 @@ def test_event_read_collision(request, prefix, async_lib):
     t1 = get_pv(pvname=f'{prefix}t1', context=cntx)
     t1.add_callback(lambda value, **kwargs: None)
 
-    for j in range(4):
+    for _ in range(4):
         image.get(timeout=45)
 
     image.disconnect()

--- a/caproto/tests/test_server.py
+++ b/caproto/tests/test_server.py
@@ -325,7 +325,7 @@ def test_write_without_notify(request, prefix, async_lib):
                     pv_to_check=pv)
     write(pv, 3.179, notify=False)
     # We do not get notified so we have to poll for an update.
-    for attempt in range(20):
+    for _attempt in range(20):
         if read(pv).data[0] > 3.178:
             break
         time.sleep(0.1)

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -219,7 +219,7 @@ def test_subscriptions(ioc, context):
     sub.clear()
     pv.write((4, ), wait=True)  # This update should not be received by us.
 
-    for i in range(3):
+    for _ in range(3):
         if pv.read().data[0] == 3:
             time.sleep(0.2)
             break
@@ -285,7 +285,7 @@ def test_multiple_subscriptions_one_server(ioc, context):
     for sub, cb in cbs.items():
         sub.add_callback(cb)
     time.sleep(0.2)
-    for sub, responses in collector.items():
+    for responses in collector.values():
         assert len(responses) == 1
     assert len(pv.circuit_manager.subscriptions) == len(pvs) > 1
 
@@ -542,7 +542,7 @@ def test_multithreaded_many_subscribe(ioc, context, thread_count,
         sub = pv.subscribe()
         sub.add_callback(callback)
         # Wait <= 20 seconds until first EventAddResponse is received.
-        for i in range(200):
+        for _ in range(200):
             if values[thread_id]:
                 break
             time.sleep(0.1)
@@ -553,7 +553,7 @@ def test_multithreaded_many_subscribe(ioc, context, thread_count,
         # Everybody here? On my signal... SEND UPDATES!! Ahahahahaha!
         # Destruction!!
         # Wait <= 20 seconds until three more EventAddResponses are received.
-        for i in range(200):
+        for _ in range(200):
             if len(values[thread_id]) == 4:
                 break
             time.sleep(0.1)
@@ -664,7 +664,7 @@ def test_events_off_and_on(ioc, context):
     pv.write((3, ), wait=True)
     time.sleep(0.2)  # Wait for the last update to be processed.
 
-    for i in range(3):
+    for _ in range(3):
         if pv.read().data[0] == 3:
             time.sleep(0.2)
             break
@@ -687,7 +687,7 @@ def test_events_off_and_on(ioc, context):
     pv.write((8, ), wait=True)
     pv.write((9, ), wait=True)
 
-    for i in range(3):
+    for _ in range(3):
         if pv.read().data[0] == 7:
             time.sleep(0.2)
             break

--- a/caproto/tests/test_utils.py
+++ b/caproto/tests/test_utils.py
@@ -13,7 +13,8 @@ def test_broadcast_auto_address_list():
         expected = [bcast for addr, bcast in ca.get_netifaces_addresses()]
         assert ca.get_address_list() == expected
     finally:
-        os.environ = env
+        os.environ.clear()
+        os.environ.update(env)
 
 
 def test_ensure_bytes():

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -36,10 +36,10 @@ from .._utils import (batch_requests, CaprotoError, ThreadsafeCounter,
                       socket_bytes_available, CaprotoTimeoutError,
                       CaprotoTypeError, CaprotoRuntimeError, CaprotoValueError,
                       CaprotoKeyError, CaprotoNetworkError)
-from .._log import ch_logger, search_logger
 
 
-print = partial(print, flush=True)
+ch_logger = logging.getLogger('caproto.ch')
+search_logger = logging.getLogger('caproto.bcast.search')
 
 
 CIRCUIT_DEATH_ATTEMPTS = 3

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1741,7 +1741,8 @@ class PV:
             # after it acquires the lock.
             try:
                 self.channel_ready.clear()
-                self.circuit_manager.send(self.channel.clear(), extra={'pv': pv.name})
+                self.circuit_manager.send(self.channel.clear(),
+                                          extra={'pv': self.name})
             except OSError:
                 # the socket is dead-dead, do nothing
                 ...

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1405,7 +1405,8 @@ class VirtualCircuitManager:
             ioid_info = self.ioids.pop(command.ioid)
             deadline = ioid_info['deadline']
             pv = ioid_info['pv']
-            tags = {'pv': pv.name, **tags}
+            tags = tags.copy()
+            tags['pv'] = pv.name
             if deadline is not None and time.monotonic() > deadline:
                 self.log.warning("Ignoring late response with ioid=%d regarding "
                                  "PV named %s because "
@@ -1438,11 +1439,13 @@ class VirtualCircuitManager:
                 # This method submits jobs to the Contexts's
                 # ThreadPoolExecutor for user callbacks.
                 sub.process(command)
-                tags = {'pv': sub.pv.name, **tags}
+                tags = tags.copy()
+                tags['pv'] = sub.pv.name
         elif isinstance(command, ca.AccessRightsResponse):
             pv = self.pvs[command.cid]
             pv.access_rights_changed(command.access_rights)
-            tags = {'pv': pv.name, **tags}
+            tags = tags.copy()
+            tags['pv'] = pv.name
         elif isinstance(command, ca.EventCancelResponse):
             # TODO Any way to add the pv name to tags here?
             ...
@@ -1454,12 +1457,14 @@ class VirtualCircuitManager:
                 pv.channel = chan
                 pv.channel_ready.set()
             pv.connection_state_changed('connected', chan)
-            tags = {'pv': pv.name, **tags}
+            tags = tags.copy()
+            tags['pv'] = pv.name
         elif isinstance(command, (ca.ServerDisconnResponse,
                                   ca.ClearChannelResponse)):
             pv = self.pvs[command.cid]
             pv.connection_state_changed('disconnected', None)
-            tags = {'pv': pv.name, **tags}
+            tags = tags.copy()
+            tags['pv'] = pv.name
             # NOTE: pv remains valid until server goes down
         elif isinstance(command, ca.EchoResponse):
             # The important effect here is that it will have updated

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1439,7 +1439,7 @@ class VirtualCircuitManager:
                 # This method submits jobs to the Contexts's
                 # ThreadPoolExecutor for user callbacks.
                 sub.process(command)
-            tags = {'pv': pv.name, **tags}
+            tags = {'pv': sub.pv.name, **tags}
         elif isinstance(command, ca.AccessRightsResponse):
             pv = self.pvs[command.cid]
             pv.access_rights_changed(command.access_rights)

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1438,7 +1438,7 @@ class VirtualCircuitManager:
                 # This method submits jobs to the Contexts's
                 # ThreadPoolExecutor for user callbacks.
                 sub.process(command)
-            tags = {'pv': sub.pv.name, **tags}
+                tags = {'pv': sub.pv.name, **tags}
         elif isinstance(command, ca.AccessRightsResponse):
             pv = self.pvs[command.cid]
             pv.access_rights_changed(command.access_rights)

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -219,10 +219,10 @@ class PV:
 
         if isinstance(callback, (tuple, list)):
             for i, thiscb in enumerate(callback):
-                if hasattr(thiscb, '__call__'):
+                if callable(thiscb):
                     self.callbacks[i] = (thiscb, {})
 
-        elif hasattr(callback, '__call__'):
+        elif callable(callback):
             self.callbacks[0] = (callback, {})
 
         self._caproto_pv, = self._context.get_pvs(
@@ -635,7 +635,7 @@ class PV:
         kwd = copy.copy(self._args)
         kwd.update(kwargs)
         kwd['cb_info'] = (index, self)
-        if hasattr(fcn, '__call__'):
+        if callable(fcn):
             fcn(**kwd)
 
     def add_callback(self, callback, *, index=None, run_now=False,

--- a/caproto/trio/client.py
+++ b/caproto/trio/client.py
@@ -287,15 +287,19 @@ class SharedBroadcaster:
         Process a command and tranport it over the UDP socket.
         """
         bytes_to_send = self.broadcaster.send(*commands)
+        tags = {'role': 'CLIENT',
+                'our_address': self.broadcaster.client_address,
+                'direction': '--->>>'}
         for host in ca.get_address_list():
             if ':' in host:
                 host, _, port_as_str = host.partition(':')
                 specified_port = int(port_as_str)
             else:
                 specified_port = port
+            tags['their_address'] = (host, specified_port)
             self.broadcaster.log.debug(
-                'Sending %d bytes to %s:%d',
-                len(bytes_to_send), host, specified_port)
+                '%d commands %dB',
+                len(commands), len(bytes_to_send), extra=tags)
             try:
                 await self.udp_sock.sendto(bytes_to_send,
                                            (host, specified_port))
@@ -384,7 +388,7 @@ class SharedBroadcaster:
                                              accepted_address, new_address)
                     else:
                         address = ca.extract_address(command)
-                        self.log.debug('Found %s at %s', name, address)
+                        self.log.debug('Found %s at %s:%d', name, *address)
                         self.search_results[name] = address
 
                 async with self.broadcaster_command_condition:

--- a/caproto/trio/client.py
+++ b/caproto/trio/client.py
@@ -436,7 +436,7 @@ class SharedBroadcaster:
             else:
                 use_cached_search[address].append(name)
 
-        for addr, names in use_cached_search.items():
+        for names in use_cached_search.values():
             yield (address, names)
 
         use_cached_search.clear()
@@ -466,11 +466,11 @@ class SharedBroadcaster:
                      if search_id not in self.unanswered_searches]
             needs_search = [key for key in needs_search
                             if key not in found]
-            for search_id, name in found:
+            for _search_id, name in found:
                 address, timestamp = self.search_results[name]
                 results[address].append(name)
 
-            for addr, names in results.items():
+            for names in results.values():
                 yield (address, names)
 
     async def wait_on_new_command(self):
@@ -560,7 +560,7 @@ class Context:
                                                                priority=priority)
 
             if wait_for_connection:
-                for name, channel in channels.items():
+                for channel in channels.values():
                     await channel.wait_for_connection()
 
         if move_on_after is not None:

--- a/caproto/trio/server.py
+++ b/caproto/trio/server.py
@@ -271,7 +271,7 @@ class Context(_Context):
                 sock.close()
             for sock in self.udp_socks.values():
                 sock.close()
-            for interface, sock in self.beacon_socks.values():
+            for _interface, sock in self.beacon_socks.values():
                 sock.close()
 
     def stop(self):

--- a/caproto/trio/server.py
+++ b/caproto/trio/server.py
@@ -155,7 +155,7 @@ class Context(_Context):
     async def broadcaster_udp_server_loop(self, task_status):
         for interface in self.interfaces:
             udp_sock = ca.bcast_socket(socket)
-            self.broadcaster._our_addresses.append(udp_sock.getsockname()[:2])
+            self.broadcaster.server_addresses.append(udp_sock.getsockname()[:2])
             try:
                 await udp_sock.bind((interface, self.ca_server_port))
             except Exception:

--- a/doc/source/clients.rst
+++ b/doc/source/clients.rst
@@ -11,7 +11,7 @@ use directly, but should generally not be used to build larger programs. It
 opts for simplicity over performance.
 
 The :doc:`threading-client` is a high-performance client and the one with the
-most features and tesitng behind it. We generally recommend this one.
+most features and testing behind it. We generally recommend this one.
 
 The :doc:`pyepics-compat-client` should only be used if you want to have
 compatibility with some existing pyepics-based code.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -2,7 +2,7 @@
 caproto: a pure-Python Channel Access protocol library
 ******************************************************
 
-Caproto is a implementation of the
+Caproto is an implementation of the
 `EPICS <http://www.aps.anl.gov/epics/>`_ Channel Access protocol for
 distributed hardware control in pure Python with a "sans-I/O" architecture.
 


### PR DESCRIPTION
This PR does a bunch of stuff, most notably.

* Correctly deal with the fact that a UDP socket does not always have one
  address, sometimes broadcasts to many.
* Avoid logging some sent messages at both the circuit level and the channel level,
  which produced redundant output.
* Adds more structured info to the LogRecord (bytesize, and counter for multi-command
  datagrams)
* Fixes some display inconsistencies.
* Generally tightens up the lines based on some working experience trying to
  use this in practice.

There is also a bunch of flake8 cleanup to respect new flake8 rules, most of
which I found constructive and caught at least one minor bug. All of that noise
is contained in one commit.