### PR TITLE
Direct fix for #514

### DIFF
--- a/caproto/asyncio/server.py
+++ b/caproto/asyncio/server.py
@@ -240,14 +240,14 @@ class Context(_Context):
         for address in ca.get_beacon_address_list():
             transport, _ = await self.loop.create_datagram_endpoint(
                 BcastLoop, remote_addr=address, allow_broadcast=True,
-                reuse_address=True, reuse_port=reuse_port)
+                reuse_port=reuse_port)
             wrapped_transport = ConnectedTransportWrapper(transport, address)
             self.beacon_socks[address] = (interface, wrapped_transport)
 
         for interface in self.interfaces:
             transport, self.p = await self.loop.create_datagram_endpoint(
                 BcastLoop, local_addr=(interface, self.ca_server_port),
-                allow_broadcast=True, reuse_address=True,
+                allow_broadcast=True,
                 reuse_port=reuse_port)
             self.udp_socks[interface] = TransportWrapper(transport)
             self.log.debug('UDP socket bound on %s:%d', interface,

--- a/caproto/curio/client.py
+++ b/caproto/curio/client.py
@@ -12,6 +12,7 @@ import getpass
 import logging
 
 import caproto as ca
+from caproto._utils import safe_getsockname
 import curio
 
 from collections import OrderedDict
@@ -237,7 +238,7 @@ class SharedBroadcaster:
 
         # UDP socket broadcasting to CA servers
         self.udp_sock = ca.bcast_socket(socket)
-        self.broadcaster.our_address = self.udp_sock.getsockname()[:2]
+        self.broadcaster.our_address = safe_getsockname(self.udp_sock)[:2]
         self.registered = False  # refers to RepeaterRegisterRequest
         self.loop_ready_event = curio.Event()
         self.unanswered_searches = {}  # map search id (cid) to name

--- a/caproto/curio/client.py
+++ b/caproto/curio/client.py
@@ -41,7 +41,7 @@ class VirtualCircuit:
     async def connect(self):
         async with self._socket_lock:
             self.socket = await socket.create_connection(self.circuit.address)
-            self.circuit.our_address = self.socket.getsockname()[:2]
+            self.circuit.our_address = self.socket.getsockname()
             # Kick off background loops that read from the socket
             # and process the commands read from it.
             await curio.spawn(self._receive_loop, daemon=True)
@@ -238,7 +238,7 @@ class SharedBroadcaster:
 
         # UDP socket broadcasting to CA servers
         self.udp_sock = ca.bcast_socket(socket)
-        self.broadcaster.our_address = safe_getsockname(self.udp_sock)[:2]
+        self.broadcaster.our_address = safe_getsockname(self.udp_sock)
         self.registered = False  # refers to RepeaterRegisterRequest
         self.loop_ready_event = curio.Event()
         self.unanswered_searches = {}  # map search id (cid) to name

--- a/caproto/curio/server.py
+++ b/caproto/curio/server.py
@@ -119,7 +119,7 @@ class Context(_Context):
     async def broadcaster_udp_server_loop(self):
         for interface in self.interfaces:
             udp_sock = ca.bcast_socket(socket)
-            self.broadcaster.server_addresses.append(udp_sock.getsockname()[:2])
+            self.broadcaster.server_addresses.append(udp_sock.getsockname())
             try:
                 udp_sock.bind((interface, self.ca_server_port))
             except Exception:

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -52,7 +52,7 @@ class VirtualCircuit:
     def __init__(self, circuit, client, context):
         self.connected = True
         self.circuit = circuit  # a caproto.VirtualCircuit
-        self.circuit.our_address = client.getsockname()[:2]
+        self.circuit.our_address = client.getsockname()
         self.log = circuit.log
         self.client = client
         self.context = context

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -52,7 +52,7 @@ def recv(circuit):
 def search(pv_name, udp_sock, timeout, *, max_retries=2):
     # Set Broadcaster log level to match our logger.
     b = ca.Broadcaster(our_role=ca.CLIENT)
-    b.client_address = safe_getsockname(udp_sock)[:2]
+    b.client_address = safe_getsockname(udp_sock)
 
     # Send registration request to the repeater
     logger.debug('Registering with the Channel Access repeater.')
@@ -157,7 +157,7 @@ def make_channel(pv_name, udp_sock, priority, timeout):
         new = True
         sockets[chan.circuit] = socket.create_connection(chan.circuit.address,
                                                          timeout)
-        circuit.our_address = sockets[chan.circuit].getsockname()[:2]
+        circuit.our_address = sockets[chan.circuit].getsockname()
     try:
         if new:
             # Initialize our new TCP-based CA connection with a VersionRequest.

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -14,7 +14,7 @@ import weakref
 import caproto as ca
 from .._dbr import (field_types, ChannelType, native_type, SubscriptionType)
 from .._utils import (ErrorResponseReceived, CaprotoError, CaprotoTimeoutError,
-                      get_environment_variables)
+                      get_environment_variables, safe_getsockname)
 from .repeater import spawn_repeater
 
 
@@ -52,7 +52,7 @@ def recv(circuit):
 def search(pv_name, udp_sock, timeout, *, max_retries=2):
     # Set Broadcaster log level to match our logger.
     b = ca.Broadcaster(our_role=ca.CLIENT)
-    b.client_address = udp_sock.getsockname()[:2]
+    b.client_address = safe_getsockname(udp_sock)[:2]
 
     # Send registration request to the repeater
     logger.debug('Registering with the Channel Access repeater.')

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -256,7 +256,7 @@ def test_deprecated_callback_signature(ioc, context):
     sub.clear()
     pv.write((4, ), wait=True)  # This update should not be received by us.
 
-    for i in range(3):
+    for _ in range(3):
         if pv.read().data[0] == 3:
             time.sleep(0.2)
             break
@@ -293,7 +293,7 @@ def test_another_deprecated_callback_signature(ioc, context):
     sub.clear()
     pv.write((4, ), wait=True)  # This update should not be received by us.
 
-    for i in range(3):
+    for _ in range(3):
         if pv.read().data[0] == 3:
             time.sleep(0.2)
             break

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -35,7 +35,7 @@ from .._constants import (MAX_ID, STALE_SEARCH_EXPIRATION,
 from .._utils import (batch_requests, CaprotoError, ThreadsafeCounter,
                       socket_bytes_available, CaprotoTimeoutError,
                       CaprotoTypeError, CaprotoRuntimeError, CaprotoValueError,
-                      CaprotoKeyError, CaprotoNetworkError)
+                      CaprotoKeyError, CaprotoNetworkError, safe_getsockname)
 
 
 ch_logger = logging.getLogger('caproto.ch')
@@ -340,7 +340,7 @@ class SharedBroadcaster:
         self.listeners = weakref.WeakSet()
 
         self.broadcaster = ca.Broadcaster(our_role=ca.CLIENT)
-        self.broadcaster.client_address = self.udp_sock.getsockname()[:2]
+        self.broadcaster.client_address = safe_getsockname(self.udp_sock)[:2]
         self.log = logging.LoggerAdapter(
             self.broadcaster.log, {'role': 'CLIENT'})
         self.search_log = logging.LoggerAdapter(

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -340,7 +340,7 @@ class SharedBroadcaster:
         self.listeners = weakref.WeakSet()
 
         self.broadcaster = ca.Broadcaster(our_role=ca.CLIENT)
-        self.broadcaster.client_address = safe_getsockname(self.udp_sock)[:2]
+        self.broadcaster.client_address = safe_getsockname(self.udp_sock)
         self.log = logging.LoggerAdapter(
             self.broadcaster.log, {'role': 'CLIENT'})
         self.search_log = logging.LoggerAdapter(
@@ -1295,7 +1295,7 @@ class VirtualCircuitManager:
             self.socket = socket.create_connection(self.circuit.address)
             self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
             self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-            self.circuit.our_address = self.socket.getsockname()[:2]
+            self.circuit.our_address = self.socket.getsockname()
             # This dict is passed to the loggers.
             self._tags = {'their_address': self.circuit.address,
                           'our_address': self.circuit.our_address,

--- a/caproto/trio/client.py
+++ b/caproto/trio/client.py
@@ -67,7 +67,7 @@ class VirtualCircuit:
         async with self._socket_lock:
             # This is a trio.SocketStream.
             self.socket = await trio.open_tcp_stream(*self.circuit.address)
-            self.circuit.our_address = self.socket.socket.getsockname()[:2]
+            self.circuit.our_address = self.socket.socket.getsockname()
         # Kick off background loops that read from the socket
         # and process the commands read from it.
         self.nursery.start_soon(self._receive_loop)
@@ -327,7 +327,7 @@ class SharedBroadcaster:
 
     async def _broadcaster_recv_loop(self, task_status):
         self.udp_sock = ca.bcast_socket(socket_module=socket)
-        self.broadcaster.our_address = safe_getsockname(self.udp_sock)[:2]
+        self.broadcaster.our_address = safe_getsockname(self.udp_sock)
         command = self.broadcaster.register('127.0.0.1')
         await self.send(ca.EPICS_CA2_PORT, command)
         task_status.started()

--- a/caproto/trio/client.py
+++ b/caproto/trio/client.py
@@ -18,7 +18,7 @@ import trio
 from collections import OrderedDict, defaultdict
 from trio import socket
 from .._utils import (batch_requests, CaprotoError, ThreadsafeCounter,
-                      get_environment_variables)
+                      get_environment_variables, safe_getsockname)
 from .._constants import (STALE_SEARCH_EXPIRATION, SEARCH_MAX_DATAGRAM_BYTES)
 
 from .util import open_memory_channel
@@ -327,7 +327,7 @@ class SharedBroadcaster:
 
     async def _broadcaster_recv_loop(self, task_status):
         self.udp_sock = ca.bcast_socket(socket_module=socket)
-        self.broadcaster.our_address = self.udp_sock.getsockname()[:2]
+        self.broadcaster.our_address = safe_getsockname(self.udp_sock)[:2]
         command = self.broadcaster.register('127.0.0.1')
         await self.send(ca.EPICS_CA2_PORT, command)
         task_status.started()

--- a/caproto/trio/server.py
+++ b/caproto/trio/server.py
@@ -157,7 +157,7 @@ class Context(_Context):
         for interface in self.interfaces:
             udp_sock = ca.bcast_socket(socket)
             self.broadcaster.server_addresses.append(
-                safe_getsockname(udp_sock)[:2])
+                safe_getsockname(udp_sock))
             try:
                 await udp_sock.bind((interface, self.ca_server_port))
             except Exception:

--- a/caproto/trio/server.py
+++ b/caproto/trio/server.py
@@ -9,6 +9,7 @@ from ..server.common import (VirtualCircuit as _VirtualCircuit,
                              Context as _Context, LoopExit,
                              DisconnectedCircuit)
 from .util import open_memory_channel
+from .._utils import safe_getsockname
 
 
 class ServerExit(Exception):
@@ -155,7 +156,8 @@ class Context(_Context):
     async def broadcaster_udp_server_loop(self, task_status):
         for interface in self.interfaces:
             udp_sock = ca.bcast_socket(socket)
-            self.broadcaster.server_addresses.append(udp_sock.getsockname()[:2])
+            self.broadcaster.server_addresses.append(
+                safe_getsockname(udp_sock)[:2])
             try:
                 await udp_sock.bind((interface, self.ca_server_port))
             except Exception:
@@ -218,7 +220,7 @@ class Context(_Context):
                 for address in ca.get_beacon_address_list():
                     sock = ca.bcast_socket(socket)
                     await sock.connect(address)
-                    interface, _ = sock.getsockname()
+                    interface, _ = safe_getsockname(sock)
                     self.beacon_socks[address] = (interface, sock)
 
                 async def make_socket(interface, port):


### PR DESCRIPTION
Our discussion around how to fix #514 has led to some clarity but also some open questions. I think it's fair to say that no one involved in the discussion so far is feeling confident that we understand the implications deeply enough to prescribe the single correct way forward. Rather than picking one, I suggest we apply this targeted workaround to the specific issue that broke caproto on Windows in v0.4.0. The discussion can continue, perhaps pulling in new expertise, and we can go from there, hopefully eventually retiring this workaround.

If there are no strong objections, I would like to merge this and release a working 0.4.x release this week.