### PR TITLE
MNT: remove implicitly concatenated empty string

### DIFF
--- a/caproto/tests/conftest.py
+++ b/caproto/tests/conftest.py
@@ -201,7 +201,7 @@ def _epics_base_ioc(prefix, request):
                 f'***********************************',
                 f'********IOC process exited!********',
                 f'******* Returned: {process.returncode} ******',
-                f'***********************************''',
+                f'***********************************',
             ])
 
             stdout, stderr = process.communicate()


### PR DESCRIPTION
While technically syntactically valid ('stuff''' -> 'stuff' + '')
it confuses the code-highlighter in emacs.