### PR TITLE
Provide Subscription to user callback (in sync client).

### DIFF
--- a/caproto/commandline/monitor.py
+++ b/caproto/commandline/monitor.py
@@ -12,7 +12,6 @@ Python session, do not import this module; instead import caproto.sync.client.
 """
 import argparse
 from datetime import datetime
-import functools
 import time
 from ..sync.client import subscribe, block
 from .. import SubscriptionType, set_handler, __version__
@@ -137,8 +136,9 @@ def main():
     history = []
     tokens = {'callback_count': 0}
 
-    def callback(pv_name, response):
+    def callback(sub, response):
         tokens['callback_count'] += 1
+        pv_name = sub.pv_name
 
         data_fmt = gen_data_format(args=args, data=response.data)
 
@@ -185,9 +185,8 @@ def main():
             sub = subscribe(pv_name,
                             mask=mask,
                             priority=args.priority)
-            cb = functools.partial(callback, pv_name)
-            sub.add_callback(cb)
-            cbs.append(cb)  # Hold ref to keep cb from being garbage collected.
+            sub.add_callback(callback)
+            cbs.append(callback)  # Hold ref to keep it from being garbage collected.
             subs.append(sub)
         # Wait to be interrupted by KeyboardInterrupt.
         block(*subs, duration=args.duration, timeout=args.timeout,

--- a/doc/source/sync-client.rst
+++ b/doc/source/sync-client.rst
@@ -136,10 +136,13 @@ the server sends an update. It must accept one positional argument.
 .. ipython:: python
 
    responses = []
-   def f(response):
-       "On each update, print the data and cache the full response in a list."
+   def f(sub, response):
+       """
+       On each update, print the PV name and data
+       Cache the full response in a list.
+       """
        responses.append(response)
-       print(response.data)
+       print(sub.pv_name, response.data)
 
 We register this function with ``sub``. We can register multiple such functions
 is we wish.
@@ -159,10 +162,10 @@ separate, background thread.) To activate the subscription, call
     :verbatim:
 
     In [1]: sub.block()
-    [14.14272394]
-    [14.94322537]
-    [15.35695388]
-    [15.74301991]
+    random_walk:x [14.14272394]
+    random_walk:x [14.94322537]
+    random_walk:x [15.35695388]
+    random_walk:x [15.74301991]
     ^C
 
 This call to ``sub.block()`` blocks indefinitely, sending a message to the
@@ -215,11 +218,19 @@ another thread).
     Out[5]: 0
 
     In [6]: block(sub_x, sub_dt)
-    [63.34866867]
-    [1.]
-    [63.53448681]
-    [64.30532391]
+    random_walk:x [63.34866867]
+    random_walk:dt [1.]
+    random_walk:x [63.53448681]
+    random_walk:x [64.30532391]
     ^C
+
+.. versionchanged:: 0.5.0
+
+   The expected signature of the callback function was changed from
+   ``f(response)`` to ``f(sub, response)``. For backward compatibility,
+   functions with signature ``f(response)`` are still accepted, but caproto
+   will issue a warning that a future release may require the new signature,
+   ``f(sub, response)``.
 
 .. warning::
 
@@ -230,7 +241,7 @@ another thread).
 
     .. code-block:: python
 
-        sub.add_callback(lambda response: print(response.data))
+        sub.add_callback(lambda sub, response: print(response.data))
 
     The lambda function will be promptly garbage collected by Python and
     removed from ``sub`` by caproto. To avoid that, make a reference before
@@ -238,7 +249,7 @@ another thread).
     
     .. code-block:: python
 
-        cb = lambda response: print(response.data)
+        cb = lambda sub, response: print(response.data)
         sub.add_callback(cb)
 
     This can be surprising, but it is a standard approach for avoiding the


### PR DESCRIPTION
In #574 we changed the expected signature for user subscription callbacks from
`f(response)` to `f(sub, response)` in the threading client. This PR
applies the same changes to the sync client, and it updates `caproto-monitor`
accordingly.

I went to apply the same change to the async clients (trio, curio) and found
that they are too far behind for this to be applicable. We still haven't
separate the "create subscription object" and "add callback" steps there.
I think we should wait to worry about that until we unify the clients around
a shared utility module, as we have done for the servers.

So, this PR completes the subscriptions refactor and paves the way for 0.5.0.