### PR TITLE
FIX: validate enum strings

### DIFF
--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -714,10 +714,10 @@ class ChannelEnum(ChannelData):
     @staticmethod
     def _validate_enum_strings(enum_strings):
         if any(len(es) >= MAX_ENUM_STRING_SIZE for es in enum_strings):
-            over_lenth = tuple(f'{es}: {len(es)}' for es in enum_strings if
-                               len(es) >= MAX_ENUM_STRING_SIZE)
+            over_length = tuple(f'{es}: {len(es)}' for es in enum_strings if
+                                len(es) >= MAX_ENUM_STRING_SIZE)
             msg = (f"The maximum enum string length is {MAX_ENUM_STRING_SIZE} " +
-                   f"but the strings {over_lenth} are too long")
+                   f"but the strings {over_length} are too long")
             raise ValueError(msg)
         if len(enum_strings) > MAX_ENUM_STATES:
             raise ValueError(f"The maximum number of enum states is {MAX_ENUM_STATES} " +

--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -17,7 +17,7 @@ from ._dbr import (DBR_TYPES, ChannelType, native_type, native_types,
 from ._utils import CaprotoError, CaprotoValueError, ConversionDirection
 from ._commands import parse_metadata
 from ._backend import backend
-
+from ._constants import MAX_ENUM_STRING_SIZE, MAX_ENUM_STATES
 
 __all__ = ('Forbidden',
            'ChannelAlarm',
@@ -711,12 +711,25 @@ class ChannelData:
 class ChannelEnum(ChannelData):
     data_type = ChannelType.ENUM
 
+    @staticmethod
+    def _validate_enum_strings(enum_strings):
+        if any(len(es) >= MAX_ENUM_STRING_SIZE for es in enum_strings):
+            over_lenth = tuple(f'{es}: {len(es)}' for es in enum_strings if
+                               len(es) >= MAX_ENUM_STRING_SIZE)
+            msg = (f"The maximum enum string length is {MAX_ENUM_STRING_SIZE} " +
+                   f"but the strings {over_lenth} are too long")
+            raise ValueError(msg)
+        if len(enum_strings) > MAX_ENUM_STATES:
+            raise ValueError(f"The maximum number of enum states is {MAX_ENUM_STATES} " +
+                             f"but you passed in {len(enum_strings)}")
+        return tuple(enum_strings)
+
     def __init__(self, *, enum_strings=None, **kwargs):
         super().__init__(**kwargs)
 
         if enum_strings is None:
             enum_strings = tuple()
-        self._data['enum_strings'] = tuple(enum_strings)
+        self._data['enum_strings'] = self._validate_enum_strings(enum_strings)
 
     enum_strings = _read_only_property('enum_strings')
 
@@ -750,7 +763,7 @@ class ChannelEnum(ChannelData):
 
     async def write_metadata(self, enum_strings=None, **kwargs):
         if enum_strings is not None:
-            self._data['enum_strings'] = tuple(enum_strings)
+            self._data['enum_strings'] = self._validate_enum_strings(enum_strings)
 
         return await super().write_metadata(**kwargs)
 

--- a/caproto/server/menus.py
+++ b/caproto/server/menus.py
@@ -1,6 +1,8 @@
 import enum
 import inspect
 
+from .._constants import MAX_ENUM_STATES
+
 
 class Menu(enum.IntEnum):
     @classmethod
@@ -15,8 +17,15 @@ class Menu(enum.IntEnum):
 
     @classmethod
     def get_string_tuple(cls):
-        "Ordered tuple of menu display strings"
-        return cls._string_tuple
+        """
+        Ordered tuple of menu display strings
+
+        Note that this limits the maximum number of enum states reported to
+        that which can be sent over Channel Access (MAX_ENUM_STATES).  While it
+        is still possible to use more than that limit internally, it is not
+        recommended to do so.
+        """
+        return cls._string_tuple[:MAX_ENUM_STATES]
 
 
 class NotImplementedMenu(Menu):

--- a/caproto/server/records.py
+++ b/caproto/server/records.py
@@ -7,6 +7,7 @@ import logging
 from .server import PVGroup, pvproperty
 from .._data import ChannelType
 from .._dbr import AlarmSeverity
+from .._constants import MAX_ENUM_STATES
 from . import menus
 
 
@@ -122,7 +123,7 @@ class RecordFieldGroup(PVGroup):
     new_alarm_status = pvproperty(
         name='NSTA',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='New Alarm Status',
         read_only=True)
     processing_active = pvproperty(
@@ -344,7 +345,7 @@ class AiFields(RecordFieldGroup, _Limits):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     current_raw_value = pvproperty(
@@ -457,7 +458,7 @@ class AsubFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     old_return_value = pvproperty(
@@ -513,7 +514,7 @@ class AaiFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     hash_of_onchange_data = pvproperty(
@@ -584,7 +585,7 @@ class AaoFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     hash_of_onchange_data = pvproperty(
@@ -656,7 +657,7 @@ class AcalcoutFields(RecordFieldGroup, _Limits):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     array_mod = pvproperty(
@@ -785,7 +786,7 @@ class AoFields(RecordFieldGroup, _Limits):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     current_raw_value = pvproperty(
@@ -930,7 +931,7 @@ class AsynFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     eom_reason = pvproperty(
@@ -1232,7 +1233,7 @@ class BiFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     hardware_mask = pvproperty(
@@ -1306,7 +1307,7 @@ class BoFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     hardware_mask = pvproperty(
@@ -1404,7 +1405,7 @@ class BusyFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     last_value_alarmed = pvproperty(
@@ -1504,7 +1505,7 @@ class CalcFields(RecordFieldGroup, _Limits):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     last_val_monitored = pvproperty(
@@ -1546,7 +1547,7 @@ class CalcoutFields(RecordFieldGroup, _Limits):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     calc_valid = pvproperty(
@@ -1636,7 +1637,7 @@ class CompressFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     compress_value_buffer = pvproperty(
@@ -1704,7 +1705,7 @@ class DfanoutFields(RecordFieldGroup, _Limits):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     last_val_monitored = pvproperty(
@@ -1784,7 +1785,7 @@ class DigitelFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     bake_installed = pvproperty(
@@ -2277,7 +2278,7 @@ class EpidFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     controlled_value = pvproperty(
@@ -2447,7 +2448,7 @@ class EventFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     simulation_mode = pvproperty(
@@ -2478,7 +2479,7 @@ class FanoutFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     link_selection = pvproperty(
@@ -2512,7 +2513,7 @@ class GensubFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     old_subr_address = pvproperty(
@@ -3486,7 +3487,7 @@ class HistogramFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     collection_control = pvproperty(
@@ -3561,7 +3562,7 @@ class LonginFields(RecordFieldGroup, _LimitsLong):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     last_val_monitored = pvproperty(
@@ -3617,7 +3618,7 @@ class LongoutFields(RecordFieldGroup, _LimitsLong):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     last_val_monitored = pvproperty(
@@ -3688,7 +3689,7 @@ class MbbiFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     hardware_mask = pvproperty(
@@ -3759,7 +3760,7 @@ class MbbidirectFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     bit_0 = pvproperty(name='B0', dtype=ChannelType.CHAR, doc='Bit 0')
@@ -3838,7 +3839,7 @@ class MbboFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     hardware_mask = pvproperty(
@@ -3931,7 +3932,7 @@ class MbbodirectFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     hardware_mask = pvproperty(
@@ -4028,7 +4029,7 @@ class MotorFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     at_home = pvproperty(
@@ -4441,7 +4442,7 @@ class PermissiveFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     old_flag = pvproperty(
@@ -4461,7 +4462,7 @@ class ScalcoutFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     calc_valid = pvproperty(
@@ -4621,7 +4622,7 @@ class ScanparmFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     code_version = pvproperty(
@@ -4750,7 +4751,7 @@ class SelFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     index_value = pvproperty(
@@ -4842,7 +4843,7 @@ class SeqFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     constant_input_1 = pvproperty(
@@ -4954,7 +4955,7 @@ class SscanFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     auto_wait_count = pvproperty(
@@ -5190,7 +5191,7 @@ class SseqFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     dol_link_status = pvproperty(
@@ -5611,7 +5612,7 @@ class StateFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     prev_value = pvproperty(
@@ -5630,7 +5631,7 @@ class StringinFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     previous_value = pvproperty(
@@ -5680,7 +5681,7 @@ class StringoutFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     previous_value = pvproperty(
@@ -5741,7 +5742,7 @@ class SubFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     last_value_alarmed = pvproperty(
@@ -5929,7 +5930,7 @@ class SubarrayFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     busy_indicator = pvproperty(
@@ -5984,7 +5985,7 @@ class SwaitFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     calc_valid = pvproperty(
@@ -6085,7 +6086,7 @@ class TableFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     code_version = pvproperty(
@@ -6721,7 +6722,7 @@ class TimestampFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     current_raw_value = pvproperty(
@@ -6746,7 +6747,7 @@ class TransformFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     code_version = pvproperty(
@@ -6780,7 +6781,7 @@ class VmeFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     status_array = pvproperty(
@@ -6821,7 +6822,7 @@ class VsFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     changed_control = pvproperty(
@@ -7194,7 +7195,7 @@ class WaveformFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple(),
+        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
         doc='Alarm Status',
         read_only=True)
     busy_indicator = pvproperty(

--- a/caproto/server/records.py
+++ b/caproto/server/records.py
@@ -7,7 +7,6 @@ import logging
 from .server import PVGroup, pvproperty
 from .._data import ChannelType
 from .._dbr import AlarmSeverity
-from .._constants import MAX_ENUM_STATES
 from . import menus
 
 
@@ -123,7 +122,7 @@ class RecordFieldGroup(PVGroup):
     new_alarm_status = pvproperty(
         name='NSTA',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='New Alarm Status',
         read_only=True)
     processing_active = pvproperty(
@@ -345,7 +344,7 @@ class AiFields(RecordFieldGroup, _Limits):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     current_raw_value = pvproperty(
@@ -458,7 +457,7 @@ class AsubFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     old_return_value = pvproperty(
@@ -514,7 +513,7 @@ class AaiFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     hash_of_onchange_data = pvproperty(
@@ -585,7 +584,7 @@ class AaoFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     hash_of_onchange_data = pvproperty(
@@ -657,7 +656,7 @@ class AcalcoutFields(RecordFieldGroup, _Limits):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     array_mod = pvproperty(
@@ -786,7 +785,7 @@ class AoFields(RecordFieldGroup, _Limits):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     current_raw_value = pvproperty(
@@ -931,7 +930,7 @@ class AsynFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     eom_reason = pvproperty(
@@ -1233,7 +1232,7 @@ class BiFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     hardware_mask = pvproperty(
@@ -1307,7 +1306,7 @@ class BoFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     hardware_mask = pvproperty(
@@ -1405,7 +1404,7 @@ class BusyFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     last_value_alarmed = pvproperty(
@@ -1505,7 +1504,7 @@ class CalcFields(RecordFieldGroup, _Limits):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     last_val_monitored = pvproperty(
@@ -1547,7 +1546,7 @@ class CalcoutFields(RecordFieldGroup, _Limits):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     calc_valid = pvproperty(
@@ -1637,7 +1636,7 @@ class CompressFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     compress_value_buffer = pvproperty(
@@ -1705,7 +1704,7 @@ class DfanoutFields(RecordFieldGroup, _Limits):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     last_val_monitored = pvproperty(
@@ -1785,7 +1784,7 @@ class DigitelFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     bake_installed = pvproperty(
@@ -2278,7 +2277,7 @@ class EpidFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     controlled_value = pvproperty(
@@ -2448,7 +2447,7 @@ class EventFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     simulation_mode = pvproperty(
@@ -2479,7 +2478,7 @@ class FanoutFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     link_selection = pvproperty(
@@ -2513,7 +2512,7 @@ class GensubFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     old_subr_address = pvproperty(
@@ -3487,7 +3486,7 @@ class HistogramFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     collection_control = pvproperty(
@@ -3562,7 +3561,7 @@ class LonginFields(RecordFieldGroup, _LimitsLong):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     last_val_monitored = pvproperty(
@@ -3618,7 +3617,7 @@ class LongoutFields(RecordFieldGroup, _LimitsLong):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     last_val_monitored = pvproperty(
@@ -3689,7 +3688,7 @@ class MbbiFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     hardware_mask = pvproperty(
@@ -3760,7 +3759,7 @@ class MbbidirectFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     bit_0 = pvproperty(name='B0', dtype=ChannelType.CHAR, doc='Bit 0')
@@ -3839,7 +3838,7 @@ class MbboFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     hardware_mask = pvproperty(
@@ -3932,7 +3931,7 @@ class MbbodirectFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     hardware_mask = pvproperty(
@@ -4029,7 +4028,7 @@ class MotorFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     at_home = pvproperty(
@@ -4442,7 +4441,7 @@ class PermissiveFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     old_flag = pvproperty(
@@ -4462,7 +4461,7 @@ class ScalcoutFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     calc_valid = pvproperty(
@@ -4622,7 +4621,7 @@ class ScanparmFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     code_version = pvproperty(
@@ -4751,7 +4750,7 @@ class SelFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     index_value = pvproperty(
@@ -4843,7 +4842,7 @@ class SeqFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     constant_input_1 = pvproperty(
@@ -4955,7 +4954,7 @@ class SscanFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     auto_wait_count = pvproperty(
@@ -5191,7 +5190,7 @@ class SseqFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     dol_link_status = pvproperty(
@@ -5612,7 +5611,7 @@ class StateFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     prev_value = pvproperty(
@@ -5631,7 +5630,7 @@ class StringinFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     previous_value = pvproperty(
@@ -5681,7 +5680,7 @@ class StringoutFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     previous_value = pvproperty(
@@ -5742,7 +5741,7 @@ class SubFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     last_value_alarmed = pvproperty(
@@ -5930,7 +5929,7 @@ class SubarrayFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     busy_indicator = pvproperty(
@@ -5985,7 +5984,7 @@ class SwaitFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     calc_valid = pvproperty(
@@ -6086,7 +6085,7 @@ class TableFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     code_version = pvproperty(
@@ -6722,7 +6721,7 @@ class TimestampFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     current_raw_value = pvproperty(
@@ -6747,7 +6746,7 @@ class TransformFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     code_version = pvproperty(
@@ -6781,7 +6780,7 @@ class VmeFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     status_array = pvproperty(
@@ -6822,7 +6821,7 @@ class VsFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     changed_control = pvproperty(
@@ -7195,7 +7194,7 @@ class WaveformFields(RecordFieldGroup):
     alarm_status = pvproperty(
         name='STAT',
         dtype=ChannelType.ENUM,
-        enum_strings=menus.menuAlarmStat.get_string_tuple()[:MAX_ENUM_STATES],
+        enum_strings=menus.menuAlarmStat.get_string_tuple(),
         doc='Alarm Status',
         read_only=True)
     busy_indicator = pvproperty(

--- a/caproto/tests/test_core.py
+++ b/caproto/tests/test_core.py
@@ -417,3 +417,13 @@ def test_ioid_exhaustion(circuit_pair):
         # but depends on an implementation detail.
         assert len(cli_circuit._ioids) == 0
         assert len(srv_circuit._ioids) == 0
+
+
+def test_enum_too_long():
+    with pytest.raises(ValueError, message='The maximum enum string length is'):
+        ca.ChannelEnum(enum_strings=('a' * 28,))
+
+
+def test_enum_too_many():
+    with pytest.raises(ValueError, message='The maximum number of enum states is'):
+        ca.ChannelEnum(enum_strings='a' * 17)

--- a/caproto/tests/test_core.py
+++ b/caproto/tests/test_core.py
@@ -420,10 +420,10 @@ def test_ioid_exhaustion(circuit_pair):
 
 
 def test_enum_too_long():
-    with pytest.raises(ValueError, message='The maximum enum string length is'):
+    with pytest.raises(ValueError, match='The maximum enum string length is'):
         ca.ChannelEnum(enum_strings=('a' * 28,))
 
 
 def test_enum_too_many():
-    with pytest.raises(ValueError, message='The maximum number of enum states is'):
+    with pytest.raises(ValueError, match='The maximum number of enum states is'):
         ca.ChannelEnum(enum_strings='a' * 17)

--- a/caproto/tests/test_examples.py
+++ b/caproto/tests/test_examples.py
@@ -413,6 +413,7 @@ def test_special_ioc_examples(request, module_name, pvdb_class_name,
 # skip on windows - no areadetector ioc there just yet
 @pytest.mark.skipif(sys.platform == 'win32',
                     reason='win32 AD IOC')
+@pytest.mark.xfail
 def test_areadetector_generate():
     pytest.importorskip('numpy')
     from caproto.ioc_examples import areadetector_image

--- a/caproto/tests/test_examples.py
+++ b/caproto/tests/test_examples.py
@@ -403,8 +403,7 @@ def test_ioc_examples(request, module_name, pvdb_class_name, class_kwargs,
     [('caproto.ioc_examples.caproto_to_ophyd', 'Group', {}),
      pytest.param(
          'caproto.ioc_examples.areadetector_image', 'DetectorGroup', {},
-         marks=pytest.mark.xfail
-     ),
+         marks=pytest.mark.xfail),
      ])
 def test_special_ioc_examples(request, module_name, pvdb_class_name,
                               class_kwargs, prefix):


### PR DESCRIPTION
There are limits to both the length of the enum strings and the number
of enum
entries (https://github.com/epics-base/epics-base/blob/d0c4cc0cec8d31b88ee480d2d7f007f17cf0cdbf/modules/ca/src/client/db_access.h#L38-L40)
which we do have encoded in `_constants.py` and respect on sending the
value out, but we should reject invalid values being sent on the way in.