### PR TITLE
FIX: missing f-string in server log

### DIFF
--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -1220,7 +1220,7 @@ class PVGroup(metaclass=PVGroupMeta):
             base = self.__class__.__module__
 
         # Instantiate the logger
-        self.log = logging.getLogger('{base}.{log_name}')
+        self.log = logging.getLogger(f'{base}.{log_name}')
         self._create_pvdb()
 
         # Prime the snapshots to the current state.


### PR DESCRIPTION
Simple fix.

@danielballan @ke-zhang-rd do you have a recommendation as to best setting up logging with an IOC external to caproto? e.g., a package `my_ioc` has `MyPVGroup`, making for a logger name `my_ioc.MyPVGroup`.

I'm thinking I'd like to use the same handler to get the same record formatting and save to the same file (perhaps even tee to standard output as well). It doesn't seem to fit well into the current structure, but I may be missing something.