### PR TITLE
FIX: Long string modifier ('PV$') for STRING/CHAR dtypes

### DIFF
--- a/caproto/_backend.py
+++ b/caproto/_backend.py
@@ -259,6 +259,8 @@ def _preprocess_string_to_wire(values, to_dtype, string_encoding,
                                        string_encoding=string_encoding,
                                        enum_strings=enum_strings)
     elif to_dtype in native_int_types:
+        if values and isinstance(values[0], str):
+            return list(''.join(values).encode(string_encoding))
         return [int(v) for v in values]
     elif to_dtype in native_float_types:
         return [float(v) for v in values]

--- a/caproto/_backend.py
+++ b/caproto/_backend.py
@@ -5,7 +5,7 @@ import collections
 import logging
 from types import SimpleNamespace
 
-from ._dbr import (ChannelType, _InternalChannelType, native_float_types,
+from ._dbr import (ChannelType, _LongStringChannelType, native_float_types,
                    native_int_types, native_types, DbrStringArray)
 
 from ._utils import ConversionDirection, CaprotoConversionError
@@ -259,7 +259,7 @@ def _preprocess_string_to_wire(values, to_dtype, string_encoding,
                                        string_encoding=string_encoding,
                                        enum_strings=enum_strings)
     elif to_dtype in native_int_types:
-        if to_dtype is _InternalChannelType.LONG_STRING and values:
+        if to_dtype is _LongStringChannelType.LONG_STRING and values:
             if isinstance(values[0], str):
                 return list(encode_or_fail(values[0], string_encoding))
             if isinstance(values[0], bytes):

--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -112,7 +112,7 @@ class ChannelAlarm:
     def disconnect(self, channel_data):
         self._channels.remove(channel_data)
 
-    async def read(self, dbr=None):
+    async def read(self, dbr=None, long_string=False):
         if dbr is None:
             dbr = DBR_STSACK_STRING()
         dbr.status = self.status
@@ -376,20 +376,20 @@ class ChannelData:
         self._queues[queue][sub_spec.channel_filter.sync][sub_spec.data_type].discard(sub_spec)
 
     async def auth_read(self, hostname, username, data_type, *,
-                        user_address=None):
+                        user_address=None, long_string=False):
         '''Get DBR data and native data, converted to a specific type'''
         access = self.check_access(hostname, username)
         if AccessRights.READ not in access:
             raise Forbidden("Client with hostname {} and username {} cannot "
                             "read.".format(hostname, username))
-        return (await self.read(data_type))
+        return (await self.read(data_type, long_string=long_string))
 
-    async def read(self, data_type):
-        # Subclass might trigger a write here to update self._data
-        # before reading it out.
-        return (await self._read(data_type))
+    async def read(self, data_type, *, long_string=False):
+        # Subclass might trigger a write here to update self._data before
+        # reading it out.
+        return (await self._read(data_type, long_string))
 
-    async def _read(self, data_type):
+    async def _read(self, data_type, *, long_string=False):
         # special cases for alarm strings and class name
         if data_type == ChannelType.STSACK_STRING:
             ret = await self.alarm.read()
@@ -407,7 +407,9 @@ class ChannelData:
             to_dtype=native_to,
             string_encoding=self.string_encoding,
             enum_strings=self._data.get('enum_strings'),
-            direction=ConversionDirection.TO_WIRE)
+            direction=ConversionDirection.TO_WIRE,
+            long_string=long_string,
+        )
 
         # for native types, there is no dbr metadata - just data
         if data_type in native_types:

--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -112,7 +112,7 @@ class ChannelAlarm:
     def disconnect(self, channel_data):
         self._channels.remove(channel_data)
 
-    async def read(self, dbr=None, long_string=False):
+    async def read(self, dbr=None):
         if dbr is None:
             dbr = DBR_STSACK_STRING()
         dbr.status = self.status
@@ -376,20 +376,20 @@ class ChannelData:
         self._queues[queue][sub_spec.channel_filter.sync][sub_spec.data_type].discard(sub_spec)
 
     async def auth_read(self, hostname, username, data_type, *,
-                        user_address=None, long_string=False):
+                        user_address=None):
         '''Get DBR data and native data, converted to a specific type'''
         access = self.check_access(hostname, username)
         if AccessRights.READ not in access:
             raise Forbidden("Client with hostname {} and username {} cannot "
                             "read.".format(hostname, username))
-        return (await self.read(data_type, long_string=long_string))
+        return (await self.read(data_type))
 
-    async def read(self, data_type, *, long_string=False):
+    async def read(self, data_type):
         # Subclass might trigger a write here to update self._data before
         # reading it out.
-        return (await self._read(data_type, long_string))
+        return (await self._read(data_type))
 
-    async def _read(self, data_type, *, long_string=False):
+    async def _read(self, data_type):
         # special cases for alarm strings and class name
         if data_type == ChannelType.STSACK_STRING:
             ret = await self.alarm.read()
@@ -408,7 +408,6 @@ class ChannelData:
             string_encoding=self.string_encoding,
             enum_strings=self._data.get('enum_strings'),
             direction=ConversionDirection.TO_WIRE,
-            long_string=long_string,
         )
 
         # for native types, there is no dbr metadata - just data

--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -416,7 +416,6 @@ class ChannelData:
         )
 
         # for native types, there is no dbr metadata - just data
-        print('data_type', data_type, 'native type?', data_type in native_types)
         if data_type in native_types:
             return b'', values
 

--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -9,10 +9,10 @@ import copy
 import time
 import weakref
 
-from ._dbr import (DBR_TYPES, ChannelType, native_type, native_types,
-                   timestamp_to_epics, time_types, DBR_STSACK_STRING,
-                   AccessRights, GraphicControlBase, AlarmStatus,
-                   AlarmSeverity, SubscriptionType)
+from ._dbr import (DBR_TYPES, _LongStringChannelType, ChannelType, native_type,
+                   native_types, timestamp_to_epics, time_types,
+                   DBR_STSACK_STRING, AccessRights, GraphicControlBase,
+                   AlarmStatus, AlarmSeverity, SubscriptionType)
 
 from ._utils import CaprotoError, CaprotoValueError, ConversionDirection
 from ._commands import parse_metadata
@@ -400,7 +400,12 @@ class ChannelData:
             class_name.value = rtyp
             return class_name, b''
 
-        native_to = native_type(data_type)
+        if data_type in _LongStringChannelType:
+            native_to = _LongStringChannelType.LONG_STRING
+            data_type = ChannelType(data_type)
+        else:
+            native_to = native_type(data_type)
+
         values = backend.convert_values(
             values=self._data['value'],
             from_dtype=self.data_type,
@@ -411,6 +416,7 @@ class ChannelData:
         )
 
         # for native types, there is no dbr metadata - just data
+        print('data_type', data_type, 'native type?', data_type in native_types)
         if data_type in native_types:
             return b'', values
 

--- a/caproto/_dbr.py
+++ b/caproto/_dbr.py
@@ -78,6 +78,16 @@ class ConnStatus(IntEnum):
 
 
 class ChannelType(IntEnum):
+    '''
+    All channel types supported by Channel Access
+
+    The ones that should be used in servers to specify the type of pvproperty
+    or ChannelData are only "native" types (STRING, INT, FLOAT, ENUM, CHAR,
+    LONG, DOUBLE)
+
+    The remaining channel data types are used for clients requesting additional
+    metadata from the server.
+    '''
     STRING = 0
     INT = 1
     FLOAT = 2
@@ -125,8 +135,18 @@ class ChannelType(IntEnum):
     CLASS_NAME = 38
 
 
-class _InternalChannelType(IntEnum):
+class _LongStringChannelType(IntEnum):
+    '''
+    An internal data type enum which mirrors CHAR values from ChannelType.
+
+    The key difference for this enum is that the server performs a different
+    conversion for STRING -> CHAR and STRING -> LONG_STRING.
+    '''
     LONG_STRING = 4
+    STS_LONG_STRING = 11
+    TIME_LONG_STRING = 18
+    GR_LONG_STRING = 25
+    CTRL_LONG_STRING = 32
 
 
 class SubscriptionType(IntFlag):

--- a/caproto/_dbr.py
+++ b/caproto/_dbr.py
@@ -125,6 +125,10 @@ class ChannelType(IntEnum):
     CLASS_NAME = 38
 
 
+class _InternalChannelType(IntEnum):
+    LONG_STRING = 4
+
+
 class SubscriptionType(IntFlag):
     '''Subscription masks
 

--- a/caproto/_utils.py
+++ b/caproto/_utils.py
@@ -593,7 +593,7 @@ def parse_record_field(pvname):
                 modifiers |= RecordModifiers.long_string
             else:
                 modifiers = RecordModifiers.long_string
-            field = field.rstrip('$')
+            field = field[:-1]
 
     # NOTE: VAL is equated to 'record' at a higher level than this.
     if field:

--- a/caproto/ioc_examples/mocking_records.py
+++ b/caproto/ioc_examples/mocking_records.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import caproto
 from caproto.server import pvproperty, PVGroup, ioc_arg_parser, run
 
 
@@ -51,6 +52,11 @@ class RecordMockingIOC(PVGroup):
     # Now that the field specification has been set on B, it can be reused:
     D = pvproperty(value=2.0, mock_record='ao',
                    precision=3, field_spec=B.field_spec)
+
+    E = pvproperty(value='this is a test',
+                   mock_record='stringin',
+                   dtype=caproto.ChannelType.STRING,
+                   )
 
 
 if __name__ == '__main__':

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -456,7 +456,9 @@ class VirtualCircuit:
 
             metadata, data = await db_entry.auth_read(
                 self.client_hostname, self.client_username,
-                data_type, user_address=self.circuit.address)
+                data_type, user_address=self.circuit.address,
+                long_string=chan.name.endswith('$')
+            )
 
             old_version = self.circuit.protocol_version < 13
             if command.data_count > 0 or old_version:

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -729,8 +729,17 @@ class Context:
                 raise CaprotoKeyError(f'Neither record nor field exists: '
                                       f'{rec_field}')
 
-            # Cache record.FIELD for later usage
-            self.pvdb[rec_field] = inst
+        # Verify the modifiers are usable BEFORE caching rec_field in the pvdb:
+        if ca.RecordModifiers.long_string in (mods or {}):
+            if inst.data_type not in (ChannelType.STRING,
+                                      ChannelType.CHAR):
+                raise CaprotoKeyError(
+                    f'Long-string modifier not supported with types '
+                    f'other than string or char ({inst.data_type})'
+                )
+
+        # Cache record.FIELD for later usage
+        self.pvdb[rec_field] = inst
         return inst
 
     async def _broadcaster_queue_iteration(self, addr, commands):

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -715,11 +715,11 @@ class Context:
             try:
                 (rec_field, rec, field, mods) = ca.parse_record_field(pvname)
             except ValueError:
-                raise ex
+                raise ex from None
 
             if not field and not mods:
-                # No field or modifiers, so there's nothing left to check
-                raise
+                # No field or modifiers, but a trailing '.' is valid
+                return self.pvdb[rec]
 
         # Without the modifiers, try 'record[.field]'
         try:

--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -114,7 +114,7 @@ class PvpropertyData:
             self.field_inst = None
             self.fields = {}
 
-    async def read(self, data_type, *, long_string=False):
+    async def read(self, data_type):
         value = await self.getter(self)
         if value is not None:
             if self.pvspec.get is None:
@@ -124,7 +124,7 @@ class PvpropertyData:
                 self.log.debug('value for %s updated: %r', self.name, value)
             # update the internal state
             await self.write(value)
-        return await self._read(data_type, long_string=long_string)
+        return await self._read(data_type)
 
     async def verify_value(self, value):
         value = await super().verify_value(value)

--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -114,7 +114,7 @@ class PvpropertyData:
             self.field_inst = None
             self.fields = {}
 
-    async def read(self, data_type):
+    async def read(self, data_type, *, long_string=False):
         value = await self.getter(self)
         if value is not None:
             if self.pvspec.get is None:
@@ -124,7 +124,7 @@ class PvpropertyData:
                 self.log.debug('value for %s updated: %r', self.name, value)
             # update the internal state
             await self.write(value)
-        return await self._read(data_type)
+        return await self._read(data_type, long_string=long_string)
 
     async def verify_value(self, value):
         value = await super().verify_value(value)

--- a/caproto/tests/test_data_conversion.py
+++ b/caproto/tests/test_data_conversion.py
@@ -4,7 +4,7 @@ from inspect import isclass
 import pytest
 
 from .._utils import ConversionDirection
-from .._dbr import _InternalChannelType, ChannelType, DbrStringArray
+from .._dbr import _LongStringChannelType, ChannelType, DbrStringArray
 from .. import backend
 from .conftest import (array_types, assert_array_almost_equal)
 
@@ -12,7 +12,7 @@ from .conftest import (array_types, assert_array_almost_equal)
 FROM_WIRE = ConversionDirection.FROM_WIRE
 TO_WIRE = ConversionDirection.TO_WIRE
 
-LONG_STRING = _InternalChannelType.LONG_STRING
+LONG_STRING = _LongStringChannelType.LONG_STRING
 STRING = ChannelType.STRING
 INT = ChannelType.INT
 FLOAT = ChannelType.FLOAT

--- a/caproto/tests/test_examples.py
+++ b/caproto/tests/test_examples.py
@@ -562,12 +562,17 @@ def test_long_strings(request, prefix):
     stringin = f'{prefix}E'
     regular = sync_read(f'{stringin}.VAL', data_type='native')
     assert regular.data_type == ca.ChannelType.STRING
-    length = len(regular.data[0])
+    data, = regular.data
+    length = len(data)
     assert length > 1  # based on the default value in the test
 
-    longstr = sync_read(f'{stringin}.VAL$', data_type='native')
-    assert longstr.data_type == ca.ChannelType.CHAR
-    assert len(longstr.data) == length
+    for dtype in ('native', 'control', 'time', 'graphic'):
+        longstr = sync_read(f'{stringin}.VAL$', data_type=dtype)
+        longstr_data = b''.join(longstr.data)
+        expected_dtype = ca._dbr.field_types[dtype][ca.ChannelType.CHAR]
+        assert longstr.data_type == expected_dtype
+        assert len(longstr.data) == length
+        assert longstr_data == data
 
     with pytest.raises(TimeoutError):
         # an analog input .VAL has no long string option


### PR DESCRIPTION
This is at least working locally - I _believe_ correctly:

```
$ cainfo mock:E.VAL
mock:E.VAL
    State:            connected
    Host:             192.168.99.1:5064
    Access:           read, write
    Native data type: DBF_STRING
    Request type:     DBR_STRING
    Element count:    1

$ cainfo mock:E.VAL$
mock:E.VAL$
    State:            connected
    Host:             192.168.99.1:5064
    Access:           read, write
    Native data type: DBF_CHAR
    Request type:     DBR_CHAR
    Element count:    14

$ caget -S mock:E.RTYP
mock:E.RTYP stringin

$ caget -S mock:E.RTYP$
mock:E.RTYP$ stringin

$ caget -S mock:E.VAL$
mock:E.VAL$ this is a test
```

And not shown for other fields:

```
$ caget -S mock:C.RTYP
mock:C.RTYP ai

$ caget mock:C.VAL$
Channel connect timed out: 'mock:C.VAL$' not found.
```
cc @baldwinb (please chime in if I'm wrong about any of the above)