### PR TITLE
Provide Subscription to user callback.

### DIFF
--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -167,7 +167,7 @@ def test_server_crash(context, ioc_factory):
     # Add a user callback so that the subscription takes effect.
     collector = []
 
-    def collect(item, sub):
+    def collect(sub, item):
         collector.append(item)
     sub.add_callback(collect)
 
@@ -205,7 +205,7 @@ def test_subscriptions(ioc, context):
 
     monitor_values = []
 
-    def callback(command, sub, **kwargs):
+    def callback(sub, command, **kwargs):
         assert isinstance(command, ca.EventAddResponse)
         monitor_values.append(command.data[0])
 
@@ -351,7 +351,7 @@ def test_multiple_subscriptions_one_server(ioc, context):
         pv.wait_for_connection(timeout=10)
     collector = collections.defaultdict(list)
 
-    def collect(response, sub):
+    def collect(sub, response):
         collector[sub].append(response)
 
     subs = [pv.subscribe() for pv in pvs]
@@ -377,7 +377,7 @@ def test_subscription_objects_are_reused(ioc, context):
     # Attach a callback so that these subs are activated and enter the
     # Context's cache.
 
-    def f(item, pv):
+    def f(sub, item):
         ...
 
     sub.add_callback(f)
@@ -396,7 +396,7 @@ def test_unsubscribe_all(ioc, context):
 
     collector = []
 
-    def f(response, sub):
+    def f(sub, response):
         collector.append(response)
 
     sub0.add_callback(f)
@@ -575,7 +575,7 @@ def test_multithreaded_many_write(ioc, context, thread_count,
     pv, = context.get_pvs(ioc.pvs['int'])
     values = []
 
-    def callback(command, sub):
+    def callback(sub, command):
         values.append(command.data.tolist()[0])
 
     sub = pv.subscribe()
@@ -608,7 +608,7 @@ def test_multithreaded_many_subscribe(ioc, context, thread_count,
 
         values[thread_id] = []
 
-        def callback(command, sub):
+        def callback(sub, command):
             print(thread_id, command)
             values[thread_id].append(command.data.tolist()[0])
 
@@ -725,7 +725,7 @@ def test_events_off_and_on(ioc, context):
 
     monitor_values = []
 
-    def callback(command, sub, **kwargs):
+    def callback(sub, command, **kwargs):
         assert isinstance(command, ca.EventAddResponse)
         monitor_values.append(command.data[0])
 

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -2167,7 +2167,7 @@ class Subscription(CallbackHandler):
         # As implemented below, updates are blocking further messages from
         # the CA servers from processing. (-> ThreadPool, etc.)
         pv = self.pv
-        super().process(command, self)
+        super().process(self, command)
         self.log.debug("%r: %r", pv.name, command)
         self.most_recent_response = command
 
@@ -2178,7 +2178,7 @@ class Subscription(CallbackHandler):
         Parameters
         ----------
         func : callable
-            Expected signature: ``func(response, sub)``.
+            Expected signature: ``func(sub, response)``.
             The signature ``func(response)`` is also supported for
             backward-compatibility but will issue warnings. Support will be
             removed in a future release of caproto.
@@ -2190,7 +2190,8 @@ class Subscription(CallbackHandler):
 
         .. versionchanged:: 0.5.0
 
-           Changed the expected signature of ``func`` to add ``sub``.
+           Changed the expected signature of ``func`` from ``func(response)``
+           to ``func(sub, response)``.
         """
         # Handle func with signature func(respons) for back-compat.
         sig = inspect.signature(func)
@@ -2200,13 +2201,13 @@ class Subscription(CallbackHandler):
         except TypeError:
             warnings.warn(
                 "The signature of a subscription callback is now expected to "
-                "be func(response, sub). The signature func(response) is "
+                "be func(sub, response). The signature func(response) is "
                 "supported, but support will be removed in a future release "
                 "of caproto.")
             raw_func = func
             raw_func_weakref = weakref.ref(raw_func)
 
-            def func(response, sub):
+            def func(sub, response):
                 # Avoid closing over raw_func itself here or it will never be
                 # garbage collected.
                 raw_func = raw_func_weakref()
@@ -2243,7 +2244,7 @@ class Subscription(CallbackHandler):
             # for that first response from the server.
             if most_recent_response is not None:
                 try:
-                    func(most_recent_response, self)
+                    func(self, most_recent_response)
                 except Exception:
                     self.log.exception(
                         "Exception raised during processing most recent "

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -2193,7 +2193,11 @@ class Subscription(CallbackHandler):
            Changed the expected signature of ``func`` to add ``pv``.
         """
         # Handle func with signature func(respons) for back-compat.
-        if len(inspect.signature(func).parameters) == 1:
+        sig = inspect.signature(func)
+        try:
+            # Does this function accept two positional arguments?
+            sig.bind(None, None)
+        except TypeError:
             warnings.warn(
                 "The signature of a subscription callback is now expected to "
                 "be func(response, pv). The signature func(response) is "

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -596,7 +596,7 @@ class PV:
             except Exception:
                 ...
 
-    def __on_changes(self, command, sub):
+    def __on_changes(self, sub, command):
         """internal callback function: do not overwrite!!
         To have user-defined code run when the PV value changes,
         use add_callback()

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -596,7 +596,7 @@ class PV:
             except Exception:
                 ...
 
-    def __on_changes(self, command):
+    def __on_changes(self, command, pv):
         """internal callback function: do not overwrite!!
         To have user-defined code run when the PV value changes,
         use add_callback()

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -596,7 +596,7 @@ class PV:
             except Exception:
                 ...
 
-    def __on_changes(self, command, pv):
+    def __on_changes(self, command, sub):
         """internal callback function: do not overwrite!!
         To have user-defined code run when the PV value changes,
         use add_callback()

--- a/doc/source/release-notes.rst
+++ b/doc/source/release-notes.rst
@@ -2,6 +2,29 @@
 Release History
 ***************
 
+Unreleased
+==========
+
+* In the threading client, the expected signature of Subscription callbacks has
+  changed from ``f(response)`` to ``f(sub, response)`` where ``sub`` is the
+  pertinent :class:`caproto.threading.client.Subscription`.
+  This change has been made in a backward-compatible way. Callbacks with the
+  old signature, ``f(response)``, will still work but caproto will issue a
+  warning. Support for the old signature may be removed in the future.
+  By giving the callback ``f`` access to ``sub``, we enable usages like
+
+  .. code-block:: python
+
+     def f(sub, response):
+         # Print the name of the pertinent PV.
+         print('Received response from', sub.pv.name)
+
+     def f(sub, response):
+         if ...:
+             sub.remove_callback(f)
+
+* The detail and formatting of the log messages has been improved.
+
 v0.4.2 (2019-11-13)
 ===================
 

--- a/doc/source/threading-client.rst
+++ b/doc/source/threading-client.rst
@@ -155,13 +155,28 @@ First, we define a :class:`Subscription`.
     sub = x.subscribe()
 
 Next, we define a callback function, a function that will be called whenever
-the server sends an update. It must accept one positional argument.
+the server sends an update. It must accept two positional arguments.
 
 .. ipython:: python
 
     responses = []
-    def f(response):
+    def f(response, pv):
+        print('Received response from', pv.name)
         responses.append(response)
+
+This user-defined function ``f`` has access to the full response from the
+server, which includes data and any metadata. The server's response does not
+include the name of the PV involved (it identifies it indirectly via a
+"subscription ID" code) so caproto provides the function with ``pv`` as well,
+the :class:`PV` object, from which you can obtain the name as shown above.
+
+.. versionchanged:: 0.5.0
+
+   The expected signature of the callback function was changed from
+   ``f(response)`` to ``f(response, pv)``. For backward compatibility,
+   functions with signature ``f(response)`` are still accepted, but caproto
+   will issue a warning that a future release may require the new signature,
+   ``f(response, pv)``.
 
 We register this function with ``sub``.
 
@@ -175,7 +190,7 @@ define a second callback:
 .. ipython:: python
 
     values = []
-    def g(response):
+    def g(response, pv):
         values.append(response.data[0])
 
 and add it to the same subscription, putting no additional load on the network.
@@ -226,7 +241,7 @@ re-initiates updates. All of this is transparent to the user.
 
     .. code-block:: python
 
-        sub.add_callback(lambda response: print(response.data))
+        sub.add_callback(lambda response, pv: print(response.data))
 
     The lambda function will be promptly garbage collected by Python and
     removed from ``sub`` by caproto. To avoid that, make a reference before
@@ -234,7 +249,7 @@ re-initiates updates. All of this is transparent to the user.
     
     .. code-block:: python
 
-        cb = lambda response: print(response.data)
+        cb = lambda response, pv: print(response.data)
         sub.add_callback(cb)
 
     This can be surprising, but it is a standard approach for avoiding the

--- a/doc/source/threading-client.rst
+++ b/doc/source/threading-client.rst
@@ -160,23 +160,25 @@ the server sends an update. It must accept two positional arguments.
 .. ipython:: python
 
     responses = []
-    def f(response, pv):
-        print('Received response from', pv.name)
+    def f(response, sub):
+        print('Received response from', sub.pv.name)
         responses.append(response)
 
 This user-defined function ``f`` has access to the full response from the
 server, which includes data and any metadata. The server's response does not
 include the name of the PV involved (it identifies it indirectly via a
-"subscription ID" code) so caproto provides the function with ``pv`` as well,
-the :class:`PV` object, from which you can obtain the name as shown above.
+"subscription ID" code) so caproto provides the function with ``sub`` as well,
+from which you can obtain the pertinent PV ``sub.pv`` and its name
+``sub.pv.name`` as illustrated above. This is useful for distinguishing
+responses when the same function is added to multiple subscriptions.
 
 .. versionchanged:: 0.5.0
 
    The expected signature of the callback function was changed from
-   ``f(response)`` to ``f(response, pv)``. For backward compatibility,
+   ``f(response)`` to ``f(response, sub)``. For backward compatibility,
    functions with signature ``f(response)`` are still accepted, but caproto
    will issue a warning that a future release may require the new signature,
-   ``f(response, pv)``.
+   ``f(response, sub)``.
 
 We register this function with ``sub``.
 
@@ -190,7 +192,7 @@ define a second callback:
 .. ipython:: python
 
     values = []
-    def g(response, pv):
+    def g(response, sub):
         values.append(response.data[0])
 
 and add it to the same subscription, putting no additional load on the network.
@@ -241,7 +243,7 @@ re-initiates updates. All of this is transparent to the user.
 
     .. code-block:: python
 
-        sub.add_callback(lambda response, pv: print(response.data))
+        sub.add_callback(lambda response, sub: print(response.data))
 
     The lambda function will be promptly garbage collected by Python and
     removed from ``sub`` by caproto. To avoid that, make a reference before
@@ -249,7 +251,7 @@ re-initiates updates. All of this is transparent to the user.
     
     .. code-block:: python
 
-        cb = lambda response, pv: print(response.data)
+        cb = lambda response, sub: print(response.data)
         sub.add_callback(cb)
 
     This can be surprising, but it is a standard approach for avoiding the

--- a/doc/source/threading-client.rst
+++ b/doc/source/threading-client.rst
@@ -160,7 +160,7 @@ the server sends an update. It must accept two positional arguments.
 .. ipython:: python
 
     responses = []
-    def f(response, sub):
+    def f(sub, response):
         print('Received response from', sub.pv.name)
         responses.append(response)
 
@@ -175,10 +175,10 @@ responses when the same function is added to multiple subscriptions.
 .. versionchanged:: 0.5.0
 
    The expected signature of the callback function was changed from
-   ``f(response)`` to ``f(response, sub)``. For backward compatibility,
+   ``f(response)`` to ``f(sub, response)``. For backward compatibility,
    functions with signature ``f(response)`` are still accepted, but caproto
    will issue a warning that a future release may require the new signature,
-   ``f(response, sub)``.
+   ``f(sub, response)``.
 
 We register this function with ``sub``.
 
@@ -192,7 +192,7 @@ define a second callback:
 .. ipython:: python
 
     values = []
-    def g(response, sub):
+    def g(sub, response):
         values.append(response.data[0])
 
 and add it to the same subscription, putting no additional load on the network.
@@ -243,7 +243,7 @@ re-initiates updates. All of this is transparent to the user.
 
     .. code-block:: python
 
-        sub.add_callback(lambda response, sub: print(response.data))
+        sub.add_callback(lambda sub, response: print(response.data))
 
     The lambda function will be promptly garbage collected by Python and
     removed from ``sub`` by caproto. To avoid that, make a reference before
@@ -251,7 +251,7 @@ re-initiates updates. All of this is transparent to the user.
     
     .. code-block:: python
 
-        cb = lambda response, sub: print(response.data)
+        cb = lambda sub, response: print(response.data)
         sub.add_callback(cb)
 
     This can be surprising, but it is a standard approach for avoiding the


### PR DESCRIPTION
In #545, @vstadnytskyi pointed out that it is inconvenient that subscription
updates do not carry information about which PV they pertain to. @tacaswell
suggested that we could change the signature of user callbacks to include the
PV as well as the raw response. Getting even more specific, we can include
the Subscription object `sub`, from which you can access the PV as `sub.pv` and the PV
name as `sub.pv.name`. That is, the callback signature would change from
``f(response)`` to ``f(response, sub)``.

(An alternative proposal, adding the PV name to the response, was rejected
because we have held that Message objects contain nothing more or less
than the information sent over the wire.)

Fortunately, this change can be made in a backward-compatible way. When a
user callback is first registered

```py
sub.add_callback(f)
```

we can inspect the signature of ``f`` *once* to determine if it would accept
only one argument. If so, we wrap ``f`` in a function that drops
the new ``sub`` argument and passes only ``response`` through to ``f`` and
subscribe that wrapper function instead. We also issue a warning.

This has not been tested locally, may need more work.