### PR TITLE
FIX: .PROC (process_record) field putter

### DIFF
--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -973,6 +973,13 @@ class ChannelByte(ChannelNumeric):
             else:
                 value = b''.join(map(bytes, ([v] for v in value)))
 
+        if self.max_length == 1:
+            try:
+                len(value)
+            except TypeError:
+                # Allow a scalar byte value to be passed in
+                value = bytes([value])
+
         if isinstance(value, str):
             raise CaprotoValueError('ChannelByte does not accept decoded strings')
 
@@ -1021,6 +1028,13 @@ class ChannelChar(ChannelData):
                 value = value[0]
             else:
                 value = b''.join(map(bytes, ([v] for v in value)))
+
+        if self.max_length == 1:
+            try:
+                len(value)
+            except TypeError:
+                # Allow a scalar byte value to be passed in
+                value = str(bytes([value]), self.string_encoding)
 
         if isinstance(value, bytes):
             value = value.decode(self.string_encoding)

--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -146,10 +146,6 @@ class PvpropertyData:
 
     async def verify_value(self, value):
         value = await super().verify_value(value)
-        if self.pvspec.put is None:
-            self.log.debug('group verify value for %s: %r', self.name, value)
-        else:
-            self.log.debug('verify value for %s: %r', self.name, value)
         return await self.putter(self, value)
 
     async def _server_startup(self, async_lib):
@@ -1293,11 +1289,10 @@ class PVGroup(metaclass=PVGroupMeta):
 
     async def group_read(self, instance):
         'Generic read called for channels without `get` defined'
-        self.log.debug('no-op group read of %s', instance.pvspec.attr)
 
     async def group_write(self, instance, value):
         'Generic write called for channels without `put` defined'
-        self.log.debug('group write of %s = %s', instance.pvspec.attr, value)
+        self.log.debug('group_write: %s = %s', instance.pvspec.attr, value)
         return value
 
 

--- a/caproto/tests/ioc_process.py
+++ b/caproto/tests/ioc_process.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from caproto.server import pvproperty, PVGroup, ioc_arg_parser, run
+from textwrap import dedent
+
+
+class ProcessIOC(PVGroup):
+    """
+    IOC which exposes `record.PROC` with a `putter`.
+    """
+
+    record = pvproperty(value=1, record='bo')
+    count = pvproperty(value=-1)
+
+    @record.fields.process_record.startup
+    async def record(fields, instance, value):  # noqa
+        process_ioc = fields.parent.group
+        await process_ioc.count.write(value=0)
+        fields.log.warning('Startup hook executed. Initialized to %d',
+                           process_ioc.count.value)
+
+    @record.fields.process_record.putter
+    async def record(fields, instance, value):  # noqa
+        process_ioc = fields.parent.group
+
+        new_value = process_ioc.count.value + 1
+        process_ioc.log.warning('Processing! Incremented to: %d', new_value)
+        await process_ioc.count.write(value=new_value)
+
+
+if __name__ == '__main__':
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix='process_test:',
+        desc=dedent(ProcessIOC.__doc__))
+    ioc = ProcessIOC(**ioc_options)
+    run(ioc.pvdb, **run_options)

--- a/caproto/tests/test_server.py
+++ b/caproto/tests/test_server.py
@@ -362,3 +362,14 @@ def test_data_copy(cls, kwargs):
     patch_alarm(args1)
     patch_alarm(args2)
     assert args1 == args2
+
+
+@pytest.mark.parametrize('async_lib', ['asyncio', 'curio', 'trio'])
+def test_process_field(request, prefix, async_lib):
+    run_example_ioc('caproto.tests.ioc_process', request=request,
+                    args=['--prefix', prefix, '--async-lib', async_lib],
+                    pv_to_check=f'{prefix}record.PROC')
+
+    write(f'{prefix}record.PROC', [1], notify=True)
+    write(f'{prefix}record.PROC', [1], notify=True)
+    assert read(f'{prefix}count').data[0] == 2

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = -ra --no-print-logs --timeout=100
+addopts = -ra --timeout=100


### PR DESCRIPTION
Prerequisite PR #621

See attached example IOC, which will not work in the current master, as it errors with:

(1) Fixed by #621:
```
Traceback (most recent call last):
  File "ioc_process.py", line 34, in <module>
    ioc = ProcessIOC(**ioc_options)
  File "/Users/klauer/docs/Repos/caproto/caproto/server/server.py", line 1224, in __init__
    self._create_pvdb()
  File "/Users/klauer/docs/Repos/caproto/caproto/server/server.py", line 1267, in _create_pvdb
    pvprop.pvspec)
  File "/Users/klauer/docs/Repos/caproto/caproto/server/server.py", line 1112, in channeldata_from_pvspec
    **kw)
  File "/Users/klauer/docs/Repos/caproto/caproto/server/server.py", line 111, in __init__
    prop = new_dict[field]
KeyError: 'process_record'
```

And then 
(2) Fixed by this PR:

`$ caput process_test:record.PROC 1`

```
Invalid write request by klauer (klauer-osx): WriteRequest(data=[b'1'], data_type=<ChannelType.STRING: 0>, data_count=1, sid=0, ioid=1, metadata=None)
Traceback (most recent call last):
  File "/Users/klauer/docs/Repos/caproto/caproto/server/common.py", line 557, in handle_write
    user_address=self.circuit.address)
  File "/Users/klauer/docs/Repos/caproto/caproto/_data.py", line 444, in auth_write
    flags=flags))
  File "/Users/klauer/docs/Repos/caproto/caproto/_data.py", line 1039, in write_from_dbr
    await super().write_from_dbr(*args, flags=flags, **kwargs)
  File "/Users/klauer/docs/Repos/caproto/caproto/_data.py", line 488, in write_from_dbr
    return (await self.write(value, flags=flags, **metadata_dict))
  File "/Users/klauer/docs/Repos/caproto/caproto/_data.py", line 1035, in write
    await super().write(*args, flags=flags, **kwargs)
  File "/Users/klauer/docs/Repos/caproto/caproto/_data.py", line 493, in write
    value = self.preprocess_value(value)
  File "/Users/klauer/docs/Repos/caproto/caproto/_data.py", line 1029, in preprocess_value
    raise CaprotoValueError('Invalid string')
caproto._utils.CaprotoValueError: Invalid string
```