### PR TITLE
Pin curio down to <1.0.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 codecov
 coverage
-curio
+curio <1.0
 dpkt
 flake8
 netifaces


### PR DESCRIPTION
It looks like a recent curio release broke us.

Pin it down until we have the resources to investigate.