### PR TITLE
MNT: tweak pytest, fix import deprecation

### DIFF
--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -1,4 +1,5 @@
-from collections import defaultdict, deque, namedtuple, ChainMap, Iterable
+from collections import defaultdict, deque, namedtuple, ChainMap
+from collections.abc import Iterable
 import copy
 import logging
 import sys

--- a/caproto/tests/_asv_shim.py
+++ b/caproto/tests/_asv_shim.py
@@ -227,7 +227,7 @@ def find_asv_root(path, *, asv_conf_filename='asv.conf.json',
     return find_asv_root(parent)
 
 
-@pytest.mark.hookwrapper(trylast=True)
+@pytest.hookimpl(trylast=True, hookwrapper=True)
 def pytest_benchmark_update_json(config, benchmarks, output_json):
     yield
 


### PR DESCRIPTION
Newer versions of pytest are strict about unregistered marks.