### PR TITLE
DOC: bump copyright date, add rebuild script

### DIFF
--- a/doc/rebuild.sh
+++ b/doc/rebuild.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+GITHUB_IO=../github.io
+OLD_ENV=caproto-3.6
+NEW_ENV=caproto
+
+conda activate $OLD_ENV
+
+for version in v0.1.2 v0.2.3 v0.3.4 v0.4.0 v0.4.1 v0.4.2 v0.4.3 v0.4.4 v0.5.0 v0.5.1 v0.5.2 v0.6.0; do
+    if [[ $version == "v0.5.0" ]]; then
+        conda activate $NEW_ENV
+    fi
+
+    kill `pgrep -f random_walk` || true
+    git reset --hard $version
+    if [ ! `grep 'doctr_versions_menu' source/conf.py` ]; then
+        sed -i -e '/^extensions = .*/a\
+            "doctr_versions_menu",' source/conf.py
+    fi
+    sed -i -e 's/201[789]/2020/g' source/conf.py
+    rm -rf build && make html
+    # it's clean, really!
+    find build/html -type f -name "*.html" -exec sed -i -e 's/+0\.g........\.dirty//g' {} \;
+    find build/html -type f -name "*.js" -exec sed -i -e 's/+0\.g........\.dirty//g' {} \;
+    find build/html -name doctr-versions-menu.js -exec sed -i -e "s#'/versions.json#'/caproto/versions.json#" {} \;
+    cp -R build/html/ $GITHUB_IO/caproto/$version/
+done

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -71,7 +71,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'caproto'
-copyright = '2017, Daniel Allan'
+copyright = '2020, Daniel Allan'
 author = 'Daniel Allan'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
This is the result of my local rebuilding efforts to get doctr-versions-menu going.

I'm cautiously optimistic that new tags / master rebuilds won't break it, but we'll see.

Note: per-version docs are already available as a result of this. It's not required to merge this for that purpose.
https://caproto.github.io/caproto/master/
See the version selector on the bottom left:
<img width="297" alt="image" src="https://user-images.githubusercontent.com/5139267/89108972-01904580-d3f2-11ea-8132-a4896fb99dff.png">
