### PR TITLE
Deprecated features of `trio`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,7 @@ doc/build
 .asv/
 pytest_bench.json
 .pytest_cache/
+.idea/
+.vscode/
 build/
 dist/

--- a/caproto/_utils.py
+++ b/caproto/_utils.py
@@ -75,7 +75,7 @@ __all__ = (  # noqa F822
     'RecordAndField',
     'ThreadsafeCounter',
     '__version__',
-     # sentinels dynamically defined and added to globals() below
+    # sentinels dynamically defined and added to globals() below
     'CLIENT', 'SERVER', 'RESPONSE', 'REQUEST', 'NEED_DATA',
     'SEND_SEARCH_REQUEST', 'AWAIT_SEARCH_RESPONSE',
     'SEND_SEARCH_RESPONSE', 'SEND_VERSION_REQUEST',

--- a/caproto/ioc_examples/mini_beamline.py
+++ b/caproto/ioc_examples/mini_beamline.py
@@ -84,8 +84,8 @@ class PinHole(_JitterDetector):
         c = - 1 / (2 * sigma * sigma)
 
         @_arrayify
-        def jitter_read(m, e, I):
-            N = (self.parent.N_per_I_per_s * I * e *
+        def jitter_read(m, e, intensity):
+            N = (self.parent.N_per_I_per_s * intensity * e *
                  np.exp(c * (m - center)**2))
             return np.random.poisson(N)
 
@@ -101,9 +101,9 @@ class Edge(_JitterDetector):
         c = 1 / sigma
 
         @_arrayify
-        def jitter_read(m, e, I):
+        def jitter_read(m, e, intensity):
             s = math.erfc(c * (-m + center)) / 2
-            N = (self.parent.N_per_I_per_s * I * e * s)
+            N = (self.parent.N_per_I_per_s * intensity * e * s)
             return np.random.poisson(N)
 
         return jitter_read(self.mtr.value,
@@ -118,11 +118,11 @@ class Slit(_JitterDetector):
         c = 1 / sigma
 
         @_arrayify
-        def jitter_read(m, e, I):
+        def jitter_read(m, e, intensity):
             s = (math.erfc(c * (m - center)) -
                  math.erfc(c * (m + center))) / 2
 
-            N = (self.parent.N_per_I_per_s * I * e * s)
+            N = (self.parent.N_per_I_per_s * intensity * e * s)
             return np.random.poisson(N)
 
         return jitter_read(self.mtr.value,

--- a/caproto/ioc_examples/records.py
+++ b/caproto/ioc_examples/records.py
@@ -45,7 +45,7 @@ class RecordMockingIOC(PVGroup):
     @B.fields.RVAL.putter
     async def B(fields, instance, value):
         ioc = fields.parent.group
-        print(f'B.RVAL: Writing modified values to A, B')
+        print('B.RVAL: Writing modified values to A, B')
         await ioc.B.write(value + 10)
         await ioc.A.write(value - 10)
 

--- a/caproto/server/conversion.py
+++ b/caproto/server/conversion.py
@@ -203,11 +203,11 @@ def group_to_device(group):
         yield from group_to_device(subgroup.group_cls)
 
         if isinstance(subgroup, pvfunction):
-            yield f''
+            yield ''
             yield from pvfunction_to_device_function(name, subgroup)
 
-        yield f''
-        yield f''
+        yield ''
+        yield ''
 
     if isinstance(group, PVGroup):
         group = group.__class__
@@ -220,7 +220,7 @@ def group_to_device(group):
                f"{doc})")
 
     if not group._pvs_:
-        yield f'    ...'
+        yield '    ...'
 
     for name, prop in group._pvs_.items():
         if '.' in name:
@@ -229,7 +229,7 @@ def group_to_device(group):
 
         pvspec = prop.pvspec
         doc = f', doc={pvspec.doc!r}' if pvspec.doc else ''
-        string = f', string=True' if pvspec.dtype == str else ''
+        string = ', string=True' if pvspec.dtype == str else ''
         cls = 'EpicsSignalRO' if pvspec.read_only else 'EpicsSignal'
         yield (f"    {name.lower()} = Cpt({cls}, '{pvspec.name}'" f"{string}{doc})")
         # TODO will break when full/macro-ified PVs is specified

--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -970,7 +970,7 @@ class pvfunction(SubGroup):
                           }
                 value = await self.func(group, **kwargs)
                 await group.retval.write(value)
-                await group.status.write(f'Success')
+                await group.status.write('Success')
             except Exception as ex:
                 await group.status.write(f'{ex.__class__.__name__}: {ex}')
                 raise

--- a/caproto/tests/conftest.py
+++ b/caproto/tests/conftest.py
@@ -565,7 +565,7 @@ def server(request):
                 for _ in range(15):
                     try:
                         if threaded_client:
-                            await trio.run_sync_in_worker_thread(client)
+                            await trio.to_thread.run_sync(client)
                         else:
                             await client(test_nursery, server_context)
                     except TimeoutError:

--- a/caproto/tests/conftest.py
+++ b/caproto/tests/conftest.py
@@ -198,10 +198,10 @@ def _epics_base_ioc(prefix, request):
         process.wait()
         with exit_lock:
             monitor_output.extend([
-                f'***********************************',
-                f'********IOC process exited!********',
+                '***********************************',
+                '********IOC process exited!********',
                 f'******* Returned: {process.returncode} ******',
-                f'***********************************',
+                '***********************************',
             ])
 
             stdout, stderr = process.communicate()
@@ -536,7 +536,7 @@ def server(request):
                     else:
                         break
                 else:
-                    raise TimeoutError(f"ioc failed to start")
+                    raise TimeoutError("ioc failed to start")
             finally:
                 await server_task.cancel()
 

--- a/caproto/tests/epics_test_utils.py
+++ b/caproto/tests/epics_test_utils.py
@@ -55,7 +55,7 @@ async def run_epics_base_binary(backend, *args, max_attempts=3):
     if backend == 'curio':
         raw_stdout, raw_stderr = await curio.run_in_thread(runner)
     elif backend == 'trio':
-        raw_stdout, raw_stderr = await trio.run_sync_in_worker_thread(runner)
+        raw_stdout, raw_stderr = await trio.to_thread.run_sync(runner)
     elif backend == 'asyncio':
         loop = asyncio.get_event_loop()
         raw_stdout, raw_stderr = await loop.run_in_executor(None, runner)

--- a/caproto/tests/test_examples.py
+++ b/caproto/tests/test_examples.py
@@ -294,7 +294,7 @@ def _test_ioc_examples(request, module_name, pvdb_class_name, class_kwargs,
     pvs = list(pvdb.keys())
     pv_to_check = pvs[0]
 
-    print(f'PVs:', pvs)
+    print('PVs:', pvs)
     print(f'PV to check: {pv_to_check}')
 
     stdin = (subprocess.DEVNULL if 'io_interrupt' in module_name

--- a/caproto/tests/test_server.py
+++ b/caproto/tests/test_server.py
@@ -202,7 +202,7 @@ def test_with_caput(backends, prefix, pvdb_from_server_example, server, pv,
         # args are ignored for curio and trio servers.
         print('* client put test: {} put value: {} check value: {}'
               ''.format(pv, put_value, check_value))
-        print('(client args: %s)'.format(client_args))
+        print('(client args: {})'.format(client_args))
 
         db_entry = caget_pvdb[pv]
         db_old = db_entry.value

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -653,9 +653,9 @@ def test_multithreaded_many_subscribe(ioc, context, thread_count,
         results = _multithreaded_exec(_test, thread_count + 1)
     except threading.BrokenBarrierError:
         if init_barrier.broken:
-            print(f'Init barrier broken!')
+            print('Init barrier broken!')
         if sub_ended_barrier.broken:
-            print(f'Sub_ended barrier broken!')
+            print('Sub_ended barrier broken!')
         raise
 
     for value_list in results:

--- a/caproto/trio/server.py
+++ b/caproto/trio/server.py
@@ -16,15 +16,43 @@ class ServerExit(Exception):
     ...
 
 
-class Event(trio.Event):
+class Event:
+    """
+    The class wraps `trio.Event` and implements `Event.clear()`
+    method that is used in the code, but deprecated in `trio`.
+    The event is cleared by creating the new event that if the
+    event is set. If the event is not set, then old event is left.
+    The class is not intended to be thread safe.
+    """
+    def __init__(self):
+        self._create_event()
+
+    def _create_event(self):
+        self._event = trio.Event()
+
+    def set(self):
+        self._event.set()
+
+    def clear(self):
+        """
+        Clearing of the event is implemented by creating a new
+        event if the event is set. It is assumed that if the event
+        is set, then it is not waited on.
+        """
+        if self._event.is_set():
+            self._create_event()
+
+    def is_set(self):
+        return self._event.is_set()
+
     async def wait(self, timeout=None):
         if timeout is not None:
             with trio.move_on_after(timeout):
-                await super().wait()
+                await self._event.wait()
                 return True
             return False
         else:
-            await super().wait()
+            await self._event.wait()
             return True
 
 


### PR DESCRIPTION
The changes in this PR are addressing deprecated features of `trio`.

- `trio.run_sync_in_worker_thread` replaced by `trio.to_thread.run_sync`.

- `trio.BlockingTrioPortal()` followed by `portal.run(...)` or `portal.run_sync(...)` replaced by `trio.from_thread.run()` or `trio.from_thread.run_sync(...)`

- There is no straightforward fix for deprecated `trio.Event.clear()`. The class `Event` in  `caproto/trio/server.py` was expanded to emulate the original `trio.Event.clear()` method.

The PR is addressing issues https://github.com/caproto/caproto/issues/548, https://github.com/caproto/caproto/issues/505 and https://github.com/caproto/caproto/issues/504.