### PR TITLE
Check if data is of type str

### DIFF
--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -548,7 +548,9 @@ def _write(chan, data, metadata, timeout, data_type, notify):
         stringy_data = False
         if isinstance(data, (str, bytes)):
             stringy_data = True
-        if hasattr(data, '__getitem__') and isinstance(data[0], (str, bytes)):
+        if hasattr(data, '__getitem__') \
+                and len(data) > 0 \
+                and isinstance(data[0], (str, bytes)):
             stringy_data = True
 
         if stringy_data:

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -542,10 +542,16 @@ def _write(chan, data, metadata, timeout, data_type, notify):
     logger.debug("Detected native data_type %r.", chan.native_data_type)
     # abundance of caution
     ntype = field_types['native'][chan.native_data_type]
-    if data_type is None:
-        # Handle ENUM: If data is INT, carry on. If data is STRING,
-        # write it specifically as STRING data_Type.
-        if (ntype is ChannelType.ENUM) and isinstance(data, str):
+    if (data_type is None) and (ntype is ChannelType.ENUM):
+        # Change data_type to STRING if data contains string-like data, or
+        # iterable of string-like data
+        stringy_data = False
+        if isinstance(data, (str, bytes)):
+            stringy_data = True
+        if hasattr(data, '__getitem__') and isinstance(data[0], (str, bytes)):
+            stringy_data = True
+
+        if stringy_data:
             logger.debug("Will write to ENUM as data_type STRING.")
             data_type = ChannelType.STRING
     logger.debug("Writing.")
@@ -597,7 +603,7 @@ def write(pv_name, data, *, notify=False, data_type=None, metadata=None,
     ----------
     pv_name : str
         The PV name to write to
-    data : str, int, or float or any Iterable of these
+    data : str, bytes, int, or float or any Iterable of these
         Value(s) to write.
     notify : boolean, optional
         Request notification of completion and wait for it. False by default.
@@ -680,7 +686,7 @@ def read_write_read(pv_name, data, *, notify=False,
     ----------
     pv_name : str
         The PV name to write/read/write
-    data : str, int, or float or a list of these
+    data : str, bytes, int, or float or any Iterable of these
         Value to write.
     notify : boolean, optional
         Request notification of completion and wait for it. False by default.

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -545,7 +545,7 @@ def _write(chan, data, metadata, timeout, data_type, notify):
     if data_type is None:
         # Handle ENUM: If data is INT, carry on. If data is STRING,
         # write it specifically as STRING data_Type.
-        if (ntype is ChannelType.ENUM) and isinstance(data[0], bytes):
+        if (ntype is ChannelType.ENUM) and isinstance(data, str):
             logger.debug("Will write to ENUM as data_type STRING.")
             data_type = ChannelType.STRING
     logger.debug("Writing.")

--- a/caproto/tests/conftest.py
+++ b/caproto/tests/conftest.py
@@ -172,7 +172,7 @@ def _epics_base_ioc(prefix, request):
             dict(FTVL='LONG', NELM=4000),
         ('{}float'.format(prefix), 'ai'): dict(VAL=3.14),
         ('{}enum'.format(prefix), 'bi'):
-            dict(VAL=1, ZNAM="zero", ONAM="one"),
+            dict(VAL=1, ZNAM="a", ONAM="b"),
         ('{}str'.format(prefix), 'stringout'): dict(VAL='test'),
         ('{}int'.format(prefix), 'longout'): dict(VAL=1),
         ('{}int2'.format(prefix), 'longout'): dict(VAL=1),

--- a/caproto/tests/test_cli_scripts.py
+++ b/caproto/tests/test_cli_scripts.py
@@ -95,6 +95,10 @@ fmt3 = '{response.data}'
                           ('caproto-get', ('float', '--format', fmt1)),
                           ('caproto-get', ('float', '--format', fmt2)),
                           ('caproto-get', ('float', '--format', fmt3)),
+                          ('caproto-put', ('enum', '0')),
+                          ('caproto-put', ('enum', '1')),
+                          ('caproto-put', ('enum', 'a')),
+                          ('caproto-put', ('enum', 'b')),
                           ('caproto-get', ('enum',)),
                           ('caproto-get', ('enum', '-n')),
                           ('caproto-get', ('float', '-n')),  # no effect


### PR DESCRIPTION
Closes #564.

In Python3, checking if a variable `isinstance` of `str` should be sufficient to determine stringyness.

The previous condition prevented enum type PVs from being set.