### PR TITLE
ENH: prototype-level pvAccess support, with command-line + simple synchronous client

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,4 +20,9 @@ repos:
     hooks:
     -   id: flake8
 
+-   repo: https://github.com/timothycrosley/isort
+    rev: 5.3.0
+    hooks:
+    -   id: isort
+
 exclude: 'CAproto.html'

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,9 @@ script:
   - pip install git+https://github.com/klauer/catvs.git@py3k
   # Work around pip bug that fails to respect trio's pin of attrs.
   - pip install -U attrs
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
+        pip install dataclasses;
+    fi
 
   - caproto-repeater &
   - coverage run --parallel-mode run_tests.py -v

--- a/caproto/_utils.py
+++ b/caproto/_utils.py
@@ -4,21 +4,22 @@
 import argparse
 import array
 import collections
+import enum
 import functools
 import inspect
+import json
 import os
 import random
 import socket
 import sys
-import enum
-import json
 import threading
+import weakref
 from collections import namedtuple
 from contextlib import contextmanager
 from warnings import warn
-import weakref
 
 from ._version import get_versions
+
 __version__ = get_versions()['version']
 
 try:
@@ -235,6 +236,26 @@ _ENVIRONMENT_DEFAULTS = dict(
     EPICS_CAS_BEACON_PORT=5065,
     EPICS_CAS_INTF_ADDR_LIST='',
     EPICS_CAS_IGNORE_ADDR_LIST='',
+
+    # pvAccess
+    EPICS_PVA_DEBUG=0,
+    EPICS_PVA_ADDR_LIST='',
+    EPICS_PVA_AUTO_ADDR_LIST='YES',
+    EPICS_PVA_CONN_TMO=30.0,
+    EPICS_PVA_BEACON_PERIOD=15.0,
+    EPICS_PVA_BROADCAST_PORT=5076,
+    EPICS_PVA_MAX_ARRAY_BYTES=16384,
+    EPICS_PVA_SERVER_PORT=5075,
+
+    # pvAccess server
+    EPICS_PVAS_BEACON_ADDR_LIST='',
+    EPICS_PVAS_AUTO_BEACON_ADDR_LIST='YES',
+    EPICS_PVAS_BEACON_PERIOD=15.0,
+    EPICS_PVAS_SERVER_PORT=5075,
+    EPICS_PVAS_BROADCAST_PORT=5076,
+    EPICS_PVAS_MAX_ARRAY_BYTES=16384,
+    EPICS_PVA_PROVIDER_NAMES='local',
+    EPICS_PVAS_PROVIDER_NAMES='local',
 )
 
 
@@ -259,26 +280,30 @@ def _split_address_list(addr_list):
     return list(set(addr for addr in addr_list.split(' ') if addr.strip()))
 
 
-def get_manually_specified_beacon_addresses():
+def get_manually_specified_beacon_addresses(*, protocol='CAS'):
     '''Get a list of addresses, as configured by EPICS_CA_ADDR_LIST'''
     return _split_address_list(
-        get_environment_variables()['EPICS_CAS_BEACON_ADDR_LIST'])
+        get_environment_variables()[f'EPICS_{protocol}_BEACON_ADDR_LIST'])
 
 
-def get_manually_specified_client_addresses():
+def get_manually_specified_client_addresses(*, protocol='CA'):
     '''Get a list of addresses, as configured by EPICS_CA_ADDR_LIST'''
     return _split_address_list(
-        get_environment_variables()['EPICS_CA_ADDR_LIST'])
+        get_environment_variables()[f'EPICS_{protocol}_ADDR_LIST'])
 
 
-def get_address_list():
-    '''Get channel access client address list based on environment variables
+def get_address_list(*, protocol='CA'):
+    '''
+    Get channel access client address list based on environment variables
 
     If the address list is set to be automatic, the network interfaces will be
     scanned and used to determine the broadcast addresses available.
     '''
     env = get_environment_variables()
-    addresses = get_manually_specified_client_addresses()
+    addresses = get_manually_specified_client_addresses(protocol=protocol)
+
+    auto_addr_list = env[f'EPICS_{protocol}_AUTO_ADDR_LIST']
+    addr_list = env[f'EPICS_{protocol}_ADDR_LIST']
 
     if addresses and env['EPICS_CA_AUTO_ADDR_LIST'].lower() != 'yes':
         # Custom address list specified, and EPICS_CA_AUTO_ADDR_LIST=NO
@@ -293,14 +318,15 @@ def get_address_list():
     return addresses + auto_addr_list
 
 
-def get_server_address_list():
-    '''Get the server interfaces based on environment variables
+def get_server_address_list(*, protocol='CAS'):
+    '''Get the server interface addresses based on environment variables
 
     Returns
     -------
     list of interfaces
     '''
-    intf_addrs = get_environment_variables()['EPICS_CAS_INTF_ADDR_LIST']
+    key = f'EPICS_{protocol}_INTF_ADDR_LIST'
+    intf_addrs = get_environment_variables()[key]
 
     if not intf_addrs:
         return ['0.0.0.0']
@@ -314,7 +340,7 @@ def get_server_address_list():
     return [strip_port(addr) for addr in _split_address_list(intf_addrs)]
 
 
-def get_beacon_address_list():
+def get_beacon_address_list(*, protocol='CAS'):
     '''Get channel access beacon address list based on environment variables
 
     If the address list is set to be automatic, the network interfaces will be
@@ -325,9 +351,9 @@ def get_beacon_address_list():
     addr_list : list of (addr, beacon_port)
     '''
     env = get_environment_variables()
-    auto_addr_list = env['EPICS_CAS_AUTO_BEACON_ADDR_LIST']
-    addr_list = get_manually_specified_beacon_addresses()
-    beacon_port = env['EPICS_CAS_BEACON_PORT']
+    auto_addr_list = env[f'EPICS_{protocol}_AUTO_BEACON_ADDR_LIST']
+    addr_list = get_manually_specified_beacon_addresses(protocol=protocol)
+    beacon_port = env[f'EPICS_{protocol}_BEACON_PORT']
 
     def get_addr_port(addr):
         if ':' in addr:

--- a/caproto/pva/__init__.py
+++ b/caproto/pva/__init__.py
@@ -1,0 +1,20 @@
+from ._broadcaster import Broadcaster  # noqa
+from ._circuit import *  # noqa
+from ._core import *  # noqa
+from ._data import *  # noqa
+from ._dataclass import PvaStruct, annotation_type_map, pva_dataclass
+from ._fields import *  # noqa
+from ._messages import *  # noqa
+from ._normative import *  # noqa
+from ._pvrequest import *  # noqa
+from ._utils import *  # noqa
+
+annotation_types = {type_.__name__: type_ for type_ in annotation_type_map
+                    if type_ not in {int, float, str, bytes}}
+globals().update(annotation_types)
+
+__all__ = [
+    'Broadcaster', 'pva_dataclass', 'PvaStruct',
+]
+
+__all__ += list(annotation_types)

--- a/caproto/pva/_annotations.py
+++ b/caproto/pva/_annotations.py
@@ -1,0 +1,118 @@
+"""
+Includes types that can be used for annotations, as-is or in Lists/Unions.
+
+Examples
+--------
+``double_item: pva.Double``
+``list_of_doubles: typing.List[pva.Double]``
+``int_or_float: typing.Union[pva.Int32, pva.Float32]``
+"""
+import typing
+
+from ._core import FieldType
+
+BoundedString = typing.NewType('BoundedString', int)
+String = typing.NewType('String', int)
+Any = typing.NewType('Any', int)
+# Union = typing.NewType('Union', int)
+# Struct = typing.NewType('Struct', int)
+Float16 = typing.NewType('Float16', int)
+Float32 = typing.NewType('Float32', int)
+Float64 = typing.NewType('Float64', int)
+Float128 = typing.NewType('Float128', int)
+Float = typing.NewType('Float', int)
+Double = typing.NewType('Double', int)
+UInt64 = typing.NewType('UInt64', int)
+Int64 = typing.NewType('Int64', int)
+ULong = typing.NewType('ULong', int)
+Long = typing.NewType('Long', int)
+UInt32 = typing.NewType('UInt32', int)
+Int32 = typing.NewType('Int32', int)
+UInt = typing.NewType('UInt', int)
+Int = typing.NewType('Int', int)
+UInt16 = typing.NewType('UInt16', int)
+Int16 = typing.NewType('Int16', int)
+UShort = typing.NewType('UShort', int)
+Short = typing.NewType('Short', int)
+UInt8 = typing.NewType('UInt8', int)
+Int8 = typing.NewType('Int8', int)
+UByte = typing.NewType('UByte', int)
+Byte = typing.NewType('Byte', int)
+Boolean = typing.NewType('Boolean', int)
+
+
+annotation_type_map = {
+    BoundedString: FieldType.bounded_string,
+    String: FieldType.string,
+    Any: FieldType.any,
+    # Union: FieldType.union,
+    # Struct: FieldType.struct,
+    Float16: FieldType.float16,
+    Float32: FieldType.float32,
+    Float64: FieldType.float64,
+    Float128: FieldType.float128,
+    Float: FieldType.float,
+    Double: FieldType.double,
+    UInt64: FieldType.uint64,
+    Int64: FieldType.int64,
+    ULong: FieldType.ulong,
+    Long: FieldType.long,
+    UInt32: FieldType.uint32,
+    Int32: FieldType.int32,
+    UInt: FieldType.uint,
+    Int: FieldType.int,
+    UInt16: FieldType.uint16,
+    Int16: FieldType.int16,
+    UShort: FieldType.ushort,
+    Short: FieldType.short,
+    UInt8: FieldType.uint8,
+    Int8: FieldType.int8,
+    UByte: FieldType.ubyte,
+    Byte: FieldType.byte,
+    Boolean: FieldType.boolean,
+
+    int: FieldType.int64,
+    float: FieldType.double,
+    str: FieldType.string,
+    bytes: FieldType.byte,
+}
+
+
+type_to_annotation = {
+    ft: annotation
+    for annotation, ft in annotation_type_map.items()
+    if annotation not in (int, float, str, bytes)
+}
+
+
+annotation_default_values = {
+    FieldType.bounded_string: '',
+    FieldType.string: '',
+    FieldType.any: None,
+    # FieldType.union: 0,
+    # FieldType.struct: 0,
+    FieldType.float16: 0.0,
+    FieldType.float32: 0.0,
+    FieldType.float64: 0.0,
+    FieldType.float128: 0.0,
+    FieldType.float: 0.0,
+    FieldType.double: 0.0,
+
+    FieldType.uint64: 0,
+    FieldType.int64: 0,
+    FieldType.ulong: 0,
+    FieldType.long: 0,
+    FieldType.uint32: 0,
+    FieldType.int32: 0,
+    FieldType.uint: 0,
+    FieldType.int: 0,
+    FieldType.uint16: 0,
+    FieldType.int16: 0,
+    FieldType.ushort: 0,
+    FieldType.short: 0,
+    FieldType.uint8: 0,
+    FieldType.int8: 0,
+    FieldType.ubyte: 0,
+    FieldType.byte: 0,
+    FieldType.boolean: False,
+}

--- a/caproto/pva/_broadcaster.py
+++ b/caproto/pva/_broadcaster.py
@@ -30,11 +30,20 @@ class Broadcaster:
     our_role : CLIENT or SERVER
         Our role.
 
+    response_addr : (addr, port)
+        The desired response address for search replies.  The address may be
+        '0.0.0.0' as an indicator to reply to the IP-layer defined source
+        address of the packet.
+
     port : int
         UDP socket port for responses
 
     endian : LITTLE_ENDIAN or BIG_ENDIAN
-        Default is SYS_ENDIAN
+        Default is SYS_ENDIAN.
+
+    guid : str, optional
+        The globally unique identifier for responses to search requests.  Must
+        be 12 characters long.
     """
     def __init__(self,
                  our_role: Role,
@@ -58,6 +67,11 @@ class Broadcaster:
 
         self.response_addr = response_addr
         self.guid = guid or utils.new_guid()
+
+        if len(self.guid) != 12:
+            raise ValueError(
+                f'GUID must be 12 characters long. Got: {self.guid}'
+            )
 
         if our_role is CLIENT:
             self.their_role = SERVER

--- a/caproto/pva/_broadcaster.py
+++ b/caproto/pva/_broadcaster.py
@@ -18,7 +18,7 @@ from ._utils import CLIENT, SERVER, CaprotoValueError, Role
 
 class Broadcaster:
     """
-    An object encapsulating the state of one CA UDP connection.
+    An object encapsulating the state of one PVA UDP connection.
 
     It is a companion to a UDP socket managed by a client or server
     implementation. All data received over the socket should be passed to

--- a/caproto/pva/_broadcaster.py
+++ b/caproto/pva/_broadcaster.py
@@ -1,0 +1,228 @@
+"""
+This module contains only the Broadcaster object, encapsulating the state of
+one pvAccess UDP connection, intended to be used as a companion to a UDP
+socket provided by a client or server implementation.
+"""
+
+import logging
+import typing
+
+from . import _utils as utils
+from ._core import BIG_ENDIAN, LITTLE_ENDIAN, SYS_ENDIAN, UserFacingEndian
+from ._messages import (SearchFlags, SearchRequest, SearchRequestBE,
+                        SearchRequestLE, SearchResponse, SearchResponseBE,
+                        SearchResponseLE, read_datagram)
+# from ._state import get_exception
+from ._utils import CLIENT, SERVER, CaprotoValueError, Role
+
+
+class Broadcaster:
+    """
+    An object encapsulating the state of one CA UDP connection.
+
+    It is a companion to a UDP socket managed by a client or server
+    implementation. All data received over the socket should be passed to
+    :meth:`recv`. Any data sent over the socket should first be passed through
+    :meth:`send`.
+
+    Parameters
+    ----------
+    our_role : CLIENT or SERVER
+        Our role.
+
+    port : int
+        UDP socket port for responses
+
+    endian : LITTLE_ENDIAN or BIG_ENDIAN
+        Default is SYS_ENDIAN
+    """
+    def __init__(self,
+                 our_role: Role,
+                 response_addr: typing.Tuple[str, int],
+                 endian: UserFacingEndian = SYS_ENDIAN,
+                 guid: str = None,
+                 ):
+        if our_role not in (SERVER, CLIENT):
+            raise CaprotoValueError("role must be caproto.SERVER or "
+                                    "caproto.CLIENT")
+        self.our_role = our_role
+        self.endian = endian
+        if endian == LITTLE_ENDIAN:
+            self.SearchRequest = SearchRequestLE
+            self.SearchResponse = SearchResponseLE
+        elif endian == BIG_ENDIAN:
+            self.SearchRequest = SearchRequestBE
+            self.SearchResponse = SearchResponseBE
+        else:
+            raise ValueError('Invalid endian setting')
+
+        self.response_addr = response_addr
+        self.guid = guid or utils.new_guid()
+
+        if our_role is CLIENT:
+            self.their_role = SERVER
+            abbrev = 'cli'  # just for logger
+        else:
+            self.their_role = CLIENT
+            abbrev = 'srv'
+        self.unanswered_searches = {}  # map search id (cid) to name
+        # Unlike VirtualCircuit and Channel, there is very little state to
+        # track for the Broadcaster. We don't need a full state machine.
+        self._sequence_id_counter = utils.ThreadsafeCounter(
+        )
+        self._search_id_counter = utils.ThreadsafeCounter(
+            dont_clash_with=self.unanswered_searches
+        )
+        logger_name = f"{abbrev}.bcast"
+        self.log = logging.getLogger(logger_name)
+
+    def send(self, *commands):
+        """
+        Convert one or more high-level Commands into bytes that may be
+        broadcast together in one UDP datagram. Update our internal
+        state machine.
+
+        Parameters
+        ----------
+        *commands :
+            any number of :class:`Message` objects
+
+        Returns
+        -------
+        bytes_to_send : bytes
+            bytes to send over a socket
+        """
+        bytes_to_send = b''
+        self.log.debug("Serializing %d commands into one datagram",
+                       len(commands))
+        for i, command in enumerate(commands):
+            self.log.debug("%d of %d %r", 1 + i, len(commands), command)
+            self._process_command(self.our_role, command)
+            bytes_to_send += bytes(command)
+        return bytes_to_send
+
+    def recv(self, byteslike, address):
+        """
+        Parse commands from a UDP datagram.
+
+        When the caller is ready to process the commands, each command should
+        first be passed to :meth:`Broadcaster.process_command` to validate it
+        against the protocol and update the Broadcaster's state.
+
+        Parameters
+        ----------
+        byteslike : bytes-like
+        address : tuple
+            ``(host, port)`` as a string and an integer respectively
+
+        Returns
+        -------
+        commands : list
+        """
+        self.log.debug("Received datagram from %r with %d bytes.",
+                       address, len(byteslike))
+
+        deserialized = read_datagram(
+            byteslike, address, role=self.their_role,
+            fixed_byte_order=LITTLE_ENDIAN)
+        return deserialized.data
+
+    def process_commands(self, commands):
+        """
+        Update internal state machine and raise if protocol is violated.
+
+        Received commands should be passed through here before any additional
+        processing by a server or client layer.
+        """
+        for command in commands:
+            self._process_command(self.their_role, command)
+
+    def _process_command(self, role, command):
+        """
+        All comands go through here.
+
+        Parameters
+        ----------
+        role : ``CLIENT`` or ``SERVER``
+        command : Message
+        """
+        # All commands go through here.
+        if isinstance(command, SearchRequest):
+            for info in command.channels.items():
+                id_ = info['id']
+                channel_name = info['channel_name']
+                self.unanswered_searches[id_] = channel_name
+        elif isinstance(command, SearchResponse):
+            for cid in command.search_instance_ids:
+                self.unanswered_searches.pop(cid, None)
+
+    # CONVENIENCE METHODS
+
+    def search(self, pvs):
+        """
+        Generate a valid :class:`SearchRequest`
+
+        Parameters
+        ----------
+        pvs : list
+            PV name list.
+
+        Returns
+        -------
+        pv_to_cid, SearchRequest
+        """
+        pv_to_cid = {pv: self._search_id_counter() for pv in pvs}
+
+        seq_id = self._sequence_id_counter()
+
+        req = self.SearchRequest(
+            sequence_id=seq_id,
+            flags=SearchFlags.broadcast,
+            # (SearchFlags.reply_required | SearchFlags.broadcast),
+            response_address=self.response_addr[0],
+            response_port=self.response_addr[1],
+            protocols=['tcp'],
+            channels=[{'id': search_id, 'channel_name': pv}
+                      for pv, search_id in pv_to_cid.items()]
+        )
+
+        return pv_to_cid, req
+
+    def search_response(self,
+                        pv_to_cid: typing.Dict[str, int],
+                        *,
+                        protocol: str = 'tcp',
+                        guid: str = None
+                        ) -> SearchResponse:
+        """
+        Generate a valid :class:`SearchResponse`
+
+        Parameters
+        ----------
+        pv_to_cid : dict
+            A mapping of {pv: cid}.
+
+        protocol : str, optional
+            Defaults to 'tcp'.
+
+        guid : str, optional
+            Override the Broadcaster guid.
+
+        Returns
+        -------
+        SearchResponse
+        """
+        seq_id = self._sequence_id_counter()
+        return self.SearchResponse(
+            guid=[ord(c) for c in (guid or self.guid)],
+            sequence_id=seq_id,
+            server_address=self.response_addr[0],
+            server_port=self.response_addr[1],
+            protocol=protocol,
+            search_count=len(pv_to_cid),
+            search_instance_ids=list(pv_to_cid.values()),
+            found=len(pv_to_cid),  # hmm
+        )
+
+    def disconnect(self):
+        ...

--- a/caproto/pva/_circuit.py
+++ b/caproto/pva/_circuit.py
@@ -1,0 +1,816 @@
+# A connection in caproto V3 is referred to as a VirtualCircuit. Let's just
+# copy that nomenclature for now.
+import dataclasses
+import logging
+import typing
+
+from .. import pva
+from .._log import ComposableLogAdapter
+from .._utils import ThreadsafeCounter
+from ._core import SYS_ENDIAN
+from ._messages import (AcknowledgeMarker, ApplicationCommands,
+                        ChannelDestroyRequest, ChannelDestroyResponse,
+                        ChannelFieldInfoRequest, ChannelFieldInfoResponse,
+                        ChannelGetRequest, ChannelGetResponse,
+                        ChannelMonitorRequest, ChannelMonitorResponse,
+                        ChannelProcessRequest, ChannelProcessResponse,
+                        ChannelPutGetRequest, ChannelPutGetResponse,
+                        ChannelPutRequest, ChannelPutResponse,
+                        ConnectionValidatedResponse,
+                        ConnectionValidationRequest,
+                        ConnectionValidationResponse, CreateChannelRequest,
+                        CreateChannelResponse, EndianSetting, MessageBase,
+                        MessageFlags, MessageHeaderBE, MessageHeaderLE,
+                        MonitorSubcommands, SetByteOrder, SetMarker,
+                        Subcommands, _StatusBase, messages,
+                        read_from_bytestream)
+# from ._pvrequest import PVRequestStruct
+from ._state import ChannelState, CircuitState, RequestState, get_exception
+from ._utils import (CLEAR_SEGMENTS, CLIENT, DISCONNECTED, NEED_DATA, SERVER,
+                     CaprotoError, CaprotoRuntimeError, Role)
+
+
+class VirtualCircuit:
+    """
+    An object encapulating the state of one CA client--server connection.
+
+    It is a companion to a TCP socket managed by the user. All data
+    received over the socket should be passed to :meth:`recv`. Any data sent
+    over the socket should first be passed through :meth:`send`.
+
+    Parameters
+    ----------
+    our_role : CLIENT or SERVER
+    address : tuple
+        ``(host, port)`` as a string and an integer respectively
+    priority : integer or None
+        QOS priority
+    """
+    def __init__(self, our_role, address, priority):
+        self.log = logging.getLogger('caproto.circ')
+        self.our_role = our_role
+        if our_role is CLIENT:
+            self.their_role = SERVER
+        else:
+            self.their_role = CLIENT
+        self.our_address = None
+        self.address = address
+        self._priority = None
+        self.channels = {}  # map cid to Channel
+        self.states = CircuitState(self.channels)
+        self._data = bytearray()
+        self._segment_state = []
+        self.channels_sid = {}  # map sid to Channel
+        self._ioids = {}  # map ioid to Channel
+        self.event_add_commands = {}  # map subscriptionid to EventAdd command
+        # There are only used by the convenience methods, to auto-generate ids.
+        self._channel_id_counter = ThreadsafeCounter(dont_clash_with=self.channels)
+        self._ioid_counter = ThreadsafeCounter(dont_clash_with=self._ioids)
+        self._sub_counter = ThreadsafeCounter(dont_clash_with=self.event_add_commands)
+        # A fixed byte order, required by the server
+        self.our_order = SYS_ENDIAN
+        self.their_order = None
+        self.fixed_recv_order = None
+        self.messages = None
+        if priority is not None:
+            self.priority = priority
+        self.cache = pva.CacheContext()
+
+    @property
+    def priority(self):
+        return self._priority
+
+    @priority.setter
+    def priority(self, priority):
+        if self._priority is not None:
+            raise CaprotoRuntimeError('Cannot update priority after already set')
+
+        # A server-side circuit does not get to know its priority until after
+        # instantiation, so we need a setter.
+        self._priority = priority
+
+    def set_byte_order(self, endian_setting: EndianSetting) -> SetByteOrder:
+        """
+        Generate a valid :class:`SetByteOrder`.
+
+        Returns
+        -------
+        SetByteOrder
+        """
+        return SetByteOrder(endian_setting)
+
+    def acknowledge_marker(self) -> AcknowledgeMarker:
+        """
+        Generate a valid :class:`AcknowledgeMarker`.
+
+        Returns
+        -------
+        AcknowledgeMarker
+        """
+        return AcknowledgeMarker()
+
+    def validate_connection(self,
+                            client_buffer_size: int,
+                            client_registry_size: int,
+                            connection_qos: int,
+                            auth_nz: str = 'ca',
+                            auth_args: dict = None,
+                            ) -> ConnectionValidationResponse:
+        """
+        Generate a valid :class:`_ConnectionValidationResponse`.
+
+        Parameters
+        ----------
+        client_buffer_size : int
+            Client buffer size.
+
+        client_registry_size : int
+            Client registry size.
+
+        connection_qos  : int
+            Connection QOS value.
+
+        auth_nz  : str, optional
+            Authorization string, defaults to 'ca'.  Caller must confirm that
+            the server supports the given authorization method prior to
+            specifying it.
+
+        Returns
+        -------
+        ConnectionValidationResponse
+        """
+        cls = self.messages[ApplicationCommands.CONNECTION_VALIDATION]
+
+        return cls(client_buffer_size=client_buffer_size,
+                   client_registry_size=client_registry_size,
+                   connection_qos=connection_qos,
+                   auth_nz=auth_nz,
+                   **(auth_args or {}),
+                   )
+
+    @property
+    def host(self) -> str:
+        '''Peer host name'''
+        return self.address[0]
+
+    @property
+    def port(self) -> int:
+        '''Port number'''
+        return self.address[1]
+
+    def __repr__(self):
+        return (f"<VirtualCircuit host={self.host} port={self.port} "
+                f"our_role={self.our_role}> logger_name={self.log.name}>")
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)
+
+    def __hash__(self):
+        return hash((self.address, self.our_role))
+
+    def send(self, *commands, extra: typing.Dict) -> typing.List[bytes]:
+        """
+        Convert one or more high-level Commands into buffers of bytes that may
+        be broadcast together in one TCP packet. Update our internal
+        state machine.
+
+        Parameters
+        ----------
+        *commands :
+            any number of :class:`Message` objects
+
+        extra : dict or None
+            Used for logging purposes. This is merged into the ``extra``
+            parameter passed to the logger to provide information like ``'pv'``
+            to the logger.
+
+        Returns
+        -------
+        buffers_to_send : list
+            list of buffers to send over a socket
+        """
+        buffers_to_send = []
+        tags = {'their_address': self.address,
+                'our_address': self.our_address,
+                'direction': '--->>>',
+                'role': repr(self.our_role)}
+        tags.update(extra or {})
+        for command in commands:
+            self._process_command(self.our_role, command)
+            self.log.debug("Serializing %r", command, extra=tags)
+
+            if isinstance(command, (SetByteOrder, SetMarker, AcknowledgeMarker)):
+                buffers_to_send.append(memoryview(command))
+            else:
+                if command._ENDIAN == pva.LITTLE_ENDIAN:
+                    header_cls = MessageHeaderLE
+                    endian_flag = pva.MessageFlags.LITTLE_ENDIAN
+                else:
+                    header_cls = MessageHeaderBE
+                    endian_flag = pva.MessageFlags.BIG_ENDIAN
+
+                payload = memoryview(command.serialize(cache=self.cache))
+                header = header_cls(
+                    flags=(pva.MessageFlags.APP_MESSAGE |
+                           pva.MessageFlags.FROM_CLIENT |
+                           endian_flag),
+                    command=command.ID,
+                    payload_size=len(payload)
+                )
+
+                command.header = header
+                buffers_to_send.append(memoryview(header))
+                buffers_to_send.append(payload)
+
+        return buffers_to_send
+
+    def recv(self, *buffers
+             ) -> typing.Generator[typing.Tuple[typing.List, int],
+                                   None, None]:
+        """
+        Parse commands from buffers received over TCP.
+
+        When the caller is ready to process the commands, each command should
+        first be passed to :meth:`VirtualCircuit.process_command` to validate
+        it against the protocol and update the VirtualCircuit's state.
+
+        Parameters
+        ----------
+        *buffers :
+            any number of bytes-like buffers
+
+        Yields
+        ------
+        command : Message
+            The command/message.
+
+        num_bytes_needed : int
+            Number of bytes needed for the next message.
+        """
+        total_received = sum(len(byteslike) for byteslike in buffers)
+        if total_received == 0:
+            self.log.debug('Zero-length recv; sending disconnect notification')
+            yield DISCONNECTED, None
+            return
+
+        self.log.debug("Received %d bytes.", total_received)
+        self._data += b''.join(buffers)
+
+        while True:
+            decoded, num_bytes_needed, segmented = read_from_bytestream(
+                self._data, self.their_role, segment_state=self._segment_state,
+                byte_order=self.fixed_recv_order, cache=self.cache)
+
+            len_data = len(self._data)
+            command, self._data, bytes_consumed = decoded
+
+            if isinstance(self._data, memoryview):
+                self._data = bytearray(self._data)
+
+            if segmented is CLEAR_SEGMENTS:
+                self._segment_state.clear()
+            elif segmented is not None:
+                self._segment_state.append(segmented)
+                continue
+
+            if command is not NEED_DATA:
+                self.log.debug("%d bytes -> %r", bytes_consumed, command)
+                yield command, None
+            else:
+                self.log.debug("%d bytes are cached. Need more bytes to parse "
+                               "next command.", len_data)
+                yield command, num_bytes_needed
+
+    def process_command(self, command: MessageBase):
+        """
+        Update internal state machine and raise if protocol is violated.
+
+        Received commands should be passed through here before any additional
+        processing by a server or client layer.
+        """
+        self._process_command(self.their_role, command)
+
+    def _process_command(self, role: Role, command: MessageBase):
+        """
+        All commands go through here.
+
+        Parameters
+        ----------
+        role : ``CLIENT`` or ``SERVER``
+        command : Message
+        """
+        if command is DISCONNECTED:
+            self.states.disconnect()
+            return
+
+        # Filter for Commands that are pertinent to a specific Channel, as
+        # opposed to the Circuit as a whole:
+        if isinstance(command, (CreateChannelRequest, CreateChannelResponse,
+                                ChannelFieldInfoRequest, ChannelFieldInfoResponse,
+                                ChannelDestroyRequest, ChannelDestroyResponse,
+                                ChannelGetRequest, ChannelGetResponse, ChannelMonitorRequest,
+                                ChannelMonitorResponse, ChannelPutRequest, ChannelPutResponse,
+                                ChannelProcessRequest, ChannelProcessResponse,
+                                ChannelPutGetRequest, ChannelPutGetResponse)):
+            if isinstance(command, CreateChannelRequest):
+                for info in command.channels:
+                    cid = info['id']
+                    chan = self.channels[cid]
+                    # TODO: only one supported now - also by C++ server, AFAIR
+                    break
+            else:
+                try:
+                    if hasattr(command, 'client_chid'):
+                        cid = command.client_chid
+                        chan = self.channels[cid]
+                    elif hasattr(command, 'server_chid'):
+                        chan = self.channels_sid[command.server_chid]
+                    else:
+                        ioid = command.ioid
+                        chan = self._ioids[ioid]['channel']
+                except KeyError:
+                    err = get_exception(self.our_role, command)
+                    raise err("Unknown ID")
+
+            # Update the state machine of the pertinent Channel.  If this is
+            # not a valid command, the state machine will raise here. Stash the
+            # state transitions in a local var, run the callbacks at the end.
+            transitions = chan.process_command(command)
+            ioid_info = None
+
+            try:
+                ioid = command.ioid
+            except AttributeError:
+                ioid = None
+            else:
+                try:
+                    ioid_info = self._ioids[ioid]
+                except KeyError:
+                    monitor = isinstance(command, (ChannelMonitorRequest,
+                                                   ChannelMonitorResponse))
+                    ioid_info = dict(
+                        channel=chan,
+                        state=RequestState(monitor)
+                    )
+                    self._ioids[ioid] = ioid_info
+
+            subcommand = getattr(command, 'subcommand', None)
+
+            if subcommand is not None:
+                ioid_state = ioid_info['state']
+                ioid_state.process_subcommand(command.subcommand)
+
+            if isinstance(command, CreateChannelResponse):
+                self.channels_sid[command.server_chid] = chan
+            elif isinstance(command, ChannelFieldInfoRequest):
+                ...
+            elif isinstance(command, ChannelFieldInfoResponse):
+                self._ioids.pop(ioid)
+            elif isinstance(command, (ChannelGetRequest,
+                                      ChannelMonitorRequest)):
+                ...
+            elif isinstance(command, ChannelPutResponse):
+                if command.is_successful:
+                    if command.subcommand == Subcommands.INIT:
+                        interface = command.put_structure_if
+                        self.cache.ioid_interfaces[ioid] = interface
+                    elif command.subcommand == Subcommands.DEFAULT:
+                        ...
+            elif isinstance(command, ChannelGetResponse):
+                if command.is_successful:
+                    if command.subcommand == Subcommands.INIT:
+                        interface = command.pv_structure_if
+                        self.cache.ioid_interfaces[ioid] = interface
+                    elif command.subcommand == Subcommands.GET:
+                        ...
+            elif isinstance(command, ChannelMonitorResponse):
+                if command.subcommand == Subcommands.INIT:
+                    if command.is_successful:
+                        interface = command.pv_structure_if
+                        self.cache.ioid_interfaces[ioid] = interface
+                elif command.subcommand == Subcommands.DEFAULT:
+                    ...
+
+            if subcommand == Subcommands.DESTROY:
+                self._ioids.pop(ioid)
+                self.cache.ioid_interfaces.pop(ioid)
+
+            # We are done. Run the Channel state change callbacks.
+            for transition in transitions:
+                chan.state_changed(*transition)
+        else:
+            # Otherwise, this Command affects the state of this circuit, not a
+            # specific Channel.
+            if isinstance(command, SetByteOrder):
+                fixed = (command.byte_order_setting == EndianSetting.use_server_byte_order)
+                if self.our_role == SERVER:
+                    self.our_order = command.byte_order
+                    self.their_order = None
+                    self.fixed_recv_order = None
+                    self.messages = messages[(self.our_order,
+                                              MessageFlags.FROM_SERVER)]
+                else:
+                    self.our_order = command.byte_order
+                    self.their_order = command.byte_order
+                    self.fixed_recv_order = (self.their_order if fixed else None)
+                    if fixed:
+                        self.log.debug('Using fixed byte order for server messages'
+                                       ': %s', self.fixed_recv_order.name)
+                    else:
+                        self.log.debug('Using byte order from individual messages.')
+                    self.messages = messages[(self.our_order,
+                                              MessageFlags.FROM_CLIENT)]
+            elif isinstance(command, ConnectionValidationRequest):
+                ...
+            elif isinstance(command, ConnectionValidationResponse):
+                ...
+            elif isinstance(command, ConnectionValidatedResponse):
+                ...
+
+            if isinstance(command, _StatusBase) and command.has_message:
+                self.log.debug(
+                    'Command status returned %s (message=%s) (call tree=%s)',
+                    command.name, command.message, command.call_tree
+                )
+
+            # Run the circuit's state machine.
+            self.states.process_command_type(self.our_role, command)
+            self.states.process_command_type(self.their_role, command)
+
+    def disconnect(self):
+        """
+        Notify all channels on this circuit that they are disconnected.
+
+        Clients should call this method when a TCP connection is lost.
+        """
+        return DISCONNECTED
+
+    def new_channel_id(self):
+        "Return a valid value for a cid or sid."
+        # Return the next sequential unused id. Wrap back to 0 on overflow.
+        return self._channel_id_counter()
+
+    def new_subscriptionid(self):
+        """
+        This is used by the convenience methods to obtain an unused integer ID.
+        It does not update any important state.
+        """
+        # Return the next sequential unused id. Wrap back to 0 on overflow.
+        return self._sub_counter()
+
+    def new_ioid(self):
+        """
+        This is used by the convenience methods to obtain an unused integer ID.
+        It does not update any important state.
+        """
+        # Return the next sequential unused id. Wrap back to 0 on overflow.
+        return self._ioid_counter()
+
+
+class _BaseChannel:
+    # Base class for ClientChannel and ServerChannel, which add convenience
+    # methods for composing requests and repsonses, respectively. All of the
+    # important code is here in the base class.
+    def __init__(self, name, circuit, cid=None):
+        tags = {'pv': name,
+                'their_address': circuit.address,
+                'role': repr(circuit.our_role)}
+        self.log = ComposableLogAdapter(logging.getLogger('caproto.ch'), tags)
+        self.endian = None  # TODO
+        self.name = name
+        self.circuit = circuit
+        if cid is None:
+            cid = self.circuit.new_channel_id()
+        self.cid = cid
+        self.circuit.channels[self.cid] = self
+        self.states = ChannelState(self.circuit.states)
+        # These will be set when the circuit processes CreateChanResponse.
+        self.interface = None
+        self.sid = None
+        self.access_rights = None
+        self.ioid_interfaces = {}
+
+    @property
+    def subscriptions(self):
+        """
+        Get cached EventAdd commands for this channel's active subscriptions.
+        """
+        return {k: v for k, v in self.circuit.event_add_commands.items()
+                if v.sid == self.sid}
+
+    def state_changed(self, role, old_state, new_state, command):
+        '''State changed callback for subclass usage'''
+        pass
+
+    def process_command(self, command):
+        if isinstance(command, CreateChannelResponse):
+            self.sid = command.server_chid
+        elif isinstance(command, ChannelFieldInfoResponse):
+            self.field_info = command.field_if
+            for line in self.field_info.summary().splitlines():
+                self.circuit.log.debug('[%s] %s', self.name, line)
+
+        transitions = []
+        for role in (self.circuit.our_role, self.circuit.their_role):
+            initial_state = self.states[role]
+            try:
+                self.states.process_command_type(role, command)
+            except CaprotoError as ex:
+                ex.channel = self
+                raise
+
+            new_state = self.states[role]
+            # Assemble arguments needed by state_changed, to be called later.
+            if initial_state is not new_state:
+                transition = (role, initial_state, new_state, command)
+                transitions.append(transition)
+        return transitions
+
+
+class ClientChannel(_BaseChannel):
+    """An object encapsulating the state of the EPICS Channel on a Client.
+
+    A ClientChannel may be created in one of two ways:
+    (1) The user instantiates a ClientChannel with a name, server address,
+    and optional cid. The server address is used to assign the ClientChannel to
+    a VirtualCircuit. If no cid is given, a unique one is allocated by the
+    VirtualCircuit.
+    (2) A VirtualCircuit processes a CreateChanRequest that refers to a cid
+    that it has not yet seen. A ClientChannel will be automatically
+    instantiated with the name and cid indicated that command and the address
+    of that VirtualCircuit. It can be accessed in the circuit's
+    ``channels`` attribute.
+
+    Parameters
+    ----------
+    name : string
+        Channnel name (PV)
+    circuit : VirtualCircuit
+    cid : integer, optional
+    """
+
+    def create(self):
+        """
+        Generate a valid :class:`CreateChanRequest`.
+
+        Returns
+        -------
+        CreateChanRequest
+        """
+        create_cls = self.circuit.messages[ApplicationCommands.CREATE_CHANNEL]
+        return create_cls(
+            count=1,
+            channels=[{'id': self.cid, 'channel_name': self.name}]
+        )
+
+    def disconnect(self):
+        """
+        Generate a valid :class:`ClearChannelRequest`.
+
+        Returns
+        -------
+        ClearChannelRequest
+        """
+        if self.sid is None:
+            return
+        cls = self.circuit.messages[ApplicationCommands.DESTROY_CHANNEL]
+        return cls(client_chid=self.cid, server_chid=self.sid)
+
+    def read_interface(self, *, ioid=None, sub_field_name=''):
+        """
+        Generate a valid :class:`ChannelFieldInfoRequest`.
+        """
+
+        if ioid is None:
+            ioid = self.circuit.new_ioid()
+        cls = self.circuit.messages[ApplicationCommands.GET_FIELD]
+        return cls(server_chid=self.sid,
+                   ioid=ioid,
+                   sub_field_name=sub_field_name,
+                   )
+
+    def read_init(self, *, ioid=None, pvrequest: str = 'field()'):
+        """
+        Generate a valid :class:`ChannelGetRequest`.
+
+        Parameters
+        ----------
+        ioid
+        pvrequest_if
+        pvrequest
+
+        Returns
+        -------
+        ChannelGetRequest
+        """
+        if ioid is None:
+            ioid = self.circuit.new_ioid()
+
+        cls = self.circuit.messages[ApplicationCommands.GET]
+        return cls(server_chid=self.sid,
+                   ioid=ioid,
+                   subcommand=Subcommands.INIT,
+                   pv_request=pvrequest,
+                   )
+
+    def read(self, ioid, interface):
+        """
+        Generate a valid :class:`ChannelGetRequest`.
+
+        Parameters
+        ----------
+        ioid
+
+        Returns
+        -------
+        ChannelGetRequest
+        """
+        # TODO state machine for get requests?
+        cls = self.circuit.messages[ApplicationCommands.GET]
+        return cls(server_chid=self.sid,
+                   ioid=ioid,
+                   subcommand=Subcommands.GET,
+                   interface=dict(pv_data=interface),
+                   )
+
+    def subscribe_init(self, *,
+                       ioid=None,
+                       pvrequest: str = 'field(value)',
+                       queue_size=None):
+        """
+        Generate a valid :class:`...`.
+
+        Parameters
+        ----------
+        ioid
+        pvrequest_if
+        pvrequest
+
+        Returns
+        -------
+        ChannelMonitorRequest
+        """
+        if ioid is None:
+            ioid = self.circuit.new_ioid()
+
+        cls = self.circuit.messages[ApplicationCommands.MONITOR]
+        return cls(server_chid=self.sid,
+                   ioid=ioid,
+                   subcommand=Subcommands.INIT,
+                   pv_request=pvrequest,
+                   )
+
+    def subscribe_control(self, ioid, *, subcommand):
+        """
+        Generate a valid ...
+
+        Parameters
+        ----------
+        ioid
+        subcommand : MonitorSubcommands
+            PIPELINE, START, STOP, DESTROY
+
+        Returns
+        -------
+        ChannelMonitorRequest
+        """
+        assert subcommand in MonitorSubcommands
+        cls = self.circuit.messages[ApplicationCommands.MONITOR]
+        return cls(server_chid=self.sid,
+                   ioid=ioid,
+                   subcommand=subcommand,
+                   )
+
+    def write_init(self, *,
+                   ioid: int = None,
+                   pvrequest: str = 'field(value)',
+                   queue_size=None) -> ChannelPutRequest:
+        """
+        Generate a valid :class:`ChannelPutRequest` (INIT).
+
+        Parameters
+        ----------
+        ioid : int, optional
+            The I/O identifier.  Generated if needed.
+        """
+        if ioid is None:
+            ioid = self.circuit.new_ioid()
+
+        cls = self.circuit.messages[ApplicationCommands.PUT]
+        return cls(server_chid=self.sid,
+                   ioid=ioid,
+                   subcommand=Subcommands.INIT,
+                   pv_request=pvrequest,
+                   )
+
+    def write(self, ioid, interface, dataclass, bitset) -> ChannelPutRequest:
+        """
+        Generate a valid :class:`ChannelPutRequest`.
+        """
+        cls = self.circuit.messages[ApplicationCommands.PUT]
+        if not isinstance(dataclass, dict):
+            value = dataclasses.asdict(dataclass)
+
+        if bitset is None:
+            raise ValueError(
+                'Must supply a bitset; if all fields are to '
+                'be written BitSet({0}) may be used.'
+            )
+
+        put_data = {
+            'data': value,
+            'interface': interface,
+            'bitset': bitset,
+        }
+        ret = cls(server_chid=self.sid,
+                  ioid=ioid,
+                  subcommand=Subcommands.DEFAULT,
+                  put_data=put_data,
+                  )
+        return ret
+
+
+class ServerChannel(_BaseChannel):
+    """
+    A server-side Channel.
+
+    (TODO no server stuff yet)
+    """
+
+#    def create(self, native_data_type, native_data_count, sid):
+#        """
+#        Generate a valid :class:`CreateChanResponse`.
+#
+#        Parameters
+#        ----------
+#
+#        Returns
+#        -------
+#        """
+#
+#    def create_fail(self):
+#        """
+#        Generate a valid :class:`CreateChFailResponse`.
+#
+#        Returns
+#        -------
+#        CreateChFailResponse
+#        """
+#
+#    def read(self, data, ioid, data_type=None, data_count=None, status=1, *,
+#             metadata=None):
+#        """
+#        Generate a valid :class:`ReadNotifyResponse`.
+#
+#        Parameters
+#        ----------
+#        data : tuple, ``numpy.ndarray``, ``array.array``, or bytes
+#        ioid : integer
+#
+#        Returns
+#        -------
+#        """
+#
+#    def write(self, ioid, data_type=None, data_count=None, status=1):
+#        """
+#        Generate a valid :class:`WriteNotifyResponse`.
+#
+#        Parameters
+#        ----------
+#        ioid : integer
+#
+#        Returns
+#        -------
+#        """
+#
+#    def subscribe(self, data, subscriptionid, data_type=None,
+#                  data_count=None, status_code=32, metadata=None):
+#        """
+#        Generate a valid :class:`EventAddResponse`.
+#
+#        Parameters
+#        ----------
+#
+#        Returns
+#        -------
+#        """
+#
+#    def unsubscribe(self, subscriptionid, data_type=None):
+#        """
+#        Generate a valid :class:`EventCancelResponse`.
+#
+#        Parameters
+#        ----------
+#
+#        Returns
+#        -------
+#        """
+#
+#    def disconnect(self):
+#        """
+#        Generate a valid :class:`ServerDisconnResponse`.
+#
+#        Returns
+#        -------
+#        ServerDisconnResponse
+#        """

--- a/caproto/pva/_circuit.py
+++ b/caproto/pva/_circuit.py
@@ -484,7 +484,7 @@ class _BaseChannel:
         self.cid = cid
         self.circuit.channels[self.cid] = self
         self.states = ChannelState(self.circuit.states)
-        # These will be set when the circuit processes CreateChanResponse.
+        # These will be set when the circuit processes CreateChannelResponse..
         self.interface = None
         self.sid = None
         self.access_rights = None
@@ -535,7 +535,7 @@ class ClientChannel(_BaseChannel):
     and optional cid. The server address is used to assign the ClientChannel to
     a VirtualCircuit. If no cid is given, a unique one is allocated by the
     VirtualCircuit.
-    (2) A VirtualCircuit processes a CreateChanRequest that refers to a cid
+    (2) A VirtualCircuit processes a CreateChannelRequest that refers to a cid
     that it has not yet seen. A ClientChannel will be automatically
     instantiated with the name and cid indicated that command and the address
     of that VirtualCircuit. It can be accessed in the circuit's
@@ -549,13 +549,13 @@ class ClientChannel(_BaseChannel):
     cid : integer, optional
     """
 
-    def create(self):
+    def create(self) -> CreateChannelRequest:
         """
-        Generate a valid :class:`CreateChanRequest`.
+        Generate a valid :class:`CreateChannelRequest`.
 
         Returns
         -------
-        CreateChanRequest
+        CreateChannelRequest
         """
         create_cls = self.circuit.messages[ApplicationCommands.CREATE_CHANNEL]
         return create_cls(
@@ -563,20 +563,21 @@ class ClientChannel(_BaseChannel):
             channels=[{'id': self.cid, 'channel_name': self.name}]
         )
 
-    def disconnect(self):
+    def disconnect(self) -> ChannelDestroyRequest:
         """
-        Generate a valid :class:`ClearChannelRequest`.
+        Generate a valid :class:`ChannelDestroyRequest`.
 
         Returns
         -------
-        ClearChannelRequest
+        ChannelDestroyRequest
         """
         if self.sid is None:
             return
         cls = self.circuit.messages[ApplicationCommands.DESTROY_CHANNEL]
         return cls(client_chid=self.cid, server_chid=self.sid)
 
-    def read_interface(self, *, ioid=None, sub_field_name=''):
+    def read_interface(self, *, ioid=None,
+                       sub_field_name='') -> ChannelFieldInfoRequest:
         """
         Generate a valid :class:`ChannelFieldInfoRequest`.
         """
@@ -589,7 +590,9 @@ class ClientChannel(_BaseChannel):
                    sub_field_name=sub_field_name,
                    )
 
-    def read_init(self, *, ioid=None, pvrequest: str = 'field()'):
+    def read_init(self, *, ioid=None,
+                  pvrequest: str = 'field()'
+                  ) -> ChannelGetRequest:
         """
         Generate a valid :class:`ChannelGetRequest`.
 
@@ -613,7 +616,7 @@ class ClientChannel(_BaseChannel):
                    pv_request=pvrequest,
                    )
 
-    def read(self, ioid, interface):
+    def read(self, ioid, interface) -> ChannelGetRequest:
         """
         Generate a valid :class:`ChannelGetRequest`.
 
@@ -636,7 +639,7 @@ class ClientChannel(_BaseChannel):
     def subscribe_init(self, *,
                        ioid=None,
                        pvrequest: str = 'field(value)',
-                       queue_size=None):
+                       queue_size=None) -> ChannelMonitorRequest:
         """
         Generate a valid :class:`...`.
 
@@ -660,7 +663,7 @@ class ClientChannel(_BaseChannel):
                    pv_request=pvrequest,
                    )
 
-    def subscribe_control(self, ioid, *, subcommand):
+    def subscribe_control(self, ioid, *, subcommand) -> ChannelMonitorRequest:
         """
         Generate a valid ...
 

--- a/caproto/pva/_core.py
+++ b/caproto/pva/_core.py
@@ -1,0 +1,343 @@
+import abc
+import ctypes
+import dataclasses
+import enum
+import sys
+import typing
+from dataclasses import field
+from typing import Dict, List, Optional, Union
+
+from ._utils import ChannelLifeCycle, _SimpleReprEnum
+
+if typing.TYPE_CHECKING:
+    from ._fields import BitSet, FieldDesc
+
+
+class UserFacingEndian(str, _SimpleReprEnum):
+    LITTLE_ENDIAN = '<'
+    BIG_ENDIAN = '>'
+
+
+MAX_INT32 = 2 ** 31 - 1
+PVA_SERVER_PORT, PVA_BROADCAST_PORT = 5075, 5076
+LITTLE_ENDIAN = UserFacingEndian.LITTLE_ENDIAN
+BIG_ENDIAN = UserFacingEndian.BIG_ENDIAN
+SYS_ENDIAN = (LITTLE_ENDIAN if sys.byteorder == 'little' else BIG_ENDIAN)
+QOS_PRIORITY_MASK = 0x7f
+
+
+if hasattr(typing, 'Literal'):  # 3.8
+    Endian = typing.Literal['<', '>']
+else:
+    Endian = str
+
+
+class TypeCode(enum.IntEnum):
+    """
+    Type code information for structures.
+
+    Optionally used in FieldDesc descriptions, it allows for the
+    synchronization of FieldDesc caches between client and server.
+    """
+    # No introspection data (also implies no data).
+    NULL_TYPE_CODE = 0xFF
+
+    # Serialization contains only an ID that was assigned by one of the
+    # previous FULL_WITH_ID_TYPE_CODE or FULL_TAGGED_ID_TYPE_CODE descriptions.
+    ONLY_ID_TYPE_CODE = 0xFE  # + ID
+
+    # Serialization contains an ID (that can be used later, if cached) and full
+    # interface description. Any existing definition with the same ID is
+    # overriden.
+    FULL_WITH_ID_TYPE_CODE = 0xFD  # + ID + FieldDesc
+
+    # Not implemented:
+    FULL_TAGGED_ID_TYPE_CODE = 0xFC  # + ID + tag + FieldDesc
+    # RESERVED = 0xFB to 0xE0
+    # FieldDesc FULL_TYPE_CODE = (0xDF - 0x00)
+
+
+class FieldArrayType(enum.IntEnum):
+    """
+    The field array type information, indicating whether the associated field
+    (of type :class:`FieldType`) is a scalar or array.
+    """
+    scalar = 0b00
+    fixed_array = 0b11
+    bounded_array = 0b10
+    variable_array = 0b01
+
+    @property
+    def has_field_desc_size(self):
+        'Fixed and bounded arrays have size information in FieldDesc'
+        return self.value in (FieldArrayType.fixed_array,
+                              FieldArrayType.bounded_array)
+
+    @property
+    def has_serialization_size(self):
+        'Bounded and variable arrays serialize size information'
+        return self.value in (FieldArrayType.bounded_array,
+                              FieldArrayType.variable_array)
+
+    def summary_with_size(self, size=None):
+        if size is None:
+            size = ''
+
+        if self == FieldArrayType.fixed_array:
+            return f'[{size}]'
+        if self == FieldArrayType.bounded_array:
+            return f'<{size}>'
+        if self == FieldArrayType.variable_array:
+            return f'[{size}]'
+        return ''
+
+
+class FieldDescByte(ctypes.Structure):
+    """
+    Field description first byte.
+
+    Attributes
+    ----------
+    field_type : FieldType
+        The field type information, indicating whether it's a structure,
+        string, int, union, etc.
+
+    array_type : FieldArrayType
+        The array type - scalar, variable_array, etc.
+    """
+
+    _fields_ = [
+        ('_type_specific', ctypes.c_ubyte, 3),
+        ('_array_type', ctypes.c_ubyte, 2),
+        ('_type', ctypes.c_ubyte, 3),
+    ]
+
+    def serialize(self, endian: Endian = None) -> typing.List[bytes]:
+        return [bytes(self)]
+
+    @classmethod
+    def deserialize(cls, data, endian: Endian = None) -> 'Deserialized':
+        fd = cls.from_buffer(bytearray([data[0]]))
+        return Deserialized(data=fd, buffer=data[1:], offset=1)
+
+    @property
+    def field_type(self) -> 'FieldType':
+        return FieldType((self._type_specific << 5) | self._type)
+
+    @property
+    def array_type(self) -> FieldArrayType:
+        return FieldArrayType(self._array_type)
+
+    def __repr__(self):
+        return (
+            f'{self.__class__.__name__}(field_type={self.field_type!r}, '
+            f'array_type={self.array_type!r})'
+        )
+
+    @classmethod
+    def from_field(cls, field: 'FieldDesc') -> 'FieldDescByte':
+        """Create a FieldDescByte from the given FieldDesc."""
+        return cls(field.field_type._type_specific, field.array_type,
+                   field.field_type._type)
+
+
+class FieldType(enum.IntEnum):
+    """
+    The field type information, indicating whether it's a structure, string,
+    int, union, etc.  Used in conjunction with FieldArrayType.
+    """
+    # complex_reserved1 = 11100100
+    # complex_reserved2 = 11000100
+    # complex_reserved3 = 10100100
+    # complex_reserved4 = 10000100
+    bounded_string = 0b01100100
+    string = 0b00000011
+
+    any = 0b01000100
+
+    union = 0b00100100
+    struct = 0b00000100
+
+    float16 = 0b00100010
+    float32 = 0b01000010
+    float64 = 0b01100010
+    float128 = 0b10000010
+
+    float = float32
+    double = float64
+
+    uint64 = 0b11100001
+    int64 = 0b01100001
+    ulong = uint64
+    long = int64
+
+    uint32 = 0b11000001
+    int32 = 0b01000001
+
+    uint = uint32
+    int = int32
+
+    uint16 = 0b10100001
+    int16 = 0b00100001
+
+    ushort = uint16
+    short = int16
+
+    uint8 = 0b10000001
+    int8 = 0b00000001
+
+    ubyte = uint8
+    byte = int8
+
+    boolean = 0b00000000
+
+    @property
+    def _type_specific(self) -> int:
+        return (0b11100000 & self.value) >> 5
+
+    @property
+    def _type(self) -> int:
+        return (0b111 & self.value)
+
+    @property
+    def is_complex(self) -> bool:
+        return self in {FieldType.union, FieldType.struct, FieldType.any}
+
+    @property
+    def has_value(self) -> bool:
+        'Can this field contain data directly?'
+        return self not in {FieldType.union, FieldType.struct}
+
+
+@dataclasses.dataclass
+class CacheContext:
+    """
+    Per-VirtualCircuit cache context.
+
+    Tracks Field Description information between clients and servers, and also
+    those associated with specific I/O identifiers (ioids)
+    """
+    ours: Dict[int, 'FieldDesc'] = field(default_factory=dict)
+    theirs: Dict[int, 'FieldDesc'] = field(default_factory=dict)
+    ioid_interfaces: Dict[int, 'FieldDesc'] = field(default_factory=dict)
+
+    def clear(self):
+        for dct in (self.ours, self.theirs, self.ioid_interfaces):
+            dct.clear()
+
+
+@dataclasses.dataclass
+class Deserialized:
+    """
+    Deserialization result container.
+
+    Attributes
+    ----------
+    data : object
+        The deserialized object.
+
+    buffer : bytearray
+        The remaining buffer contents, after consuming `data`.
+
+    offset : int
+        The number of bytes consumed in deserializing `data`, i.e., the offset
+        to the buffer passed in to ``deserialize()``.
+    """
+    data: object
+    buffer: bytearray
+    offset: int
+
+    SUPER_DEBUG = False
+    if SUPER_DEBUG:
+        def __post_init__(self):
+            import inspect
+            import textwrap
+            for idx in (3, 4):
+                caller = inspect.stack()[idx]
+                print(caller.filename, caller.lineno)
+                print(textwrap.dedent('\n'.join(caller.code_context)).rstrip())
+            print('------> deserialized', repr(self.data), 'next is', bytes(self.buffer)[:10], self.offset)
+
+    def __iter__(self):
+        return iter((self.data, self.buffer, self.offset))
+
+
+@dataclasses.dataclass
+class SegmentDeserialized:
+    """
+    Serialized messages may be segmented when sent over TCP with pvAccess.
+    This class contains additional deserialization information necessary to
+    track it, along with the usual :class:`Deserialized` information.
+
+    Between segments, control messages can be interspersed according to the
+    pvAccess specification.
+
+    Attributes
+    ----------
+    deserialized : Deserialized
+        Contains the deserialized message, remaining data, bytes consumed.
+
+    bytes_needed : int
+        The number of bytes needed to finish the segment.
+
+    segment_state : ChannelLifeCycle, bytes, or None
+        Segmentation control information.
+    """
+    data: Deserialized
+    bytes_needed: int
+    segment_state: Optional[Union[ChannelLifeCycle, bytes]]
+
+    def __iter__(self):
+        return iter((self.data, self.bytes_needed, self.segment_state))
+
+
+class Serializable(abc.ABC):
+    """
+    A serializable item. May be instantiated (and hold state).
+    """
+
+    @abc.abstractmethod
+    def serialize(self, endian: Endian) -> List[bytes]:
+        ...
+
+    @abc.abstractclassmethod
+    def deserialize(cls, data: bytes, *, endian: Endian) -> Deserialized:  # noqa
+        ...
+
+
+class StatelessSerializable(abc.ABC):
+    """
+    A stateless, serializable item. Instance-level data may not be used as
+    serialize and deserialize are class methods.
+    """
+
+    @abc.abstractclassmethod
+    def serialize(self, value, endian: Endian) -> List[bytes]:
+        ...
+
+    @abc.abstractclassmethod
+    def deserialize(cls, data: bytes, *, endian: Endian) -> Deserialized:  # noqa
+        ...
+
+
+class _DataSerializer(abc.ABC):
+    """ABC for DataSerializer below."""
+    @abc.abstractclassmethod
+    def serialize(cls,
+                  field: 'FieldDesc',
+                  value: typing.Any,
+                  endian: Endian,
+                  bitset: 'BitSet' = None,
+                  cache: CacheContext = None,
+                  ) -> List[bytes]:
+        ...
+
+    @abc.abstractclassmethod
+    def deserialize(cls,
+                    field: 'FieldDesc',
+                    data: bytes, *,
+                    endian: Endian,
+                    bitset: 'BitSet' = None,
+                    cache: CacheContext = None,
+                    ) -> Deserialized:
+        ...

--- a/caproto/pva/_data.py
+++ b/caproto/pva/_data.py
@@ -1,0 +1,624 @@
+import array
+import ctypes
+import functools
+import typing
+from typing import Dict, List
+
+from . import _core as core
+from ._core import (Deserialized, Endian, FieldArrayType, FieldType, TypeCode,
+                    _DataSerializer)
+from ._fields import BitSet, CacheContext, FieldDesc, SimpleField, Size, String
+from ._pvrequest import PVRequestStruct
+
+
+class SerializationFailure(Exception):
+    ...
+
+
+class DataSerializer(_DataSerializer):
+    """
+    Tracks subclasses which handle certain data types for serialization.
+    """
+
+    handlers: Dict['FieldType', _DataSerializer] = {}
+
+    def __init_subclass__(cls, handles):
+        super().__init_subclass__()
+        for handle in handles:
+            DataSerializer.handlers[handle] = cls
+
+
+class ArrayBasedDataSerializer(DataSerializer, handles={}):
+    """
+    A data serializer which works not on an element-by-element basis, but
+    rather with an array of elements.  Used for arrays of basic data types.
+    """
+
+    @classmethod
+    def deserialize(cls,
+                    field: 'FieldDesc',
+                    data: bytes, *,
+                    endian: Endian,
+                    bitset: 'BitSet' = None,
+                    cache: CacheContext = None,
+                    count: int = 1,
+                    ) -> Deserialized:
+        ...
+
+
+class StringFieldData(DataSerializer,
+                      handles={FieldType.string, FieldType.bounded_string}):
+    """
+    Data serializer for run-length encoded strings.
+
+    Wraps :class:`String` to support the :class:`DataSerializer` interface.
+    """
+
+    @classmethod
+    def serialize(cls,
+                  field: FieldDesc,
+                  value: typing.Union[str, List[str]],
+                  endian: Endian,
+                  bitset: BitSet = None,
+                  cache: CacheContext = None,
+                  ) -> List[bytes]:
+        return String.serialize(value, endian=endian)
+
+    @classmethod
+    def deserialize(cls,
+                    field: FieldDesc,
+                    data: bytes, *,
+                    endian: Endian,
+                    bitset: BitSet = None,
+                    cache: CacheContext = None,
+                    count: int = 1,
+                    ) -> Deserialized:
+        return String.deserialize(data, endian=endian)
+
+
+_numeric_types = {
+    FieldType.float16, FieldType.float32, FieldType.float64,
+    FieldType.float128, FieldType.uint64, FieldType.int64, FieldType.uint32,
+    FieldType.int32, FieldType.uint16, FieldType.int16, FieldType.uint8,
+    FieldType.int8, FieldType.boolean
+}
+
+
+class NumericFieldData(ArrayBasedDataSerializer, handles=_numeric_types):
+    """
+    Numeric field data serialization.
+
+    Handles integer and floating point type variations.
+    """
+
+    type_to_ctypes = {
+        # FieldType.float16 ?
+        FieldType.float32: ctypes.c_float,
+        FieldType.float64: ctypes.c_double,
+        FieldType.uint64: ctypes.c_uint64,
+        FieldType.int64: ctypes.c_int64,
+        FieldType.uint32: ctypes.c_uint32,
+        FieldType.int32: ctypes.c_int32,
+        FieldType.uint16: ctypes.c_uint16,
+        FieldType.int16: ctypes.c_int16,
+        FieldType.uint8: ctypes.c_uint8,
+        FieldType.int8: ctypes.c_int8,
+        FieldType.boolean: ctypes.c_ubyte,
+    }
+
+    type_to_array_code = {
+        name: ctypes_type._type_
+        for name, ctypes_type in type_to_ctypes.items()
+    }
+
+    @classmethod
+    def serialize(cls,
+                  field: FieldDesc,
+                  value: typing.Union[str, List[str]],
+                  endian: Endian,
+                  bitset: BitSet = None,
+                  cache: CacheContext = None,
+                  ) -> List[bytes]:
+        try:
+            len(value)
+        except TypeError:
+            value = (value, )
+
+        if field.array_type == FieldArrayType.scalar and len(value) > 1:
+            raise ValueError('Too many values for FieldArrayType.scalar')
+
+        arr = array.array(cls.type_to_array_code[field.field_type], value)
+        if endian != core.SYS_ENDIAN:
+            arr.byteswap()
+        return [arr]
+
+    @classmethod
+    def deserialize(cls,
+                    field: FieldDesc,
+                    data: bytes, *,
+                    endian: Endian,
+                    bitset: BitSet = None,
+                    cache: CacheContext = None,
+                    count: int = 1,
+                    ) -> Deserialized:
+        ctypes_type = cls.type_to_ctypes[field.field_type]
+        byte_size = count * ctypes.sizeof(ctypes_type)
+
+        value = array.array(ctypes_type._type_)
+        if len(data) < byte_size:
+            raise SerializationFailure(
+                f'Deserialization buffer does not hold all values. Expected '
+                f'byte length {byte_size}, actual length {len(data)}. '
+                f'Value of type {field.field_type}[{count}]'
+            )
+
+        value.frombytes(data[:byte_size])
+        if endian != core.SYS_ENDIAN:
+            value.byteswap()
+
+        return Deserialized(data=value,
+                            buffer=data[byte_size:],
+                            offset=byte_size)
+
+
+class VariantFieldData(DataSerializer, handles={FieldType.any}):
+    """
+    Variant (i.e., "any") data type.
+
+    Handles serialization of the FieldDesc of the item and the data contained.
+    """
+
+    type_map = {
+        str: FieldType.string,
+        bytes: FieldType.string,
+        int: FieldType.int64,
+        bool: FieldType.boolean,
+        float: FieldType.double,
+    }
+
+    @classmethod
+    def field_from_value(cls, value: typing.Any, *, name: str = '') -> FieldDesc:
+        'Name and native Python value -> field description dictionary'
+        if isinstance(value, (str, bytes)):
+            return SimpleField(
+                name=name,
+                field_type=FieldType.string,
+                size=1,
+                array_type=FieldArrayType.scalar,
+            )
+
+        if isinstance(value, (tuple, list, array.array)):
+            if len(value) > 1:
+                return SimpleField(
+                    name=name,
+                    field_type=cls.type_map[type(value[0])],
+                    size=len(value),
+                    array_type=FieldArrayType.variable_array,
+                )
+
+            value = value[0]
+
+        return SimpleField(
+            name=name,
+            field_type=cls.type_map[type(value)],
+            size=1,
+            array_type=FieldArrayType.scalar,
+        )
+
+    @classmethod
+    def serialize(cls,
+                  field: FieldDesc,
+                  value: typing.Any,
+                  endian: Endian,
+                  bitset: BitSet = None,
+                  cache: CacheContext = None,
+                  ) -> List[bytes]:
+        if value is None:
+            return [bytes([TypeCode.NULL_TYPE_CODE])]
+
+        new_field = cls.field_from_value(value)
+        serialized = new_field.serialize(endian=endian)
+        serialized += Data.serialize(new_field, value=value, endian=endian,
+                                     bitset=None, cache=cache)
+        return serialized
+
+    @classmethod
+    def deserialize(cls,
+                    field: FieldDesc,
+                    data: bytes, *,
+                    endian: Endian,
+                    bitset: BitSet = None,
+                    cache: CacheContext = None,
+                    count: int = 1,
+                    ) -> Deserialized:
+
+        any_field, data, offset = FieldDesc.deserialize(
+            data, endian=endian, cache=cache, named=False)
+        if any_field is None:
+            return Deserialized(data=None, buffer=data, offset=offset)
+
+        value, data, off = Data.deserialize(any_field, data=data,
+                                            endian=endian, bitset=None,
+                                            cache=cache)
+        offset += off
+        return Deserialized(data=value, buffer=data, offset=offset)
+
+
+class UnionFieldData(DataSerializer, handles={FieldType.union}):
+    """
+    Union field data.
+
+    Handles serialization of the field selector (i.e., which element is
+    chosen from the union) and the data contained.
+    """
+
+    @classmethod
+    def serialize(cls,
+                  field: FieldDesc,
+                  value: typing.Any,
+                  endian: Endian,
+                  bitset: BitSet = None,
+                  cache: CacheContext = None,
+                  ) -> List[bytes]:
+        possible_keys = set(field.children)
+        found_keys = set(value).intersection(possible_keys)
+        if len(found_keys) == 0:
+            return Size.serialize(None, endian=endian)
+
+        if len(found_keys) > 1:
+            raise SerializationFailure(
+                f'Too many keys specified for union. Options: {possible_keys};'
+                f' found: {found_keys}.'
+            )
+
+        key, = found_keys
+        child = field.children[key]
+        index = list(field.children).index(key)
+        serialized = Size.serialize(index, endian=endian)
+        serialized.extend(
+            Data.serialize(field=child, value=value[key], endian=endian,
+                           bitset=None, cache=cache)
+        )
+        return serialized
+
+    @classmethod
+    def deserialize(cls,
+                    field: FieldDesc,
+                    data: bytes, *,
+                    endian: Endian,
+                    bitset: BitSet = None,
+                    cache: CacheContext = None,
+                    count: int = 1,
+                    ) -> Deserialized:
+        index, data, offset = Size.deserialize(data, endian=endian)
+        if index is None:
+            return Deserialized(data=None, buffer=data, offset=offset)
+
+        selected_key, selected_field = list(field.children.items())[index]
+        value, data, off = Data.deserialize(
+            selected_field, data=data, endian=endian, bitset=None, cache=cache)
+
+        offset += off
+        return Deserialized(data={selected_key: value}, buffer=data, offset=offset)
+
+
+class StructFieldData(DataSerializer, handles={FieldType.struct}):
+    """
+    Struct field data.
+
+    Handles serialization of the children of the struct, respecting the
+    provided BitSet.
+    """
+
+    @classmethod
+    def serialize(cls,
+                  field: FieldDesc,
+                  value: typing.Any,
+                  endian: Endian,
+                  bitset: BitSet = None,
+                  cache: CacheContext = None,
+                  ) -> List[bytes]:
+        if bitset is None:
+            bitset = BitSet({0})
+
+        bitset_index_to_child = [
+            (field.descendents.index((name, child)) + 1, child)
+            for name, child in field.children.items()
+        ]
+
+        serialized = []
+        for index, child in bitset_index_to_child:
+            if child.field_type in {FieldType.struct, FieldType.union}:
+                # Child may have bits selected
+                child_bitset = bitset.offset_by(-index)
+            elif index not in bitset and 0 not in bitset:
+                continue
+            else:
+                child_bitset = None
+
+            child_value = value[child.name]
+            serialized.extend(
+                Data.serialize(field=child, value=child_value, endian=endian,
+                               cache=cache, bitset=child_bitset)
+            )
+        return serialized
+
+    @classmethod
+    def deserialize(cls,
+                    field: FieldDesc,
+                    data: bytes, *,
+                    endian: Endian,
+                    bitset: BitSet = None,
+                    cache: CacheContext = None,
+                    count: int = 1,
+                    ) -> Deserialized:
+        if bitset is None:
+            bitset = BitSet({0})
+
+        offset = 0
+        if field.array_type == FieldArrayType.variable_array:
+            # TODO: haven't been able to confirm where this comes from
+            # always appears to be 1
+            count, data, off = Size.deserialize(data, endian=endian)
+            offset += off
+            assert count == 1
+
+        bitset_index_to_child = [
+            (field.descendents.index((name, child)) + 1, child)
+            for name, child in field.children.items()
+        ]
+        value = {}
+        for index, child in bitset_index_to_child:
+            if child.field_type == FieldType.struct:
+                if child.array_type == FieldArrayType.variable_array:
+                    if index not in bitset and 0 not in bitset:
+                        continue
+                    child_bitset = BitSet({0})
+                else:
+                    # Child may have bits selected
+                    child_bitset = bitset.offset_by(-index)
+                    if not child_bitset:
+                        continue
+            elif index not in bitset and 0 not in bitset:
+                continue
+            else:
+                child_bitset = None
+
+            value[child.name], data, off = Data.deserialize(
+                field=child, data=data, endian=endian,
+                cache=cache, bitset=child_bitset
+            )
+            offset += off
+
+        return Deserialized(data=value, buffer=data, offset=offset)
+
+
+class DataWithBitSet(DataSerializer, handles={'bitset_and_data'}):
+    """
+    Pair of Data, described by ``field`` (FieldDesc), and BitSet.
+
+    Serializes the BitSet first, and then the Data that goes along with it.
+    """
+
+    field_type = 'bitset_and_data'  # hack
+    array_type = FieldArrayType.scalar  # hack
+    size = 1
+
+    @classmethod
+    def serialize(cls,
+                  field: FieldDesc,
+                  value: typing.Any,
+                  endian: Endian,
+                  bitset: BitSet = None,
+                  cache: CacheContext = None,
+                  ) -> List[bytes]:
+        serialized = []
+        # TODO especially awkward handling
+        serialized.extend(value['bitset'].serialize(endian=endian))
+        serialized.extend(Data.serialize(value['interface'],
+                                         value=value['data'],
+                                         endian=endian, bitset=bitset,
+                                         cache=cache))
+        return serialized
+
+    @classmethod
+    def deserialize(cls,
+                    field: str,
+                    data: bytes, *,
+                    endian: Endian,
+                    bitset: BitSet = None,
+                    cache: CacheContext = None,
+                    count: int = 1,
+                    ) -> Deserialized:
+        bitset, data, offset = BitSet.deserialize(data, endian=endian)
+        value, data, off = Data.deserialize(field, data=data, endian=endian,
+                                            bitset=bitset, cache=cache)
+        offset += off
+        return Deserialized(data=dict(field=field, value=value),
+                            buffer=data,
+                            offset=offset)
+
+
+class FieldDescAndData(DataSerializer, handles={'field_and_data'}):
+    """
+    A field description and associated data.
+
+    Serializes the field description first, and then the associated data.
+    """
+
+    field_type = 'field_and_data'  # hack
+    array_type = FieldArrayType.scalar  # hack
+    field_class = FieldDesc
+
+    @classmethod
+    def serialize(cls,
+                  field: FieldDesc,
+                  value: typing.Any,
+                  endian: Endian,
+                  bitset: BitSet = None,
+                  cache: CacheContext = None,
+                  ) -> List[bytes]:
+        field = value['field']
+        value = value['value']
+        serialized = []
+        serialized.extend(field.serialize(endian=endian, cache=cache))
+        serialized.extend(Data.serialize(field, value=value, endian=endian,
+                                         bitset=bitset, cache=cache))
+        return serialized
+
+    @classmethod
+    def deserialize(cls,
+                    field: str,
+                    data: bytes, *,
+                    endian: Endian,
+                    bitset: BitSet = None,
+                    cache: CacheContext = None,
+                    count: int = 1,
+                    ) -> Deserialized:
+        field, data, offset = cls.field_class.deserialize(
+            data, endian=endian, cache=cache)
+        if field is None:
+            value = None
+        else:
+            value, data, off = Data.deserialize(field, data=data, endian=endian,
+                                                bitset=bitset, cache=cache)
+            offset += off
+        return Deserialized(data=dict(field=field, value=value),
+                            buffer=data,
+                            offset=offset)
+
+
+class PVRequest(FieldDescAndData, handles={'PVRequest'}):
+    """
+    A special form of FieldDescAndData, representing a PVRequest.
+
+    Handles string to PVRequest structure translation, if required.
+    """
+
+    field_type = 'PVRequest'  # hack
+    array_type = FieldArrayType.scalar  # hack
+    field_class = FieldDesc  # PVRequestStruct
+
+    @classmethod
+    def serialize(cls,
+                  field: FieldDesc,
+                  value: typing.Any,
+                  endian: Endian,
+                  bitset: BitSet = None,
+                  cache: CacheContext = None,
+                  ) -> List[bytes]:
+        if isinstance(value, str):
+            st = PVRequestStruct.from_string(value)
+            value = {'field': st, 'value': st.values}
+        else:
+            assert 'field' in value
+            assert 'value' in value
+
+        return super().serialize(field=None, value=value, endian=endian,
+                                 bitset=bitset, cache=cache)
+
+
+class Data(DataSerializer, handles={}):
+    """
+    Top-level data serializer.  Dispatches serialization to the handlers.
+    """
+
+    @classmethod
+    def serialize(cls,
+                  field: FieldDesc,
+                  value: typing.Any,
+                  endian: Endian,
+                  bitset: BitSet = None,
+                  cache: CacheContext = None,
+                  ) -> List[bytes]:
+
+        if field is FieldDesc:
+            # For deserialization consistency (TODO annotation / refactor)
+            return FieldDesc.serialize(value=value, endian=endian, cache=cache)
+
+        handler = DataSerializer.handlers[field.field_type]
+        try:
+            len(value)
+        except TypeError:
+            value = (value, )
+
+        if isinstance(value, (str, bytes, typing.Mapping)):
+            value = (value, )
+
+        serialized = []
+        if field.array_type.has_serialization_size:
+            serialized.extend(Size.serialize(len(value), endian=endian))
+
+        for single_value in value:
+            serialized.extend(
+                handler.serialize(field=field, value=single_value,
+                                  endian=endian, bitset=bitset, cache=cache)
+            )
+
+        return serialized
+
+    @classmethod
+    def deserialize(cls,
+                    field: FieldDesc,
+                    data: bytes, *,
+                    endian: Endian,
+                    bitset: BitSet = None,
+                    cache: CacheContext = None,
+                    count: int = 1,
+                    ) -> Deserialized:
+
+        if field is FieldDesc:
+            # For deserialization consistency (TODO annotation / refactor)
+            return FieldDesc.deserialize(data=data, endian=endian, cache=cache,
+                                         named=False)
+        if field is BitSet:
+            # For deserialization consistency (TODO annotation / refactor)
+            return BitSet.deserialize(data=data, endian=endian)
+
+        # print('\n\n', ' '.join(hex(c)[2:].zfill(2) for c in data[:20]))
+        offset = 0
+
+        if field.array_type.has_serialization_size:
+            count, data, off = Size.deserialize(data, endian=endian)
+            offset += off
+        else:
+            count = field.size if field.size is not None else 1
+
+        handler = DataSerializer.handlers[field.field_type]
+        array_based = issubclass(handler, ArrayBasedDataSerializer)
+
+        # Minimal set here:
+        deserialize = functools.partial(handler.deserialize, endian=endian)
+        if array_based:
+            loops = 1
+            deserialize = functools.partial(deserialize, field=field,
+                                            bitset=bitset, cache=cache,
+                                            count=count)
+        else:
+            loops = count
+            deserialize = functools.partial(
+                handler.deserialize, field=field, endian=endian, bitset=bitset,
+                cache=cache,
+            )
+
+        value = []
+        for _ in range(loops):
+            # print('\n\n', ' '.join(hex(c)[2:].zfill(2) for c in data[:20]))
+            # print('reading', _, field, handler)
+            item, data, off = deserialize(data=data)
+            # print('reading', _, item, 'took', off, 'bytes')
+            offset += off
+            value.append(item)
+
+        if array_based:
+            if field.array_type == FieldArrayType.scalar:
+                # [array([0, 1, 2])] -> array([0, 1, 2])
+                value = value[0][0]
+            else:
+                # [array([0])] -> 0
+                value = value[0]
+        elif field.array_type == FieldArrayType.scalar:
+            # if not isinstance(value, (dict, str, bytes)):
+            value = value[0]
+
+        return Deserialized(data=value, buffer=data, offset=offset)

--- a/caproto/pva/_dataclass.py
+++ b/caproto/pva/_dataclass.py
@@ -1,0 +1,335 @@
+"""
+Create a new PVAccess-compatible dataclass given a type-annotated class, and
+vice-versa.
+"""
+
+import dataclasses
+import inspect
+import typing
+
+from . import _typing_compat as typing_compat
+from ._annotations import (annotation_default_values, annotation_type_map,
+                           type_to_annotation)
+from ._core import FieldArrayType, FieldType
+from ._fields import (BitSet, FieldDesc, SimpleField, StructuredField,
+                      _children_from_field_list, _descendents_from_field_list)
+
+
+def new_struct(fields: dict,
+               struct_name: str = '',
+               parent: typing.Optional[StructuredField] = None,
+               name: str = '',
+               array_type: FieldArrayType = FieldArrayType.scalar,
+               size: typing.Optional[int] = None,
+               field_type=FieldType.struct,
+               ) -> StructuredField:
+    return StructuredField(
+        field_type=field_type,
+        array_type=array_type,
+        name=name,
+        struct_name=struct_name,
+        metadata={'parent': parent},
+        children=_children_from_field_list(fields.values()),
+        descendents=_descendents_from_field_list(fields.values()),
+        size=size,
+    )
+
+
+def _field_from_annotation(attr, annotation,
+                           array_type=FieldArrayType.scalar,
+                           parent=None):
+    annotation = annotation_type_map.get(annotation, annotation)
+    if isinstance(annotation, FieldType):
+        return SimpleField(
+            field_type=annotation,
+            array_type=array_type,
+            name=attr,
+            size=None,
+        )
+
+    if hasattr(annotation, '_pva_struct_'):
+        struct = annotation._pva_struct_
+        return new_struct(
+            struct.children,
+            struct_name=struct.struct_name,
+            name=attr,
+            array_type=array_type,
+            parent=parent,
+        )
+
+
+def _get_union_from_annotation(attr, annotation,
+                               array_type=FieldArrayType.scalar):
+    """
+    We get::
+
+        attr = typing.Union[option1, option2]
+
+    We create::
+
+        @pva_dataclass
+        class attr:
+            option1
+            option2
+
+    And then change it to a FieldType.union.
+
+    The annotation has no access to the dynamically created dataclass.  So, add
+    in metadata to refer back to that.  It can then be used for instantiating a
+    new dataclass.
+    """
+
+    def _get_name(arg):
+        if hasattr(arg, 'name'):
+            return arg.name
+        if hasattr(arg, '__name__'):
+            return arg.__name__
+        return arg.__class__.__name__
+
+    options = [
+        (_get_name(arg), arg)
+        for idx, arg in enumerate(typing_compat.get_args(annotation))
+    ]
+
+    union_class = pva_dataclass(
+        dataclasses.make_dataclass(cls_name=attr, fields=options),
+        union=True,
+    )
+
+    union_class._pva_struct_.metadata['union_dataclass'] = union_class
+    return union_class
+
+
+def _get_pva_fields_from_annotations(cls: type) -> dict:
+    pva_fields = {}
+
+    for attr, annotation in typing.get_type_hints(cls).items():
+        origin = typing_compat.get_origin(annotation)
+        if origin is list:
+            array_type = FieldArrayType.variable_array
+            args = typing_compat.get_args(annotation)
+            try:
+                annotation, = args
+            except ValueError:
+                raise ValueError(
+                    f'Array annotation only allows one type. Got: {args}'
+                ) from None
+        elif origin is typing.Union:
+            union_cls = _get_union_from_annotation(attr, annotation)
+            pva_fields[attr] = union_cls._pva_struct_
+            continue
+        else:
+            array_type = FieldArrayType.scalar
+
+        pva_fields[attr] = _field_from_annotation(
+            attr=attr, annotation=annotation, array_type=array_type
+        )
+
+    return pva_fields
+
+
+def _get_default_by_field(attr: str,
+                          field: FieldDesc,
+                          annotation) -> dataclasses.Field:
+    dcls_field = dataclasses.field()
+
+    if field.array_type == FieldArrayType.scalar:
+        if field.field_type == FieldType.struct:
+            dcls_field.default_factory = lambda item=annotation: item()
+        elif field.field_type == FieldType.union:
+            # TODO this isn't quite right
+            union_dcls = field.metadata['union_dataclass']
+
+            def union_init(*, dcls=union_dcls):
+                kwargs = {}
+                items = enumerate(typing.get_type_hints(dcls).items())
+                for idx, (attr, annotation) in items:
+                    print(idx, attr, annotation)
+                    kwargs[attr] = None
+                return union_dcls(**kwargs)
+
+            dcls_field.default_factory = union_init
+        else:
+            dcls_field.default = annotation_default_values[field.field_type]
+    else:
+        dcls_field.default_factory = list
+        dcls_field.default = dataclasses.MISSING
+    dcls_field.name = attr
+    return dcls_field
+
+
+def _get_defaults_to_add(cls: type, pva_fields: typing.Dict[str, FieldDesc]):
+    defaults = {}
+    for attr, annotation in typing.get_type_hints(cls).items():
+        try:
+            pva_field = pva_fields[attr]
+        except KeyError:
+            # ?
+            continue
+
+        if not hasattr(cls, attr):
+            # No default defined
+            defaults[attr] = _get_default_by_field(attr, pva_field, annotation)
+
+    return defaults
+
+
+def pva_dataclass(_cls: typing.Optional[type] = None, *,
+                  add_defaults: bool = True,
+                  union: bool = False):
+    """
+    Create a new PVAccess-compatible dataclass given a type-annotated class.
+
+    Parameters
+    ----------
+    _cls : type
+        The class.
+
+    add_defaults : bool, optional
+        Add default values for easy instantiation of the data class. Supports
+        sub-structures as well.
+    """
+
+    def wrap(cls: type) -> type:
+        pva_fields = _get_pva_fields_from_annotations(cls)
+        if add_defaults:
+            for attr, default in _get_defaults_to_add(cls, pva_fields).items():
+                setattr(cls, attr, default)
+        dcls = dataclasses.dataclass(cls)
+        dcls._pva_struct_ = new_struct(
+            pva_fields,
+            struct_name=cls.__name__,
+            field_type=FieldType.union if union else FieldType.struct,
+        )
+        return dcls
+
+    if _cls is None:
+        return wrap
+
+    return wrap(_cls)
+
+
+def array_of(item: typing.Union[SimpleField, StructuredField, FieldType, type],
+             *,
+             array_type=FieldArrayType.variable_array,
+             size=None,
+             name=None,
+             ) -> FieldDesc:
+    # Obsolete due to List[] annotation?
+    if isinstance(item, FieldType):
+        return SimpleField(
+            field_type=item,
+            array_type=array_type,
+            name=name or '',
+            size=size,
+        )
+    if isinstance(item, SimpleField):
+        return SimpleField(
+            field_type=item.field_type,
+            array_type=array_type,
+            name=name or item.name,
+            size=size,
+        )
+    if isinstance(item, StructuredField):
+        struct = item
+    else:
+        struct = item._pva_struct_
+
+    return new_struct(
+        struct.children,
+        struct_name=struct.struct_name,
+        name=name or struct.name,
+        array_type=array_type,
+        size=size,
+    )
+
+
+class PvaStruct(type):
+    """
+    An alternative wrapper for pva dataclasses, using metaclasses instead.
+
+    Preliminary API; may be removed.
+    """
+
+    def __new__(cls, name, bases, classdict):
+        return pva_dataclass(type.__new__(cls, name, bases, dict(classdict)))
+
+
+def dataclass_from_field_desc(field: FieldDesc) -> type:
+    """
+    Take a field description, and make a pva_dataclass out of it.
+
+    Parameters
+    ----------
+    field : FieldDesc
+        The field description.
+
+    Returns
+    -------
+    datacls : type
+        The generated dataclass.
+    """
+    # Use a roundabout approach - create a class, add annotations, and
+    # use `pva_dataclass` machinery to do the heavy lifting.
+    cls = type(field.struct_name or field.name, (), {})
+
+    annotations = {}
+    cls.__annotations__ = annotations
+
+    for attr, child in field.children.items():
+        if child.field_type in {FieldType.struct, FieldType.union}:
+            annotation_type = dataclass_from_field_desc(child)
+        else:
+            annotation_type = type_to_annotation[child.field_type]
+
+        if child.array_type == FieldArrayType.variable_array:
+            annotation_type = typing.List[annotation_type]
+
+        annotations[attr] = annotation_type
+
+    return pva_dataclass(cls)
+
+
+def is_pva_dataclass(obj) -> bool:
+    """
+    Is ``obj`` a dataclass?
+    """
+    return inspect.isclass(obj) and hasattr(obj, '_pva_struct_')
+
+
+def is_pva_dataclass_instance(obj) -> bool:
+    """
+    Is ``obj`` a dataclass?
+    """
+    return not inspect.isclass(obj) and hasattr(obj, '_pva_struct_')
+
+
+def fill_dataclass(instance: object, value: dict) -> BitSet:
+    """
+    Fill a dataclass instance given a dictionary.
+
+    Returns a BitSet indicating the fields that were set.
+    """
+    if not is_pva_dataclass_instance(instance):
+        print(instance, hasattr(instance, '_pva_struct_'))
+        raise ValueError(f'{instance} is not a pva dataclass')
+
+    bitset = BitSet({})
+    pva_struct = instance._pva_struct_
+    children = list(pva_struct.children)
+
+    for key, v in value.items():
+        try:
+            bitset_index = children.index(key) + 1
+        except KeyError:
+            raise KeyError(f'Key {key} not found in structure '
+                           f'{pva_struct.struct_name}')
+
+        if isinstance(v, dict):
+            child_bitset = fill_dataclass(getattr(instance, key), value=v)
+            bitset |= child_bitset.offset_by(bitset_index)
+        else:
+            setattr(instance, key, v)
+            bitset.add(bitset_index)
+
+    return bitset

--- a/caproto/pva/_messages.py
+++ b/caproto/pva/_messages.py
@@ -1,0 +1,1808 @@
+import ctypes
+import dataclasses
+import enum
+import functools
+import logging
+import typing
+from typing import Optional, Tuple, Union
+
+from . import _core as core
+from ._core import (BIG_ENDIAN, LITTLE_ENDIAN, Deserialized, FieldArrayType,
+                    FieldType, SegmentDeserialized, UserFacingEndian)
+from ._data import Data, DataWithBitSet, FieldDescAndData, PVRequest
+from ._dataclass import array_of, pva_dataclass
+from ._fields import BitSet, CacheContext, FieldDesc, SimpleField
+from ._utils import (SERVER, ChannelLifeCycle, Role, ip_to_ubyte_array,
+                     ubyte_array_to_ip)
+
+NullCache = CacheContext()
+
+
+@pva_dataclass
+class ChannelWithID:
+    """
+    A channel and ID pair, used for searching and channel creation.
+    """
+    id: FieldType.int32
+    channel_name: FieldType.string
+
+
+serialization_logger = logging.getLogger('caproto.pva.serialization')
+
+
+class _MessageField:
+    def __post_init__(self):
+        if isinstance(self.type, FieldType):
+            # Can use a basic FieldType such as FieldType.string
+            self.type = SimpleField(name=self.name,
+                                    field_type=self.type,
+                                    array_type=FieldArrayType.scalar,
+                                    size=1,
+                                    )
+        elif hasattr(self.type, '_pva_struct_'):
+            # Can use a pva_struct-wrapped dataclass
+            self.type = self.type._pva_struct_
+
+        # With the end result of `type` being a SimpleField or StructuredField
+
+
+@dataclasses.dataclass
+class RequiredField(_MessageField):
+    name: str
+    type: ...
+
+
+@dataclasses.dataclass
+class NonstandardArrayField(RequiredField):
+    count_attr: str = None
+
+
+@dataclasses.dataclass
+class OptionalField(_MessageField):
+    name: str
+    type: ...
+    stop: ...
+    condition: typing.Optional[callable]
+
+
+class QOSFlags(enum.IntFlag):
+    'First 7 bits of QOS settings are the priority (see QOS_PRIORITY_MASK)'
+    unused_7 = 1 << 7
+    low_latency = 1 << 8
+    throughput_priority = 1 << 9
+    enable_compression = 1 << 10
+    unused_11 = 1 << 11
+    unused_12 = 1 << 12
+    unused_13 = 1 << 13
+    unused_14 = 1 << 14
+    unused_15 = 1 << 15
+
+    @classmethod
+    def encode(cls, priority, flags):
+        return (core.QOS_PRIORITY_MASK & priority) | flags
+
+    @classmethod
+    def decode(cls, priority_word):
+        priority = (priority_word & core.QOS_PRIORITY_MASK)
+        flags = QOSFlags(priority_word & ~core.QOS_PRIORITY_MASK)
+        return (priority, flags)
+
+
+class ApplicationCommands(enum.IntEnum):
+    """
+    Application messages. These are the requests and their responses.
+    """
+    BEACON = 0
+    CONNECTION_VALIDATION = 1
+    ECHO = 2
+    SEARCH_REQUEST = 3
+    SEARCH_RESPONSE = 4
+    AUTHNZ = 5
+    ACL_CHANGE = 6
+    CREATE_CHANNEL = 7
+    DESTROY_CHANNEL = 8
+    CONNECTION_VALIDATED = 9
+    GET = 10
+    PUT = 11
+    PUT_GET = 12
+    MONITOR = 13
+    ARRAY = 14
+    DESTROY_REQUEST = 15
+    PROCESS = 16
+    GET_FIELD = 17
+    MESSAGE = 18
+    RPC = 20
+    CANCEL_REQUEST = 21
+    ORIGIN_TAG = 22
+
+    # These message codes are never used, and considered deprecated.
+    MULTIPLE_DATA = 19
+
+
+class ControlCommands(enum.Enum):
+    """
+    Control messages. These include flow control and have no payload.
+    """
+    # NOTE: this is not set as an IntEnum to avoid clashing with
+    # ApplicationCommands in dictionaries.
+    SET_MARKER = 0
+    ACK_MARKER = 1
+    SET_ENDIANESS = 2
+    ECHO_REQUEST = 3
+    ECHO_RESPONSE = 4
+
+
+class SearchFlags(enum.IntFlag):
+    # 0-bit for replyRequired, 7-th bit for "sent as unicast" (1)/"sent as
+    # broadcast/multicast" (0)
+    reply_required = 0b00000001
+    unicast = 0b10000000
+    broadcast = 0b00000000
+
+
+class EndianSetting(enum.IntEnum):
+    use_server_byte_order = 0x00000000
+    use_message_byte_order = 0xffffffff
+
+
+class MessageFlags(enum.IntFlag):
+    APP_MESSAGE = 0b0000_0000_0000
+    CONTROL_MESSAGE = 0b0000_0000_0001
+
+    UNSEGMENTED = 0b0000_0000_0000
+    FIRST = 0b0000_0001_0000
+    LAST = 0b0000_0010_0000
+    MIDDLE = 0b0000_0011_0000
+
+    FROM_CLIENT = 0b0000_0000_0000
+    FROM_SERVER = 0b0000_0100_0000
+
+    LITTLE_ENDIAN = 0b0000_0000_0000
+    BIG_ENDIAN = 0b0000_1000_0000
+
+    @property
+    def is_segmented(self):
+        return any(item in self
+                   for item in (self.FIRST, self.LAST, self.MIDDLE)
+                   )
+
+
+class Subcommands(enum.IntEnum):
+    # Default behavior
+    DEFAULT = 0x00
+    # Require reply (acknowledgment for reliable operation)
+    REPLY_REQUIRED = 0x01
+    # Best-effort option (no reply)
+    BEST_EFFORT = 0x02
+    PROCESS = 0x04
+    INIT = 0x08
+    DESTROY = 0x10
+    # Share data option
+    SHARE = 0x20
+    GET = 0x40
+    GET_PUT = 0x80
+
+
+class MonitorSubcommands(enum.IntFlag):
+    INIT = 0x08
+    DEFAULT = 0x00
+    PIPELINE = 0x80
+    START = 0x44
+    STOP = 0x04
+    DESTROY = 0x10
+
+
+class StatusType(enum.IntEnum):
+    OK = -1
+    OK_VERBOSE = 0
+    WARNING = 1
+    ERROR = 2
+    FATAL = 3
+
+
+class OptionalStopMarker(enum.IntEnum):
+    stop = True
+    continue_ = False
+
+
+success_status_types = {
+    StatusType.OK,
+    StatusType.OK_VERBOSE,
+    StatusType.WARNING,
+}
+
+default_pvrequest = 'record[]field()'
+
+
+class MessageBase:
+    """
+    Base class for all Messages.
+    """
+    _pack_ = 1
+    _additional_fields_ = None
+    _subcommand_fields_ = None
+
+    def __repr__(self):
+        info = ', '.join('{}={!r}'.format(field, getattr(self, field))
+                         for field, type_ in self._fields_)
+        return '{}({})'.format(type(self).__name__, info)
+
+    @classmethod
+    def _get_additional_fields(cls, subcommand=None):
+        if (cls._additional_fields_ is None and
+                cls._subcommand_fields_ is None):
+            return []
+
+        fields = cls._additional_fields_
+        if cls._subcommand_fields_ and subcommand is not None:
+            try:
+                return fields + cls._subcommand_fields_[subcommand]
+            except KeyError:
+                raise ValueError(f'Invalid (or currently unhandled) subcommand'
+                                 f' for class {cls}: {subcommand}') from None
+        return fields
+
+    @property
+    def has_subcommand(self):
+        return ('subcommand', ctypes.c_byte) in self._fields_
+
+    def serialize(self, *, default_pvrequest=default_pvrequest,
+                  cache=NullCache):
+        additional_fields = self._get_additional_fields(
+            subcommand=self.subcommand if self.has_subcommand else None
+        )
+        if not additional_fields:
+            # Without additional fields, this is just a ctypes.Structure
+            return bytes(self)
+
+        endian = self._ENDIAN
+
+        # (1) serialize the ctypes.Structure _fields_ first
+        buf = [bytes(self)]
+
+        # (2) move onto the "additional fields" which are not as easily
+        # serializable:
+        for field_info in additional_fields:
+            if isinstance(field_info, OptionalField):
+                if field_info.condition is not None:
+                    if not field_info.condition(self, buf):
+                        break
+
+            value = getattr(self, field_info.name)
+            if isinstance(field_info, NonstandardArrayField):
+                count = getattr(self, field_info.count_attr)
+            else:
+                value = [value]
+                count = 1
+
+            assert len(value) == count
+
+            serialize = functools.partial(
+                Data.serialize, field=field_info.type, endian=endian, cache=cache,
+                bitset=None
+            )
+
+            for v in value:
+                buf.extend(serialize(value=v))
+
+        # (3) end result is the sum of all buffers
+        return b''.join(buf)
+
+    @classmethod
+    def deserialize(cls, buf, *, cache=NullCache, header=None):
+        base_size = ctypes.sizeof(cls)
+        buflen = len(buf) - base_size
+        buf = memoryview(buf)
+        msg = cls.from_buffer(buf[:base_size])
+
+        offset = base_size
+        buf = buf[offset:]
+
+        additional_fields = cls._get_additional_fields(
+            subcommand=msg.subcommand if msg.has_subcommand else None
+        )
+
+        if not additional_fields:
+            # Without additional fields, this is just a ctypes.Structure
+            return Deserialized(data=msg, buffer=buf, offset=offset)
+
+        serialization_logger.debug(
+            'deserializing %s base_size=%s subcommand=%s payload=%s', cls,
+            base_size, getattr(msg, 'subcommand', None), bytes(buf))
+
+        for field_info in additional_fields:
+            if isinstance(field_info, OptionalField):
+                if not buflen:
+                    # No bytes remaining, and any additional fields are
+                    # optional.
+                    break
+                if field_info.condition is not None:
+                    if not field_info.condition(msg, buf):
+                        if field_info.stop == OptionalStopMarker.stop:
+                            break
+                        else:
+                            continue
+
+            field_interface = field_info.type
+
+            if field_interface in (Data, DataWithBitSet):
+                try:
+                    field_interface = cache.ioid_interfaces[msg.ioid]
+                except KeyError:
+                    raise RuntimeError(
+                        f'Field description unavailable for Data in '
+                        f'{field_info.name!r} (ioid={msg.ioid})'
+                    ) from None
+                data_cls = field_info.type
+            else:
+                data_cls = Data
+
+            is_nonstandard_array = isinstance(field_info,
+                                              NonstandardArrayField)
+
+            deserialize = functools.partial(
+                data_cls.deserialize, field=field_interface,
+                endian=cls._ENDIAN, cache=cache, bitset=None,
+            )
+
+            if is_nonstandard_array:
+                count = getattr(msg, field_info.count_attr)
+                values = []
+                for i in range(count):
+                    value, buf, off = deserialize(data=buf)
+                    offset += off
+                    buflen -= off
+                    values.append(value)
+
+                setattr(msg, field_info.name, values)
+                serialization_logger.debug('%s (%s) = %s', field_info.name,
+                                           field_info.type, values)
+            else:
+                value, buf, off = deserialize(data=buf)
+                offset += off
+                buflen -= off
+                setattr(msg, field_info.name, value)
+                serialization_logger.debug('%s (%s) = %s', field_info.name,
+                                           field_info.type, value)
+
+        # Attach the header for future reference
+        msg.header = header
+        return Deserialized(data=msg, buffer=buf, offset=offset)
+
+
+class ExtendedMessageBase(MessageBase):
+    '''
+    Additional fields in _additional_fields_ with pva-specific types, and
+    optional entries based on certain conditions
+    '''
+    _fields_ = []
+
+    def __repr__(self):
+        def name_and_value(name):
+            if name.startswith('_'):
+                prop_name = name.lstrip('_')
+                if hasattr(type(self), prop_name):
+                    return (prop_name, getattr(self, prop_name))
+            return name, getattr(self, name)
+
+        info = ', '.join('{}={!r}'.format(*name_and_value(field))
+                         for field, type_ in self._fields_)
+        if not self._additional_fields_:
+            return '{}({})'.format(type(self).__name__, info)
+
+        if info:
+            info += ', '
+
+        info += ', '.join('{}={!r}'.format(*name_and_value(fi.name))
+                          for fi in self._additional_fields_)
+        return '{}({})'.format(type(self).__name__, info)
+
+
+def _success_condition(msg, buf):
+    """
+    Continue if-and-only-if the status message indicates success.
+    """
+    return (msg.status_type in success_status_types)
+
+
+def SuccessField(name: str,
+                 type,
+                 stop=OptionalStopMarker.stop) -> OptionalField:
+    'Return an OptionalField which requires the message status be successful'
+    return OptionalField(name, type, stop, _success_condition)
+
+
+def _make_endian(cls: type, endian: core.UserFacingEndian) -> type:
+    '''Creates big- or little-endian versions of a Structure
+
+    Checks for _additional_fields from ExtendedMessageBase
+    Adds _ENDIAN attr for easy struct.unpacking = big (>) or little (<)
+    '''
+
+    if endian == LITTLE_ENDIAN:
+        endian_base = ctypes.LittleEndianStructure
+        suffix = 'LE'
+    else:
+        endian_base = ctypes.BigEndianStructure
+        suffix = 'BE'
+
+    name = cls.__name__.lstrip('_') + suffix
+    endian_cls = type(name, (cls, endian_base),
+                      {'_fields_': cls._fields_})
+
+    if endian_cls._additional_fields_:
+        for field_info in endian_cls._additional_fields_:
+            setattr(endian_cls, field_info.name, None)
+
+    cls._ENDIAN = None
+    endian_cls._ENDIAN = (LITTLE_ENDIAN
+                          if endian_base is ctypes.LittleEndianStructure
+                          else BIG_ENDIAN)
+    return endian_cls
+
+
+class MessageHeader(MessageBase):
+    _fields_ = [
+        ('magic', ctypes.c_ubyte),
+        ('version', ctypes.c_ubyte),
+        ('_flags', ctypes.c_ubyte),
+        ('message_command', ctypes.c_ubyte),
+        ('payload_size', ctypes.c_uint),
+    ]
+
+    def __init__(self, *, flags: MessageFlags,
+                 command: typing.Union[ApplicationCommands, ControlCommands],
+                 payload_size: int):
+        self.magic = 0xca
+        self.version = 1
+        self._flags = flags
+        self.message_command = command
+        self.payload_size = payload_size
+
+    @property
+    def flags(self):
+        return MessageFlags(self._flags)
+
+    @property
+    def valid(self):
+        return self.magic == 0xca
+
+    @property
+    def byte_order(self):
+        'Byte order/endianness of message'
+        return (BIG_ENDIAN
+                if bool(self._flags & MessageFlags.BIG_ENDIAN)
+                else LITTLE_ENDIAN)
+
+    def get_message(self, direction: MessageFlags, *,
+                    use_fixed_byte_order=None):
+        byte_order = (use_fixed_byte_order
+                      if use_fixed_byte_order is not None
+                      else self.byte_order)
+        flags = self.flags
+
+        if MessageFlags.CONTROL_MESSAGE in flags:
+            command = ControlCommands(self.message_command)
+        else:
+            command = ApplicationCommands(self.message_command)
+
+        try:
+            message_group = messages[(byte_order, direction)]
+            return message_group[command]
+        except KeyError as ex:
+            raise KeyError(
+                f'{ex} where flags={flags} and command={command!r}'
+            )
+
+
+MessageHeaderLE = _make_endian(MessageHeader, LITTLE_ENDIAN)
+MessageHeaderBE = _make_endian(MessageHeader, BIG_ENDIAN)
+_MessageHeaderSize = ctypes.sizeof(MessageHeaderLE)
+
+
+class _StatusBase:
+    """
+    Mixin class that can be used to provide a common interface for messages
+    with status responses.
+
+    NOTE
+    ----
+    It's up to the struct to place '_status_type' in its _fields_, as its exact
+    location may change based on the message.
+    """
+    _status_type: ctypes.c_byte
+
+    _additional_fields_ = [
+        OptionalField('message', FieldType.string, OptionalStopMarker.continue_,
+                      lambda msg, buf: msg.status_type != StatusType.OK),
+        OptionalField('call_tree', FieldType.string, OptionalStopMarker.continue_,
+                      lambda msg, buf: msg.status_type != StatusType.OK),
+    ]
+
+    @property
+    def is_successful(self) -> bool:
+        return self.status_type in success_status_types
+
+    @property
+    def has_message(self) -> bool:
+        return self.status_type != StatusType.OK
+
+    @property
+    def status_type(self):
+        return StatusType(self._status_type)
+
+
+class Status(_StatusBase, ExtendedMessageBase):
+    _fields_ = [('_status_type', ctypes.c_byte)]
+
+
+class BeaconMessage(ExtendedMessageBase):
+    """
+    A beacon message.
+
+    Notes
+    -----
+    Servers MUST broadcast or multicast beacons over UDP. Beacons are be used
+    to announce the appearance and continued presense of servers. Clients may
+    use Beacons to detect when new servers appear, and may use this information
+    to more quickly retry unanswered CMD_SEARCH messages.
+    """
+    ID = ApplicationCommands.BEACON
+    # FieldDesc serverStatusIF;
+    # [if serverStatusIF != NULL_TYPE_CODE] PVField serverStatus;
+    _fields_ = [
+        ('guid', ctypes.c_ubyte * 12),
+        ('flags', ctypes.c_ubyte),
+        ('beacon_sequence_id', ctypes.c_ubyte),
+        ('change_count', ctypes.c_uint16),  # TODO_DOCS
+        ('server_address', ctypes.c_ubyte * 16),
+        ('server_port', ctypes.c_uint16),
+    ]
+
+    _additional_fields_ = [
+        RequiredField('protocol', FieldType.string),
+        RequiredField('server_status', FieldDescAndData),
+    ]
+
+
+# NOTE: the following control messages do not have any elements which require
+# an endian setting. They are arbitrarily set to little-endian here for all
+# platforms.
+class SetMarker(MessageHeaderLE):
+    """
+    A control command which sets a marker for total bytes sent.
+
+    Notes
+    -----
+    (from pva documentation)
+    Note that this message type has so far not been used.
+
+    The payload size field holds the value of the total bytes sent. The client
+    SHOULD respond with an acknowledgment control message (0x01) as soon as
+    possible.
+    """
+    ID = ControlCommands.SET_MARKER
+
+
+class AcknowledgeMarker(MessageHeaderLE):
+    """
+    A control command to acknowledge the total bytes received.
+
+    Notes
+    -----
+    (from pva documentation)
+    Note that this message type has so far not been used.
+
+    The payload size field holds the acknowledge value of total bytes received.
+    This must match the previously received marked value as described above.
+    """
+    ID = ControlCommands.ACK_MARKER
+
+
+class SetByteOrder(MessageHeaderLE):
+    """
+    An indicator to set the byte order of future messages.
+
+    Notes
+    -----
+    The 7-th bit of a header flags field indicates the server's selected byte
+    order for the connection on which this message was received. Client MUST
+    encode all the messages sent via this connection using this byte order.
+    """
+    ID = ControlCommands.SET_ENDIANESS
+    # uses EndianSetting in header payload size
+
+    def __init__(self, endian_setting):
+        assert endian_setting in (EndianSetting.use_message_byte_order,
+                                  EndianSetting.use_server_byte_order)
+        self.message_type = 0
+        self.payload_size = endian_setting
+
+    @property
+    def byte_order_setting(self):
+        return EndianSetting(self.payload_size)
+
+
+class EchoRequest(MessageHeaderLE):
+    """
+    A request to echo the payload.
+
+    Notes
+    -----
+    Diagnostic/test echo message. The receiver should respond with an Echo
+    response (0x04) message with the same payload size field value.
+
+    In protocol version v1:
+    * v1 servers reply to 'Echo' with empty payload.
+    * v1 clients never send 'Echo'.
+    * v1 peers never timeout inactive TCP connections.
+
+    In protocol version v2:
+    * v2 clients must send 'Echo' more often than $EPICS_PVA_CONN_TMO seconds.
+    The recommended interval is half of $EPICS_PVA_CONN_TMO (default 15 sec.).
+    """
+    ID = ControlCommands.ECHO_REQUEST
+
+
+class EchoResponse(MessageHeaderLE):
+    """
+    A response to an echo request.
+
+    Notes
+    -----
+    The payload size field contains the same value as in the request message.
+
+    In protocol version v2:
+    * v2 server's 'Echo' reply must include the request payload.
+    * v2 peers must close TCP connections when no data has been received in
+    $EPICS_PVA_CONN_TMO seconds (default 30 sec.).
+    """
+    ID = ControlCommands.ECHO_REQUEST
+
+
+class ConnectionValidationRequest(ExtendedMessageBase):
+    """
+    A validation request from the server.
+
+    Notes
+    -----
+    A ConnectionValidationRequest message MUST be the first application message
+    sent from the server to a client when a TCP/IP connection is established
+    (after a Set byte order Control message). The client MUST NOT send any
+    messages on the connection until it has received a connection validation
+    message from the server.
+
+    The server lists the support authentication methods. Currently supported
+    are "anonymous" and "ca". In the ConnectionValidationResponse, the client
+    selects one of these. For "anonymous", no further detail is required. For
+    "ca", a structure with string elements "user" and "host" needs to follow.
+    """
+    ID = ApplicationCommands.CONNECTION_VALIDATION
+
+    _fields_ = [
+        ('server_buffer_size', ctypes.c_int32),
+        ('server_registry_size', ctypes.c_int16),
+    ]
+
+    _additional_fields_ = [
+        RequiredField('auth_nz', array_of(FieldType.string)),
+    ]
+
+
+class ConnectionValidationResponse(ExtendedMessageBase):
+    """
+    A client's connection validation response message.
+
+    Notes
+    -----
+    Each Quality of Service (QoS) parameter value REQUIRES a separate TCP/IP
+    connection. If the Low-latency priority bit is set, this indicates clients
+    should attempt to minimize latency if they have the capacity to do so. If
+    the Throughput priority bit is set, this indicates a client similarly
+    should attempt to maximize throughput. How this is achieved is
+    implementation defined. The Compression bit enables compression for the
+    connection (Which compression? From which support layer?). A matter for a
+    future version of the specification should be whether a streaming mode
+    algorithm should be specified.
+    """
+    ID = ApplicationCommands.CONNECTION_VALIDATION
+
+    _fields_ = [
+        ('client_buffer_size', ctypes.c_int32),
+        ('client_registry_size', ctypes.c_int16),
+        ('connection_qos', ctypes.c_int16),
+    ]
+
+    _additional_fields_ = [
+        RequiredField('auth_nz', FieldType.string),
+        OptionalField('user', FieldType.string,
+                      condition=lambda msg, buf: msg.auth_nz == 'ca',
+                      stop=OptionalStopMarker.stop),
+        OptionalField('host', FieldType.string,
+                      condition=lambda msg, buf: msg.auth_nz == 'ca',
+                      stop=OptionalStopMarker.stop),
+    ]
+
+
+class Echo(ExtendedMessageBase):
+    """
+    A TCP Echo request/response.
+
+    Notes
+    -----
+    An Echo diagnostic message is usually sent to check if TCP/IP connection is
+    still valid.
+    """
+    ID = ApplicationCommands.ECHO
+    _additional_fields_ = [
+        RequiredField('payload', array_of(FieldType.byte)),
+    ]
+
+
+class ConnectionValidatedResponse(Status):
+    """Validation results - success depends on the status."""
+    ID = ApplicationCommands.CONNECTION_VALIDATED
+
+
+class SearchRequest(ExtendedMessageBase):
+    """
+    A search request for PVs by name.
+
+    Notes
+    -----
+    A channel "search request" message SHOULD be sent over UDP/IP, however UDP
+    congestion control SHOULD be implemented in this case. A server MUST accept
+    this message also over TCP/IP.
+
+    Note that the element count for protocol uses the normal size encoding,
+    i.e. unsigned 8-bit integer 1 for one supported protocol. The element count
+    for the channels array, however, always uses an unsigned 16 bit integer.
+    This choice is based on the reference implementations which append channel
+    names to the network buffer and update the count. With normal size
+    encoding, an increment to 254 would change the count from requiring 1 byte
+    to 3 bytes, shifting already added channel names.
+
+    In caproto-pva, this becomes the :class:`NonstandardArrayField`.
+    """
+    ID = ApplicationCommands.SEARCH_REQUEST
+
+    _fields_ = [
+        ('sequence_id', ctypes.c_int32),
+        ('flags', ctypes.c_ubyte),
+        ('reserved', ctypes.c_ubyte * 3),
+        ('_response_address', ctypes.c_ubyte * 16),
+        ('response_port', ctypes.c_uint16),
+    ]
+
+    _additional_fields_ = [
+        RequiredField('protocols', array_of(FieldType.string)),
+        # TODO custom handling as this expects a SHORT count before the number
+        # of arrays.
+        # if it were implemented as expected, this would be all that's
+        # necessary:
+        # RequiredField('channels', 'channel_with_id[]'),
+        RequiredField('channel_count', FieldType.uint16),
+        NonstandardArrayField('channels', ChannelWithID,
+                              count_attr='channel_count'),
+    ]
+
+    @property
+    def response_address(self):
+        return ubyte_array_to_ip(self._response_address)
+
+    @response_address.setter
+    def response_address(self, value):
+        self._response_address = ip_to_ubyte_array(value)
+
+    def serialize(self, *args, **kwargs):
+        self.channel_count = len(self.channels)
+        return super().serialize(*args, **kwargs)
+
+
+def _array_property(name, doc):
+    'Array property to make handling ctypes arrays a bit easier'
+    def fget(self):
+        return bytes(getattr(self, name))
+
+    def fset(self, value):
+        item = getattr(self, name)
+        item[:] = value
+
+    return property(fget, fset, doc=doc)
+
+
+class SearchResponse(ExtendedMessageBase):
+    """
+    A response to a SearchRequest.
+
+    Notes
+    -----
+    A client MUST examine the protocol member field to verify it supports the
+    given exchange protocol; if not, the search response is ignored.
+
+    The count for the number of searchInstanceIDs elements is always sent as an
+    unsigned 16 bit integer, not using the default size encoding.
+    """
+    ID = ApplicationCommands.SEARCH_RESPONSE
+
+    _fields_ = [
+        ('_guid', ctypes.c_ubyte * 12),
+        ('sequence_id', ctypes.c_int32),
+        ('_server_address', ctypes.c_ubyte * 16),
+        ('server_port', ctypes.c_uint16),
+    ]
+
+    _additional_fields_ = [
+        RequiredField('protocol', FieldType.string),
+        # TODO_DOCS found is not 'int' but 'byte' (uint8 or int8?)
+        RequiredField('found', FieldType.uint8),
+        # TODO_DOCS search_instance_ids array is prefixed by a short length
+        #  i.e., a nonstandard array serialization format
+        # RequiredField('search_instance_ids', array_of(FieldType.int32)),
+        RequiredField('search_count', FieldType.int16),
+        NonstandardArrayField('search_instance_ids', FieldType.int32,
+                              count_attr='search_count'),
+    ]
+
+    guid = _array_property('_guid', 'GUID for server')
+
+    @property
+    def server_address(self):
+        return ubyte_array_to_ip(self._server_address)
+
+    @server_address.setter
+    def server_address(self, value):
+        self._server_address = ip_to_ubyte_array(value)
+
+
+class CreateChannelRequest(ExtendedMessageBase):
+    """
+    A client's request to create a channel.
+
+    Notes
+    -----
+    A channel provides a communication path between a client and a server
+    hosted "process variable."  Each channel instance MUST be bound only to one
+    connection.
+
+    The CreateChannelRequest.channels array starts with a short count, not
+    using the normal size encoding. Current PVA server implementations only
+    support requests for creating a single channel, i.e. the count must be 1.
+
+    """
+    ID = ApplicationCommands.CREATE_CHANNEL
+
+    _additional_fields_ = [
+        RequiredField('count', FieldType.uint16),
+        NonstandardArrayField('channels', ChannelWithID, count_attr='count'),
+    ]
+
+
+class CreateChannelResponse(_StatusBase, ExtendedMessageBase):
+    """
+    A server's response to a CreateChannelRequest.
+
+    Notes
+    -----
+    A server MUST store the client ChannelID and respond with its value in a
+    destroyChannelMessage when a channel destroy request is requested, see
+    below. A client uses the serverChannelID value for all subsequent requests
+    on the channel. Agents SHOULD NOT make any assumptions about how given IDs
+    are generated. IDs MUST be unique within a connection and MAY be recycled
+    after a channel is disconnected.
+    """
+    ID = ApplicationCommands.CREATE_CHANNEL
+
+    _fields_ = [('client_chid', ctypes.c_int32),
+                ('server_chid', ctypes.c_int32),
+                ('_status_type', ctypes.c_byte),
+                ]
+    _additional_fields_ = Status._additional_fields_ + [
+        # TODO access rights aren't sent, even if status_type is OK
+        SuccessField('access_rights', FieldType.int16),
+    ]
+
+
+class ChannelDestroyRequest(MessageBase):
+    """
+    Request to destroy a previously-created channel.
+
+    Notes
+    -----
+    A "destroy channel" message is sent by a client to a server to destroy a
+    channel that was previously created (with a create channel message).
+
+    A server may also send this message to the client when the channel is no
+    longer available. Examples include a PVA gateway that sends this message
+    from its server side when it lost a channel on its client side.
+    """
+    # TODO: caproto-pva does not allow for a server to send this at the moment
+    ID = ApplicationCommands.DESTROY_CHANNEL
+    _fields_ = [('client_chid', ctypes.c_int32),
+                ('server_chid', ctypes.c_int32),
+                ]
+
+
+class ChannelDestroyResponse(_StatusBase, ExtendedMessageBase):
+    """
+    A response to a destroy request.
+
+    Notes
+    -----
+    If the request (clientChannelID, serverChannelID) pair does not match, the
+    server MUST respond with an error status. The server MAY break its response
+    into several messages.
+
+    A server MUST send this message to a client to notify the client about
+    server-side initiated channel destruction. Subsequently, a client MUST mark
+    such channels as disconnected. If the client's interest in the process
+    variable continues, it MUST start sending search request messages for the
+    channel.
+    """
+    ID = ApplicationCommands.DESTROY_CHANNEL
+
+    _fields_ = [('client_chid', ctypes.c_int32),
+                ('server_chid', ctypes.c_int32),
+                ('_status_type', ctypes.c_byte),
+                ]
+
+
+class ChannelGetRequest(ExtendedMessageBase):
+    """
+    A "channel get" set of messages are used to retrieve (get) data from the channel.
+    """
+    ID = ApplicationCommands.GET
+
+    _fields_ = [
+        ('server_chid', ctypes.c_int32),
+        ('ioid', ctypes.c_int32),
+        ('subcommand', ctypes.c_byte),
+    ]
+
+    _additional_fields_ = []
+    _subcommand_fields_ = {
+        Subcommands.INIT: [
+            RequiredField('pv_request', PVRequest),
+        ],
+        Subcommands.GET: [],
+        Subcommands.DESTROY: [],
+    }
+
+
+class ChannelGetResponse(_StatusBase, ExtendedMessageBase):
+    """
+    A response to a ChannelGetRequest.
+    """
+    ID = ApplicationCommands.GET
+
+    _fields_ = [
+        ('ioid', ctypes.c_int32),
+        ('subcommand', ctypes.c_byte),
+        ('_status_type', ctypes.c_byte),
+    ]
+    _subcommand_fields_ = {
+        Subcommands.INIT: [
+            SuccessField('pv_structure_if', FieldDesc),
+        ],
+        Subcommands.GET: [
+            SuccessField('pv_data', DataWithBitSet,
+                         # `pv_structure_if` is tracked by ioid
+                         ),
+        ],
+        Subcommands.DESTROY: [],
+    }
+
+
+class ChannelFieldInfoRequest(ExtendedMessageBase):
+    """
+    Used to retrieve a channel's type introspection data, i.e., a :class:`FieldDesc`.
+    """
+    ID = ApplicationCommands.GET_FIELD
+
+    _fields_ = [('server_chid', ctypes.c_int32),
+                ('ioid', ctypes.c_int32),
+                ]
+    _additional_fields_ = [
+        RequiredField('sub_field_name', FieldType.string),
+    ]
+
+
+class ChannelFieldInfoResponse(_StatusBase, ExtendedMessageBase):
+    """
+    A response to a :class:`ChannelFieldInfoRequest`.
+    """
+    ID = ApplicationCommands.GET_FIELD
+
+    _fields_ = [('ioid', ctypes.c_int32),
+                ('_status_type', ctypes.c_byte),
+                ]
+    _additional_fields_ = Status._additional_fields_ + [
+        SuccessField('field_if', FieldDesc),
+    ]
+
+
+class ChannelPutRequest(ExtendedMessageBase):
+    """
+    A "channel put" message is used to set (put) data to the channel.
+
+    After a put request is successfully initialized, the client can issue
+    actual put request(s) on the channel.
+
+    Notes
+    -----
+    A "GET_PUT" subcommand here retrieves the remote put structure. This MAY be
+    used by user applications to show data that was set the last time by the
+    application.
+    """
+    ID = ApplicationCommands.PUT
+
+    _fields_ = [('server_chid', ctypes.c_int32),
+                ('ioid', ctypes.c_int32),
+                ('subcommand', ctypes.c_byte),
+                ]
+    _additional_fields_ = []
+    _subcommand_fields_ = {
+        Subcommands.INIT: [
+            RequiredField('pv_request', PVRequest),
+        ],
+        Subcommands.GET: [
+            # Query what the last put request was
+            RequiredField('pv_put_data', Data),
+        ],
+        Subcommands.DEFAULT: [
+            # Perform the put
+            RequiredField('put_data', DataWithBitSet),
+        ],
+        # TODO mask DESTROY | DEFAULT
+        Subcommands.DESTROY: [],
+    }
+
+
+class ChannelPutResponse(_StatusBase, ExtendedMessageBase):
+    """
+    A response to a :class:`ChannelPutRequest`.
+    """
+    ID = ApplicationCommands.PUT
+
+    _fields_ = [('ioid', ctypes.c_int32),
+                ('subcommand', ctypes.c_byte),
+                ('_status_type', ctypes.c_byte),
+                ]
+
+    _subcommand_fields_ = {
+        Subcommands.INIT: [
+            SuccessField('put_structure_if', FieldDesc),
+        ],
+        Subcommands.DEFAULT: [
+            # The actual put
+        ],
+        Subcommands.DESTROY: [
+        ],
+    }
+
+
+class ChannelPutGetRequest(ExtendedMessageBase):
+    """
+    A "channel put-get" set of messages are used to set (put) data to the
+    channel and then immediately retrieve data from the channel. Channels are
+    usually "processed" or "updated" by their host between put and get, so that
+    the get reflects changes in the process variable's state.
+
+    After a put-get request is successfully initialized, the client can issue
+    actual put-get request(s) on the channel.
+
+    Notes
+    -----
+    A "GET_PUT" request retrieves the remote put structure. This MAY be used by
+    user applications to show data that was set the last time by the application.
+    """
+    ID = ApplicationCommands.PUT_GET
+
+    _fields_ = [('server_chid', ctypes.c_int32),
+                ('ioid', ctypes.c_int32),
+                ('subcommand', ctypes.c_byte),
+                ]
+    _additional_fields_ = []
+    _subcommand_fields_ = {
+        Subcommands.INIT: [
+            RequiredField('pv_request', PVRequest),
+        ],
+        Subcommands.DEFAULT: [
+            RequiredField('put_data', DataWithBitSet)
+        ],
+        Subcommands.GET: [
+            # Get the remote "put request"
+        ],
+        Subcommands.GET_PUT: [
+            # Get the remote "get request"
+        ],
+        Subcommands.DESTROY: [],
+    }
+
+
+class ChannelPutGetResponse(_StatusBase, ExtendedMessageBase):
+    """
+    A response to a :class:`ChannelPutGetRequest`.
+    """
+    ID = ApplicationCommands.PUT_GET
+
+    _fields_ = [('ioid', ctypes.c_int32),
+                ('subcommand', ctypes.c_byte),
+                ('_status_type', ctypes.c_byte),
+                ]
+
+    _subcommand_fields_ = {
+        Subcommands.INIT: [
+            SuccessField('put_structure_if', FieldDesc),
+            SuccessField('get_structure_if', FieldDesc),
+        ],
+        Subcommands.DEFAULT: [
+            SuccessField('pv_data', Data),
+        ],
+        Subcommands.GET: [
+            SuccessField('get_data', Data),
+        ],
+        Subcommands.GET_PUT: [
+            SuccessField('put_data', Data),
+        ],
+        Subcommands.DESTROY: [],
+    }
+
+
+class ChannelArrayRequest(ExtendedMessageBase):
+    """
+    A "channel array" set of messages are used to handle remote array values.
+    Requests allow a client agent to: retrieve (get) and set (put) data from/to
+    the array, and to change the array's length (number of valid elements in
+    the array).
+
+    Notes
+    -----
+    This is not yet implemented in caproto-pva.
+    """
+    ID = ApplicationCommands.ARRAY
+    # TODO
+
+
+class ChannelArrayResponse(ExtendedMessageBase):
+    """
+    A response to a :class:`ChannelArrayRequest`.
+
+    Notes
+    -----
+    This is not yet implemented in caproto-pva.
+    """
+    ID = ApplicationCommands.ARRAY
+    # TODO
+
+
+class ChannelRequestDestroyRequest(ExtendedMessageBase):
+    """
+    A "destroy request" messages is used destroy any request instance, i.e. an
+    instance with requestID.
+
+    Notes
+    -----
+    This is not yet implemented in caproto-pva.
+    """
+    ID = ApplicationCommands.DESTROY_REQUEST
+    # TODO
+
+
+class ChannelRequestDestroyResponse(ExtendedMessageBase):
+    """
+    A response to a :class:`ChannelRequestDestroyRequest`.
+
+    Notes
+    -----
+    This is not yet implemented in caproto-pva.
+    """
+    ID = ApplicationCommands.DESTROY_REQUEST
+    # TODO
+
+
+class ChannelRequestCancelRequest(ExtendedMessageBase):
+    """
+    A "cancel request" messages is used cancel any pending request, i.e. an
+    instance with a requestID.
+
+    Notes
+    -----
+    This is not yet implemented in caproto-pva.
+    """
+    ID = ApplicationCommands.CANCEL_REQUEST
+    # TODO
+
+
+class ChannelRequestCancelResponse(ExtendedMessageBase):
+    """
+    A response to a :class:`ChannelRequestCancelRequest`.
+
+    Notes
+    -----
+    This is not yet implemented in caproto-pva.
+    """
+    ID = ApplicationCommands.CANCEL_REQUEST
+    # TODO
+
+
+class ChannelMonitorRequest(ExtendedMessageBase):
+    """
+    The "channel monitor" set of messages are used by client agents to indicate
+    that they wish to be asynchronously informed of changes in the state or
+    values of the process variable of a channel.
+
+    Notes
+    -----
+    This is currently partially supported by caproto-pva.
+
+    More details on the `wiki <https://github.com/epics-base/pvAccessCPP/wiki/Protocol-Operation-Monitor>`_.
+    """
+    ID = ApplicationCommands.MONITOR
+
+    _fields_ = [('server_chid', ctypes.c_int32),
+                ('ioid', ctypes.c_int32),
+                ('subcommand', ctypes.c_byte),
+                ]
+    _additional_fields_ = []
+    _subcommand_fields_ = {
+        Subcommands.INIT: [
+            RequiredField('pv_request', PVRequest),
+            OptionalField('queue_size', 'int',
+                          OptionalStopMarker.stop,
+                          lambda msg, buf: bool(msg.subcommand &
+                                                MonitorSubcommands.PIPELINE)),
+        ],
+        Subcommands.DEFAULT: [],
+        MonitorSubcommands.START: [],
+        MonitorSubcommands.STOP: [],
+        # Subcommands.PIPELINE: [],
+        Subcommands.DESTROY: [],
+    }
+
+
+class ChannelMonitorResponse(ExtendedMessageBase):
+    """
+    A response to a :class:`ChannelMonitorRequest`.
+    """
+    ID = ApplicationCommands.MONITOR
+
+    _fields_ = [('ioid', ctypes.c_int32),
+                ('subcommand', ctypes.c_byte),
+                ]
+
+    @property
+    def is_successful(self) -> bool:
+        # status_type only on INIT!  Do not mix in _StatusBase.
+        status_type = getattr(self, '_status_type', StatusType.OK)
+        return status_type in success_status_types
+
+    _additional_fields_ = []
+    _subcommand_fields_ = {
+        MonitorSubcommands.INIT: [
+            RequiredField('status_type', FieldType.byte),
+        ] + Status._additional_fields_ + [
+            SuccessField('pv_structure_if', FieldDesc),
+        ],
+        MonitorSubcommands.DEFAULT: [
+            # `pv_structure_if` is tracked by ioid
+            RequiredField('pv_data', DataWithBitSet),
+            RequiredField('overrun_bitset', BitSet),
+        ],
+        # MonitorSubcommands.START: [],
+        # MonitorSubcommands.STOP: [],
+        MonitorSubcommands.PIPELINE: [
+            RequiredField('nfree', FieldType.int32),
+        ],
+        Subcommands.DESTROY: [],
+    }
+
+
+class ChannelProcessRequest(ExtendedMessageBase):
+    """
+    A "channel process" set of messages are used to indicate to the server that
+    the computation actions associated with a channel should be executed.
+
+    In EPICS terminology, this means that the channel should be "processed".
+
+    Notes
+    -----
+    After a process request is successfully initialized, the client can issue
+    the actual process request(s).
+    """
+    ID = ApplicationCommands.PROCESS
+
+    _fields_ = [('server_chid', ctypes.c_int32),
+                ('ioid', ctypes.c_int32),
+                ('subcommand', ctypes.c_byte),
+                ]
+    _additional_fields_ = []
+    _subcommand_fields_ = {
+        Subcommands.INIT: [
+            RequiredField('pv_request', PVRequest),
+            # TODO_DOCS typo serverStatusIF -> PVRequestIF
+        ],
+        Subcommands.DEFAULT: [],  # TODO: not PROCESS?
+        Subcommands.DESTROY: [],
+    }
+
+
+class ChannelProcessResponse(_StatusBase, ExtendedMessageBase):
+    """
+    A response to a :class:`ChannelProcessRequest`.
+    """
+    ID = ApplicationCommands.PROCESS
+
+    _fields_ = [('ioid', ctypes.c_int32),
+                ('subcommand', ctypes.c_byte),
+                ('_status_type', ctypes.c_byte),
+                ]
+
+    _subcommand_fields_ = {
+        Subcommands.INIT: [],
+        Subcommands.DEFAULT: [],  # TODO: not PROCESS?
+        Subcommands.DESTROY: [],
+    }
+
+
+class ChannelRpcRequest(ExtendedMessageBase):
+    """
+    A remote procedure call request.
+
+    Notes
+    -----
+    The "channel RPC" set of messages are used to provide remote procedure call
+    (RPC) support over pvAccess. After a RPC request is successfully
+    initialized, the client can issue actual RPC request(s).
+
+    """
+    ID = ApplicationCommands.RPC
+
+    _fields_ = [('server_chid', ctypes.c_int32),
+                ('ioid', ctypes.c_int32),
+                ('subcommand', ctypes.c_byte),
+                ]
+    _additional_fields_ = []
+    _subcommand_fields_ = {
+        Subcommands.INIT: [
+            RequiredField('pv_request', PVRequest),
+        ],
+        Subcommands.DEFAULT: [
+            RequiredField('pv_data', FieldDescAndData),
+        ],
+        Subcommands.DESTROY: [],
+    }
+
+
+class ChannelRpcResponse(_StatusBase, ExtendedMessageBase):
+    ID = ApplicationCommands.PROCESS
+
+    _fields_ = [('ioid', ctypes.c_int32),
+                ('subcommand', ctypes.c_byte),
+                ('_status_type', ctypes.c_byte),
+                ]
+
+    _subcommand_fields_ = {
+        Subcommands.INIT: [],
+        Subcommands.DEFAULT: [
+            SuccessField('pv_response', FieldDescAndData),
+        ],
+        Subcommands.DESTROY: [],
+    }
+
+
+class OriginTagRequest(_StatusBase, ExtendedMessageBase):
+    """
+    When a client or server receives a packet containing a Search message with
+    flagged "sent as unicast" it may resend this as a multicast to
+    "224.0.0.128" through the loopback interface ("127.0.0.1").
+
+    Notes
+    -----
+    This is not yet implemented in caproto-pva.
+
+    More details on the `wiki
+    <https://github.com/epics-base/pvAccessCPP/wiki/Protocol-Messages#cmd_origin_tag-0x16>`_.
+    """
+    ID = ApplicationCommands.ORIGIN_TAG
+
+
+BIG_ENDIAN, LITTLE_ENDIAN = BIG_ENDIAN, LITTLE_ENDIAN  # removed below
+BeaconMessageBE = _make_endian(BeaconMessage, BIG_ENDIAN)
+BeaconMessageLE = _make_endian(BeaconMessage, LITTLE_ENDIAN)
+EchoBE = _make_endian(Echo, BIG_ENDIAN)
+EchoLE = _make_endian(Echo, LITTLE_ENDIAN)
+StatusBE = _make_endian(Status, BIG_ENDIAN)
+StatusLE = _make_endian(Status, LITTLE_ENDIAN)
+
+ChannelDestroyRequestBE = _make_endian(ChannelDestroyRequest, BIG_ENDIAN)
+ChannelDestroyRequestLE = _make_endian(ChannelDestroyRequest, LITTLE_ENDIAN)
+ChannelDestroyResponseBE = _make_endian(ChannelDestroyResponse, BIG_ENDIAN)
+ChannelDestroyResponseLE = _make_endian(ChannelDestroyResponse, LITTLE_ENDIAN)
+ChannelFieldInfoRequestBE = _make_endian(ChannelFieldInfoRequest, BIG_ENDIAN)
+ChannelFieldInfoRequestLE = _make_endian(ChannelFieldInfoRequest, LITTLE_ENDIAN)
+ChannelFieldInfoResponseBE = _make_endian(ChannelFieldInfoResponse, BIG_ENDIAN)
+ChannelFieldInfoResponseLE = _make_endian(ChannelFieldInfoResponse, LITTLE_ENDIAN)
+ChannelGetRequestBE = _make_endian(ChannelGetRequest, BIG_ENDIAN)
+ChannelGetRequestLE = _make_endian(ChannelGetRequest, LITTLE_ENDIAN)
+ChannelGetResponseBE = _make_endian(ChannelGetResponse, BIG_ENDIAN)
+ChannelGetResponseLE = _make_endian(ChannelGetResponse, LITTLE_ENDIAN)
+ChannelMonitorRequestBE = _make_endian(ChannelMonitorRequest, BIG_ENDIAN)
+ChannelMonitorRequestLE = _make_endian(ChannelMonitorRequest, LITTLE_ENDIAN)
+ChannelMonitorResponseBE = _make_endian(ChannelMonitorResponse, BIG_ENDIAN)
+ChannelMonitorResponseLE = _make_endian(ChannelMonitorResponse, LITTLE_ENDIAN)
+ChannelProcessRequestBE = _make_endian(ChannelProcessRequest, BIG_ENDIAN)
+ChannelProcessRequestLE = _make_endian(ChannelProcessRequest, LITTLE_ENDIAN)
+ChannelProcessResponseBE = _make_endian(ChannelProcessResponse, BIG_ENDIAN)
+ChannelProcessResponseLE = _make_endian(ChannelProcessResponse, LITTLE_ENDIAN)
+ChannelPutGetRequestBE = _make_endian(ChannelPutGetRequest, BIG_ENDIAN)
+ChannelPutGetRequestLE = _make_endian(ChannelPutGetRequest, LITTLE_ENDIAN)
+ChannelPutGetResponseBE = _make_endian(ChannelPutGetResponse, BIG_ENDIAN)
+ChannelPutGetResponseLE = _make_endian(ChannelPutGetResponse, LITTLE_ENDIAN)
+ChannelPutRequestBE = _make_endian(ChannelPutRequest, BIG_ENDIAN)
+ChannelPutRequestLE = _make_endian(ChannelPutRequest, LITTLE_ENDIAN)
+ChannelPutResponseBE = _make_endian(ChannelPutResponse, BIG_ENDIAN)
+ChannelPutResponseLE = _make_endian(ChannelPutResponse, LITTLE_ENDIAN)
+ChannelRpcRequestBE = _make_endian(ChannelRpcRequest, BIG_ENDIAN)
+ChannelRpcRequestLE = _make_endian(ChannelRpcRequest, LITTLE_ENDIAN)
+ChannelRpcResponseBE = _make_endian(ChannelRpcResponse, BIG_ENDIAN)
+ChannelRpcResponseLE = _make_endian(ChannelRpcResponse, LITTLE_ENDIAN)
+ConnectionValidatedResponseBE = _make_endian(ConnectionValidatedResponse, BIG_ENDIAN)
+ConnectionValidatedResponseLE = _make_endian(ConnectionValidatedResponse, LITTLE_ENDIAN)
+ConnectionValidationRequestBE = _make_endian(ConnectionValidationRequest, BIG_ENDIAN)
+ConnectionValidationRequestLE = _make_endian(ConnectionValidationRequest, LITTLE_ENDIAN)
+ConnectionValidationResponseBE = _make_endian(ConnectionValidationResponse, BIG_ENDIAN)
+ConnectionValidationResponseLE = _make_endian(ConnectionValidationResponse, LITTLE_ENDIAN)
+CreateChannelRequestBE = _make_endian(CreateChannelRequest, BIG_ENDIAN)
+CreateChannelRequestLE = _make_endian(CreateChannelRequest, LITTLE_ENDIAN)
+CreateChannelResponseBE = _make_endian(CreateChannelResponse, BIG_ENDIAN)
+CreateChannelResponseLE = _make_endian(CreateChannelResponse, LITTLE_ENDIAN)
+SearchRequestBE = _make_endian(SearchRequest, BIG_ENDIAN)
+SearchRequestLE = _make_endian(SearchRequest, LITTLE_ENDIAN)
+SearchResponseBE = _make_endian(SearchResponse, BIG_ENDIAN)
+SearchResponseLE = _make_endian(SearchResponse, LITTLE_ENDIAN)
+
+FROM_CLIENT, FROM_SERVER = MessageFlags.FROM_CLIENT, MessageFlags.FROM_SERVER
+
+messages = {
+    # LITTLE ENDIAN, CLIENT -> SERVER
+    (LITTLE_ENDIAN, FROM_CLIENT): {
+        ApplicationCommands.BEACON: BeaconMessageLE,
+        ApplicationCommands.CONNECTION_VALIDATION: ConnectionValidationResponseLE,
+        ApplicationCommands.ECHO: EchoLE,
+        ApplicationCommands.SEARCH_REQUEST: SearchRequestLE,
+        ApplicationCommands.CREATE_CHANNEL: CreateChannelRequestLE,
+        ApplicationCommands.GET: ChannelGetRequestLE,
+        ApplicationCommands.GET_FIELD: ChannelFieldInfoRequestLE,
+        ApplicationCommands.DESTROY_CHANNEL: ChannelDestroyRequestLE,
+        ApplicationCommands.PUT: ChannelPutRequestLE,
+        ApplicationCommands.PUT_GET: ChannelPutGetRequestLE,
+        ApplicationCommands.MONITOR: ChannelMonitorRequestLE,
+        ApplicationCommands.PROCESS: ChannelProcessRequestLE,
+        ApplicationCommands.RPC: ChannelRpcRequestLE,
+    },
+
+    # BIG ENDIAN, CLIENT -> SERVER
+    (BIG_ENDIAN, FROM_CLIENT): {
+        ApplicationCommands.BEACON: BeaconMessageBE,
+        ApplicationCommands.CONNECTION_VALIDATION: ConnectionValidationResponseBE,
+        ApplicationCommands.ECHO: EchoBE,
+        ApplicationCommands.SEARCH_REQUEST: SearchRequestBE,
+        ApplicationCommands.CREATE_CHANNEL: CreateChannelRequestBE,
+        ApplicationCommands.GET: ChannelGetRequestBE,
+        ApplicationCommands.GET_FIELD: ChannelFieldInfoRequestBE,
+        ApplicationCommands.DESTROY_CHANNEL: ChannelDestroyRequestBE,
+        ApplicationCommands.PUT: ChannelPutRequestBE,
+        ApplicationCommands.PUT_GET: ChannelPutGetRequestBE,
+        ApplicationCommands.MONITOR: ChannelMonitorRequestBE,
+        ApplicationCommands.PROCESS: ChannelProcessRequestBE,
+        ApplicationCommands.RPC: ChannelRpcRequestBE,
+    },
+
+    # LITTLE ENDIAN, SERVER -> CLIENT
+    (LITTLE_ENDIAN, FROM_SERVER): {
+        ControlCommands.SET_ENDIANESS: SetByteOrder,
+        ApplicationCommands.BEACON: BeaconMessageLE,
+        ApplicationCommands.CONNECTION_VALIDATION: ConnectionValidationRequestLE,
+        ApplicationCommands.ECHO: EchoLE,
+        ApplicationCommands.CONNECTION_VALIDATED: ConnectionValidatedResponseLE,
+        ApplicationCommands.SEARCH_RESPONSE: SearchResponseLE,
+        ApplicationCommands.CREATE_CHANNEL: CreateChannelResponseLE,
+        ApplicationCommands.GET: ChannelGetResponseLE,
+        ApplicationCommands.GET_FIELD: ChannelFieldInfoResponseLE,
+        ApplicationCommands.DESTROY_CHANNEL: ChannelDestroyResponseLE,
+        ApplicationCommands.PUT: ChannelPutResponseLE,
+        ApplicationCommands.PUT_GET: ChannelPutGetResponseLE,
+        ApplicationCommands.MONITOR: ChannelMonitorResponseLE,
+        ApplicationCommands.PROCESS: ChannelProcessResponseLE,
+        ApplicationCommands.RPC: ChannelRpcResponseLE,
+    },
+
+    # BIG ENDIAN, SERVER -> CLIENT
+    (BIG_ENDIAN, FROM_SERVER): {
+        ControlCommands.SET_ENDIANESS: SetByteOrder,
+        ApplicationCommands.BEACON: BeaconMessageBE,
+        ApplicationCommands.CONNECTION_VALIDATION: ConnectionValidationRequestBE,
+        ApplicationCommands.ECHO: EchoBE,
+        ApplicationCommands.CONNECTION_VALIDATED: ConnectionValidatedResponseBE,
+        ApplicationCommands.SEARCH_RESPONSE: SearchResponseBE,
+        ApplicationCommands.CREATE_CHANNEL: CreateChannelResponseBE,
+        ApplicationCommands.GET: ChannelGetResponseBE,
+        ApplicationCommands.GET_FIELD: ChannelFieldInfoResponseBE,
+        ApplicationCommands.DESTROY_CHANNEL: ChannelDestroyResponseBE,
+        ApplicationCommands.PUT: ChannelPutResponseBE,
+        ApplicationCommands.PUT_GET: ChannelPutGetResponseBE,
+        ApplicationCommands.MONITOR: ChannelMonitorResponseBE,
+        ApplicationCommands.PROCESS: ChannelProcessResponseBE,
+        ApplicationCommands.RPC: ChannelRpcResponseBE,
+    },
+}
+
+
+def read_datagram(data: bytes,
+                  address: Tuple[str, int],
+                  role: Role,
+                  *,
+                  fixed_byte_order: Optional[UserFacingEndian] = None,
+                  cache: CacheContext = NullCache
+                  ) -> Deserialized:
+    """
+    Parse bytes from one datagram into one or more commands.
+
+    Parameters
+    ----------
+    data : bytes
+        The data to deserialize.
+
+    address : (addr, port)
+        The sender's address.
+
+    role : Role
+        The role of the sender.
+
+    fixed_byte_order : UserFacingEndian, optional
+        Use this specific byte order for deserialization.
+
+    cache : CacheContext, optional
+        The serialization cache.
+    """
+    buf = bytearray(data)
+    commands = []
+    offset = 0
+    direction_flag = (MessageFlags.FROM_SERVER
+                      if role == SERVER
+                      else MessageFlags.FROM_CLIENT)
+
+    while buf:
+        header, buf, off = MessageHeaderLE.deserialize(buf, cache=cache)
+        offset += off
+
+        msg_class = header.get_message(
+            direction_flag, use_fixed_byte_order=fixed_byte_order)
+        msg, buf, off = msg_class.deserialize(buf, cache=cache)
+        offset += off
+
+        commands.append(msg)
+
+    return Deserialized(data=commands, buffer=buf, offset=offset)
+
+
+def header_from_wire(data: bytes,
+                     byte_order: Optional[UserFacingEndian] = None
+                     ) -> 'MessageHeader':
+    """
+    Deserialize a message header from the wire.
+
+    Parameters
+    ----------
+    data : bytes
+        The data to deserialize.
+
+    byte_order : LITTLE_ENDIAN or BIG_ENDIAN, optional
+        Defaults to LITTLE_ENDIAN, falling back to BIG_ENDIAN if incorrect.
+        If specified, the fallback is not attempted.
+    """
+    if byte_order is not None:
+        # Use a fixed byte order, ignoring header flags
+        header_cls = (MessageHeaderLE
+                      if byte_order == LITTLE_ENDIAN
+                      else MessageHeaderBE)
+        header = header_cls.from_buffer(data)
+        assert header.valid, 'invalid header'
+        return header
+
+    # Guess little-endian, but fall back to big-endian if wrong.
+    header = MessageHeaderLE.from_buffer(data)
+    if header.byte_order != LITTLE_ENDIAN:
+        header = MessageHeaderBE.from_buffer(data)
+
+    assert header.valid, 'invalid header'
+    return header
+
+
+def bytes_needed_for_command(data, direction, cache, *, byte_order=None):
+    '''
+    Parameters
+    ----------
+    data
+    direction
+
+    Returns
+    -------
+    (header, num_bytes_needed, segmented)
+
+    If segmented, num_bytes_needed only applies to the current segment.
+    '''
+    data_len = len(data)
+
+    # We need at least one header's worth of bytes to interpret anything.
+    if data_len < _MessageHeaderSize:
+        return None, _MessageHeaderSize - data_len, None
+
+    header = header_from_wire(data, byte_order)
+    command = header.get_message(direction=direction,
+                                 use_fixed_byte_order=byte_order)
+    if issubclass(command, (SetByteOrder, )):
+        # SetByteOrder uses the payload in a custom way
+        return header, 0, False
+
+    total_size = _MessageHeaderSize + header.payload_size
+
+    if data_len < total_size:
+        return header, total_size - data_len, header.flags.is_segmented
+    return header, 0, header.flags.is_segmented
+
+
+def _deserialize_unsegmented_message(
+        msg_class: MessageBase,
+        data: bytes,
+        header: MessageHeader,
+        cache: CacheContext,
+        *,
+        payload_size: Optional[int] = None):
+    """
+    Deserialize a single, unsegmented message.
+
+    Parameters
+    ----------
+    msg_class : MessageBase
+        The message type to deserialize.
+
+    data : bytes
+        Sufficient data to deserialize the message.
+
+    header : MessageHeader
+        The associated message header.
+
+    cache : CacheContext
+        Serialization cache context.
+
+    payload_size : int, optional
+        The size of the message payload, if needed.  Generally, this can be
+        determined from the header.  However, some messages use the header
+        payload size in "special" ways, so allow overriding it as an argument.
+    """
+
+    if payload_size is None:
+        payload_size = header.payload_size
+
+    cmd, _, off = msg_class.deserialize(data, cache=cache, header=header)
+
+    if off != payload_size:
+        raise RuntimeError(
+            f'Number of bytes used in deserialization ({off}) did not match '
+            f'full payload size: {payload_size}'
+        )
+
+    return cmd, off
+
+
+def read_from_bytestream(
+        data: bytes, role: Role,
+        segment_state: Optional[Union[bytes, ChannelLifeCycle]],
+        cache: CacheContext,
+        *,
+        byte_order=UserFacingEndian) -> SegmentDeserialized:
+    '''
+    Handles segmentation but requires the caller to track it for us.
+
+    Parameters
+    ----------
+    data : bytes
+        The new data.
+
+    role : Role
+        Their role.
+
+    segment_state : ChannelLifeCycle, byte, or None
+        The state of segmentation, if available.
+
+    cache : CacheContext
+        Serialization cache context.
+
+    byte_order : LITTLE_ENDIAN or BIG_ENDIAN, optional
+        Fixed byte order if server message endianness is to be interpreted on a
+        message-by-message basis.
+
+    Returns
+    -------
+    SegmentDeserialized
+    '''
+    direction = (MessageFlags.FROM_SERVER
+                 if role == SERVER
+                 else MessageFlags.FROM_CLIENT)
+
+    header, num_bytes_needed, segmented = bytes_needed_for_command(
+        data, direction, cache=cache, byte_order=byte_order)
+
+    if num_bytes_needed > 0:
+        data = Deserialized(data=ChannelLifeCycle.NEED_DATA, buffer=data, offset=0)
+        return SegmentDeserialized(data,
+                                   bytes_needed=num_bytes_needed,
+                                   segment_state=None)
+
+    msg_class = header.get_message(direction=direction,
+                                   use_fixed_byte_order=byte_order)
+
+    data = memoryview(data)
+    payload_start = _MessageHeaderSize
+    if issubclass(msg_class, (SetByteOrder, )):
+        message_start = 0
+        payload_size = _MessageHeaderSize
+    else:
+        message_start = payload_start
+        payload_size = header.payload_size
+
+    message_end = message_start + payload_size
+    next_data = data[message_end:]
+    payload_data = data[message_start:message_end]
+
+    if not header.flags.is_segmented:
+        msg, offset = _deserialize_unsegmented_message(
+            msg_class=msg_class,
+            data=payload_data,
+            header=header,
+            cache=cache,
+            payload_size=payload_size,
+        )
+        return SegmentDeserialized(
+            Deserialized(data=msg, buffer=next_data, offset=offset),
+            bytes_needed=0, segment_state=None,
+        )
+
+    # Otherwise, we're dealing with a segmented message - a large message
+    # broken up over multiple segments.
+
+    # TODO: docs indicate payloads should be aligned, but i can't confirm this
+    # if len(segment_state):
+    #     last_segment = segment_state[-1]
+    #     start_padding = 8 - (len(last_segment) % 8)
+    #     print('alignment padding', start_padding)
+    #     message_start += start_padding
+
+    if MessageFlags.LAST not in header.flags:
+        # Not the last segment - just return it; need at least another header
+        return SegmentDeserialized(
+            Deserialized(data=ChannelLifeCycle.NEED_DATA, buffer=next_data,
+                         offset=message_end),
+            bytes_needed=_MessageHeaderSize,
+            segment_state=bytes(payload_data),
+        )
+
+    # This is the last segment, combine all and deserialize.
+    full_payload = bytearray(b''.join(segment_state))
+    full_payload += payload_data
+
+    header.payload_size = len(full_payload)
+    msg, _ = _deserialize_unsegmented_message(
+        msg_class=msg_class,
+        data=memoryview(full_payload),
+        header=header,
+        cache=cache,
+        payload_size=header.payload_size,
+    )
+    return SegmentDeserialized(
+        Deserialized(data=msg, buffer=next_data, offset=message_end),
+        bytes_needed=0,
+        segment_state=ChannelLifeCycle.CLEAR_SEGMENTS,
+    )

--- a/caproto/pva/_normative.py
+++ b/caproto/pva/_normative.py
@@ -1,0 +1,56 @@
+# TODO: class-based definitions + usual introspection abilities as well?
+# TODO: NTValue class which helps handle a structured value of an NTType?
+
+import logging
+
+from ._core import FieldType
+from ._dataclass import PvaStruct, pva_dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@pva_dataclass
+class time_t:
+    secondsPastEpoch: FieldType.long = 0
+    nanoseconds: FieldType.int32 = 0
+    userTag: FieldType.int32 = 0
+
+
+@pva_dataclass
+class alarm_t:
+    severity: FieldType.int32 = 0
+    status: FieldType.int32 = 0
+    message: FieldType.string = ''
+
+
+@pva_dataclass
+class display_t:
+    limitLow: FieldType.double = 0.0  # TODO: type depends on value (isnumeric)
+    limitHigh: FieldType.double = 0.0  # TODO: type depends on value
+    description: FieldType.string = ''
+    format: FieldType.string = ''
+    units: FieldType.string = ''
+
+
+@pva_dataclass
+class control_t:
+    limitLow: FieldType.double = 0.0
+    limitHigh: FieldType.double = 0.0
+    minStep: FieldType.double = 0.0
+
+
+class combined(metaclass=PvaStruct):
+    time: time_t
+    alarm: alarm_t
+    display: display_t
+    control: control_t
+
+
+# ? epics:nt/NTScalar:1.0
+# ? epics:nt/NTScalarArray:1.0
+# value
+# alarm_t
+# time_t
+# display_t
+# control_t
+# value alarm?

--- a/caproto/pva/_pvrequest.py
+++ b/caproto/pva/_pvrequest.py
@@ -1,0 +1,295 @@
+'''PVRequest parsing
+
+Reference: http://epics-pvdata.sourceforge.net/informative/pvRequest.html
+
+PVRequests come in the form of either:
+
+    1. A full definition
+        'record[option,...]
+         field(fieldDef,...)
+         putField(fieldDef,...)
+         getField(fieldDef,...)
+         '
+    2. A set of FieldDefs
+        'fieldDef,...'
+
+where FieldDefs are of the form:
+
+    1. 'fullFieldName'
+    2. 'fullFieldName[option,...]'
+    3. 'fullFieldName{request}' - a recursive definition.
+
+This had a full
+'''
+
+import typing
+from collections import namedtuple
+
+from parsimonious.grammar import Grammar, NodeVisitor
+
+from ._core import FieldArrayType, FieldType
+from ._fields import (SimpleField, StructuredField, _children_from_field_list,
+                      _descendents_from_field_list)
+
+_Record = namedtuple('Record', 'options')
+_FieldCategory = namedtuple('FieldCategory', 'name fields')
+_FieldDef = namedtuple('FieldDef', 'field_name options request')
+_Option = namedtuple('Option', 'name value')
+_ParsedPVRequest = namedtuple('PVRequest', 'record field getField putField')
+
+
+pvrequest_grammar = Grammar(r"""
+    PVRequest       = (record / field_category / field_def)*
+
+    category_name   = ("field" / "getField" / "putField")
+    field_category  = category_name "(" field_def* ")" ","?
+
+    record          = "record" options ","?
+    field_def       = identifier options? subfield? ","?
+    options         = "[" single_option* "]"
+    single_option   = identifier "=" value ","?
+    subfield        = "{" PVRequest "}"
+
+    identifier      = ~"[a-z_][a-z_0-9]*"i ("." identifier+)?
+    value           = ( identifier / ~"[0-9\.]+" )
+    """)
+
+
+class PVRequestToStructureVisitor(NodeVisitor):
+    grammar = pvrequest_grammar
+
+    def visit_PVRequest(self, node, visited_children):
+        req_kw = dict(record=None,
+                      field=[],
+                      getField=None,
+                      putField=None)
+        for child in visited_children:
+            child = child[0]
+            if isinstance(child, _Record):
+                req_kw['record'] = child
+            elif isinstance(child, _FieldCategory):
+                if child.fields:
+                    if child.name == 'field':
+                        req_kw['field'].extend(child.fields)
+                    else:
+                        req_kw[child.name] = child.fields
+            else:
+                req_kw['field'].append(child)
+
+        return _ParsedPVRequest(**req_kw)
+
+    def visit_subfield(self, node, visited_children):
+        _, pvreq, _ = visited_children
+        return pvreq
+
+    def visit_(self, node, visited_children):
+        return visited_children or node
+
+    def visit_record(self, node, visited_children):
+        _, options, _ = visited_children
+        return _Record(options=options)
+
+    def visit_field_def(self, node, visited_children):
+        identifier, option, subfield, comma = visited_children
+        option = option[0] if isinstance(option, list) else None
+        subfield = subfield[0] if isinstance(subfield, list) else None
+
+        # due to excessive * usage?
+        return _FieldDef(field_name=identifier,
+                         options=option,
+                         request=subfield,
+                         )
+
+    def visit_options(self, node, visited_children):
+        _, options, _ = visited_children
+        if not isinstance(options, list) and options.text == '':
+            options = None
+        return options
+
+    def visit_single_option(self, node, visited_children):
+        identifier, _equals, value, _comma = visited_children
+        return _Option(name=identifier, value=value)
+
+    def visit_field_category(self, node, visited_children):
+        name, _, field_defs, _, _ = visited_children
+        if not isinstance(field_defs, list) and field_defs.text == '':
+            field_defs = None
+        return _FieldCategory(name=name, fields=field_defs)
+
+    def visit_category_name(self, node, visited_children):
+        return node.text
+
+    def visit_identifier(self, node, visited_children):
+        return node.text
+
+    def visit_value(self, node, visited_children):
+        return node.text
+
+
+# field_options = dict(
+#     array=FieldOption(valid_for=_scalar_arrays,
+#                       arg_map={
+#                           1: namedtuple('ArraySlice1', 'start'),
+#                           2: namedtuple('ArraySlice2', 'start end'),
+#                           3: namedtuple('ArraySlice3', 'start increment end'),
+#                       },
+#                       valid_args=None,
+#                       ),
+#     deadband=FieldOption(valid_for=scalar_type_names,
+#                          arg_map={
+#                              2: namedtuple('Deadband', 'abs_rel value'),
+#                          },
+#                          valid_args={'abs_rel': {'abs', 'rel'}},
+#                          ),
+#     timestamp=FieldOption(valid_for='timeStamp_t',
+#                           arg_map={
+#                               1: namedtuple('Timestamp', 'option'),
+#                           },
+#                           valid_args={'option': {'current', 'copy'}},
+#                           ),
+#     ignore=_BoolFieldOption('ignore'),
+#     causeMonitor=_BoolFieldOption('cause_monitor'),
+#     algorithm=FieldOption(valid_for='all',
+#                           arg_map={
+#                               1: namedtuple('Ignore', 'option'),
+#                           },
+#                           valid_args={1: {'onPut', 'onChange',
+#                                           'deadband', 'periodic'}},
+#                           ),
+# )
+
+
+def _new_struct(fields, struct_name='', parent=None, name=''):
+    struct = PVRequestStruct(
+        field_type=FieldType.struct,
+        array_type=FieldArrayType.scalar,
+        name=name,
+        struct_name=struct_name,
+        metadata={'parent': parent},
+        children=_children_from_field_list(fields.values()),
+        descendents=_descendents_from_field_list(fields.values()),
+        size=None,
+    )
+    struct.values = {
+        name: getattr(child, 'values', {})
+        for name, child in struct.children.items()
+    }
+    return struct
+
+
+def _new_options(options):
+    struct = _new_struct(
+        {opt.name: SimpleField(
+            field_type=FieldType.string,
+            array_type=FieldArrayType.scalar,
+            name=opt.name,
+            size=None,
+        ) for opt in options},
+        name='_options',
+    )
+    struct.values = dict(options)
+    return struct
+
+
+class _PVRequestNode:
+    """Tree node to create structures from the bottom-up."""
+
+    def __init__(self, name, field_def=None, root=False):
+        self.name = name
+        self.children = {}
+        self.field_def = field_def
+        self.root = root
+        if field_def is not None:
+            field_def = field_def._replace(field_name=name)
+
+    def add_item(self, name, item):
+        first, *rest = name.split('.')
+        if len(rest) == 0:
+            assert first not in self.children, 'dupe?'
+            self.children[first] = _PVRequestNode(first, field_def=item)
+            return
+
+        if first not in self.children:
+            self.children[first] = _PVRequestNode(name=first)
+
+        self.children[first].add_item('.'.join(rest), item)
+
+    def to_structure(self):
+        fields = {}
+        for name, node in self.children.items():
+            if node.field_def is not None:
+                ret = PVRequestStruct._from_parsed(node.field_def)
+                ret = _new_struct(dict(ret.children),
+                                  struct_name=ret.struct_name, name=name)
+                fields[name] = ret
+            else:
+                fields[name] = node.to_structure()
+
+        return _new_struct(fields=fields, name=self.name)
+
+    def __repr__(self):
+        return f'<Node {self.name} {self.children}>'
+
+
+class PVRequestStruct(StructuredField):
+    _pv_request_to_structure = PVRequestToStructureVisitor()
+    values: typing.Dict[str, typing.Union[typing.Dict, str]]
+
+    @classmethod
+    def from_string(cls, req):
+        req = cls._pv_request_to_structure.parse(req.replace(' ', ''))
+        return cls._from_parsed(req)
+
+    @classmethod
+    def _from_field_def(cls, req, outer_name=''):
+        fields = {}
+        if req.options:
+            fields['_options'] = _new_options(req.options)
+
+        if req.request:
+            if any(getattr(req.request, other, None)
+                   for other in ('record', 'getField', 'putField')):
+                raise ValueError('Unsupported full nested PVRequest '
+                                 'specification {}'.format(req.request))
+
+            sub_struct = cls._from_parsed(req.request)
+            # confusing mix here: top sub_structure just has fields
+            # ('record', 'field', ...), we want the fields of
+            # 'top_struct.field'
+            if 'field' in sub_struct.children:
+                fields.update(**sub_struct.children['field'].children)
+
+        ret = _new_struct(fields, struct_name=outer_name)
+        return ret
+
+    @classmethod
+    def _from_parsed_pvrequest(cls, req, outer_name=''):
+        fields = {}
+        if req.record is not None:
+            record_fields = {}
+            if req.record.options:
+                record_fields['_options'] = _new_options(req.record.options)
+                # TODO value thrown away
+            fields['record'] = _new_struct(record_fields, name='record')
+
+        for category in ('field', 'getField', 'putField'):
+            cat_fields = getattr(req, category, None)
+            if cat_fields is None or not len(cat_fields):
+                continue
+
+            root = _PVRequestNode(name=category, root=True)
+            for field_def in cat_fields:
+                root.add_item(field_def.field_name, field_def)
+
+            fields[category] = root.to_structure()
+
+        return _new_struct(fields=fields, name=outer_name)
+
+    @classmethod
+    def _from_parsed(cls, req, outer_name=''):
+        'PVRequest namedtuple -> PVStructure description'
+        if isinstance(req, _FieldDef):
+            return cls._from_field_def(req, outer_name=outer_name)
+        if isinstance(req, _ParsedPVRequest):
+            return cls._from_parsed_pvrequest(req, outer_name=outer_name)
+        raise TypeError(str(type(req)))

--- a/caproto/pva/_repr_helper.py
+++ b/caproto/pva/_repr_helper.py
@@ -1,0 +1,139 @@
+"""
+This is a tool that allows you to re-create a FieldDesc from a pvAccess
+documentation-style repr such as::
+
+    struct my_struct
+        byte[] value
+        byte<16> boundedSizeArray
+        byte[4] fixedSizeArray
+        struct timeStamp_t timeStamp
+            long secondsPastEpoch
+            uint nanoSeconds
+            uint userTag
+
+
+(TODO: I think this should be removed entirely, or perhaps support a better
+ syntax)
+"""
+
+
+import ast
+import dataclasses
+import typing
+
+from parsimonious.grammar import Grammar, NodeVisitor, OneOf, Optional
+
+from ._core import FieldArrayType
+
+
+@dataclasses.dataclass
+class DefinitionLine:
+    type_name: str
+    array_info: str
+    name: str
+    value: str
+
+    def __str__(self):
+        line = f'{self.type_name}{self.array_info} {self.name}'
+        if self.value is not None:
+            return f'{line} = {self.value!r}'
+        return line
+
+
+@dataclasses.dataclass
+class ArrayTypeAndSize:
+    array_type: FieldArrayType
+    size: typing.Optional[int]
+
+    def format_index(self, index):
+        if index is None:
+            index = ''
+
+        return {
+            FieldArrayType.fixed_array: '[{}]',
+            FieldArrayType.bounded_array: '<{}>',
+            FieldArrayType.variable_array: '[{}]',
+        }.get(self.array_type, '').format(index)
+
+    def __str__(self):
+        return self.format_index(self.size)
+
+
+definition_line_grammar = Grammar(
+    r"""
+    definition_line = _ type_name _ array_info _ name _ value?
+    type_name       = identifier
+    name            = identifier
+    value           = "=" _ ~r".*$"
+    array_info      = ( fixed_array / bounded_array / variable_array )?
+    fixed_array     = "[" array_size "]"
+    variable_array  = "[" _ "]"
+    bounded_array   = "<" array_size ">"
+    array_size      = _ ~r"[1-9][0-9]*" _
+    identifier      = ~"[a-z_][a-z_0-9]*"i
+
+    # whitespace
+    _               = ~r"\s*"
+    """
+)
+
+
+class DefinitionLineVisitor(NodeVisitor):
+    grammar = definition_line_grammar
+
+    def generic_visit(self, node, visited_children):
+        if isinstance(node.expr, Optional):
+            # top-level optionals come here ('value?' etc.)
+            return (visited_children[0] if visited_children
+                    else None)
+        elif isinstance(node.expr, OneOf):
+            return visited_children[0]
+
+        return node.text or visited_children or None
+
+    def visit_definition_line(self, node, visited_children):
+        type_name, array_info, name, value = visited_children[1::2]
+        return DefinitionLine(type_name=type_name, array_info=array_info,
+                              name=name, value=value)
+
+    def visit_type_name(self, node, visited_children):
+        return visited_children[0]
+
+    visit_name = visit_type_name
+
+    def visit_value(self, node, visited_children):
+        equals, _, value_string = visited_children
+        return (ast.literal_eval(value_string)
+                if value_string else None)
+
+    def visit_array_info(self, node, visited_children):
+        if not node.text:
+            return ArrayTypeAndSize(array_type=FieldArrayType.scalar,
+                                    size=None)
+        return visited_children[0]
+
+    def visit_array_size(self, node, visited_children):
+        return int(node.text)
+
+    def visit_fixed_array(self, node, visited_children):
+        _, array_size, _ = visited_children
+        return ArrayTypeAndSize(array_type=FieldArrayType.fixed_array,
+                                size=array_size)
+
+    def visit_bounded_array(self, node, visited_children):
+        _, array_size, _ = visited_children
+        return ArrayTypeAndSize(array_type=FieldArrayType.bounded_array,
+                                size=array_size)
+
+    def visit_variable_array(self, node, visited_children):
+        return ArrayTypeAndSize(array_type=FieldArrayType.variable_array,
+                                size=None)
+
+    def visit_identifier(self, node, visited_children):
+        return node.text
+
+    def visit__(self, node, visited_children):
+        'Whitespace'
+
+
+definition_line_visitor = DefinitionLineVisitor()

--- a/caproto/pva/_state.py
+++ b/caproto/pva/_state.py
@@ -1,0 +1,336 @@
+from .._state import ChannelState as _ChannelState
+from .._state import CircuitState as _CircuitState
+from .._state import _BaseState
+from ._messages import (ApplicationCommands, ChannelDestroyRequest,
+                        ChannelDestroyResponse, ChannelFieldInfoRequest,
+                        ChannelFieldInfoResponse, ChannelGetRequest,
+                        ChannelGetResponse, ChannelMonitorRequest,
+                        ChannelMonitorResponse, ChannelProcessRequest,
+                        ChannelProcessResponse, ChannelPutGetRequest,
+                        ChannelPutGetResponse, ChannelPutRequest,
+                        ChannelPutResponse, ChannelRpcRequest,
+                        ChannelRpcResponse, ConnectionValidatedResponse,
+                        ConnectionValidationRequest,
+                        ConnectionValidationResponse, CreateChannelRequest,
+                        CreateChannelResponse, MessageFlags,
+                        MonitorSubcommands, SetByteOrder, Subcommands)
+from ._utils import (CLIENT, CONNECTED, DISCONNECTED, INIT, NEVER_CONNECTED,
+                     RESPONSIVE, SERVER, UNRESPONSIVE, LocalProtocolError,
+                     RemoteProtocolError)
+
+# TODO: SetMarker, AcknowledgeMarker, BeaconMessage, Echo, SearchRequest, SearchResponse,
+# TODO: DESTROYED, IN_PROGRESS, NEED_DATA, READY
+
+# Connection state; Channel life-cycle;
+# also: CONNECTED, DISCONNECTED; Channel
+# request; also: DISCONNECTED, DESTROYED
+
+
+COMMAND_TRIGGERED_CIRCUIT_TRANSITIONS = {
+    CLIENT: {
+        INIT: {
+            SetByteOrder: CONNECTED,
+        },
+        CONNECTED: {
+            ConnectionValidationRequest: CONNECTED,
+            ConnectionValidationResponse: CONNECTED,
+            ConnectionValidatedResponse: RESPONSIVE,
+        },
+        RESPONSIVE: {
+            CreateChannelRequest: RESPONSIVE,
+            CreateChannelResponse: RESPONSIVE,
+            ChannelFieldInfoRequest: RESPONSIVE,
+            ChannelFieldInfoResponse: RESPONSIVE,
+            ChannelGetRequest: RESPONSIVE,
+            ChannelGetResponse: RESPONSIVE,
+            ChannelPutRequest: RESPONSIVE,
+            ChannelPutResponse: RESPONSIVE,
+            ChannelMonitorRequest: RESPONSIVE,
+            ChannelMonitorResponse: RESPONSIVE,
+            ChannelPutGetRequest: RESPONSIVE,
+            ChannelPutGetResponse: RESPONSIVE,
+            ChannelRpcRequest: RESPONSIVE,
+            ChannelRpcResponse: RESPONSIVE,
+            ChannelProcessRequest: RESPONSIVE,
+            ChannelProcessResponse: RESPONSIVE,
+            ChannelDestroyRequest: RESPONSIVE,
+            ChannelDestroyResponse: RESPONSIVE,
+        },
+        UNRESPONSIVE: {
+        },
+        DISCONNECTED: {
+            # a terminal state that may only be reached by a special method
+        },
+    },
+    SERVER: {
+        INIT: {
+            SetByteOrder: CONNECTED,
+        },
+        CONNECTED: {
+            ConnectionValidationRequest: CONNECTED,
+            ConnectionValidationResponse: CONNECTED,
+            ConnectionValidatedResponse: RESPONSIVE,
+        },
+        RESPONSIVE: {
+            CreateChannelRequest: RESPONSIVE,
+            CreateChannelResponse: RESPONSIVE,
+            ChannelFieldInfoRequest: RESPONSIVE,
+            ChannelFieldInfoResponse: RESPONSIVE,
+            ChannelGetRequest: RESPONSIVE,
+            ChannelGetResponse: RESPONSIVE,
+            ChannelMonitorRequest: RESPONSIVE,
+            ChannelMonitorResponse: RESPONSIVE,
+            ChannelPutRequest: RESPONSIVE,
+            ChannelPutResponse: RESPONSIVE,
+            ChannelPutGetRequest: RESPONSIVE,
+            ChannelPutGetResponse: RESPONSIVE,
+            ChannelRpcRequest: RESPONSIVE,
+            ChannelRpcResponse: RESPONSIVE,
+            ChannelProcessRequest: RESPONSIVE,
+            ChannelProcessResponse: RESPONSIVE,
+            ChannelDestroyRequest: RESPONSIVE,
+            ChannelDestroyResponse: RESPONSIVE,
+        },
+        UNRESPONSIVE: {
+        },
+        DISCONNECTED: {
+            # a terminal state that may only be reached by a special method
+        },
+    },
+}
+
+
+COMMAND_TRIGGERED_CHANNEL_TRANSITIONS = {
+    CLIENT: {
+        NEVER_CONNECTED: {
+            CreateChannelRequest: NEVER_CONNECTED,
+            CreateChannelResponse: CONNECTED,
+        },
+        CONNECTED: {
+            ChannelFieldInfoRequest: CONNECTED,
+            ChannelFieldInfoResponse: CONNECTED,
+            ChannelGetRequest: CONNECTED,
+            ChannelGetResponse: CONNECTED,
+            ChannelPutRequest: CONNECTED,
+            ChannelPutResponse: CONNECTED,
+            ChannelDestroyRequest: CONNECTED,
+            ChannelDestroyResponse: DISCONNECTED,
+            ChannelMonitorRequest: CONNECTED,
+            ChannelMonitorResponse: CONNECTED,
+            ChannelPutGetRequest: CONNECTED,
+            ChannelPutGetResponse: CONNECTED,
+            ChannelRpcRequest: CONNECTED,
+            ChannelRpcResponse: CONNECTED,
+            ChannelProcessRequest: CONNECTED,
+            ChannelProcessResponse: CONNECTED,
+        },
+        DISCONNECTED: {
+        },
+    },
+    SERVER: {
+        NEVER_CONNECTED: {
+            CreateChannelRequest: NEVER_CONNECTED,
+            CreateChannelResponse: CONNECTED,
+        },
+        CONNECTED: {
+            ChannelFieldInfoRequest: CONNECTED,
+            ChannelFieldInfoResponse: CONNECTED,
+            ChannelGetRequest: CONNECTED,
+            ChannelGetResponse: CONNECTED,
+            ChannelPutRequest: CONNECTED,
+            ChannelPutResponse: CONNECTED,
+            ChannelDestroyRequest: CONNECTED,
+            ChannelDestroyResponse: DISCONNECTED,
+            ChannelMonitorRequest: CONNECTED,
+            ChannelMonitorResponse: CONNECTED,
+            ChannelPutGetRequest: CONNECTED,
+            ChannelPutGetResponse: CONNECTED,
+            ChannelRpcRequest: CONNECTED,
+            ChannelRpcResponse: CONNECTED,
+            ChannelProcessRequest: CONNECTED,
+            ChannelProcessResponse: CONNECTED,
+        },
+        DISCONNECTED: {
+        },
+    },
+}
+
+SUBCOMMAND_TRANSITIONS = {
+    CLIENT: {
+        NEVER_CONNECTED: {
+            Subcommands.INIT: CONNECTED,
+        },
+        CONNECTED: {
+            Subcommands.INIT: CONNECTED,
+            Subcommands.DEFAULT: CONNECTED,
+            Subcommands.GET: CONNECTED,
+            Subcommands.GET_PUT: CONNECTED,
+            Subcommands.PROCESS: CONNECTED,
+            Subcommands.DESTROY: DISCONNECTED,
+        },
+        DISCONNECTED: {
+        },
+    }
+}
+
+SUBCOMMAND_TRANSITIONS[SERVER] = SUBCOMMAND_TRANSITIONS[CLIENT]
+
+MONITOR_TRANSITIONS = {
+    CLIENT: {
+        NEVER_CONNECTED: {
+            MonitorSubcommands.INIT: CONNECTED,
+        },
+        CONNECTED: {
+            MonitorSubcommands.INIT: CONNECTED,
+            MonitorSubcommands.DEFAULT: CONNECTED,
+            MonitorSubcommands.PIPELINE: CONNECTED,
+            MonitorSubcommands.START: CONNECTED,
+            MonitorSubcommands.STOP: CONNECTED,
+            MonitorSubcommands.DESTROY: DISCONNECTED,
+        },
+        DISCONNECTED: {
+        },
+    }
+}
+
+
+MONITOR_TRANSITIONS[SERVER] = MONITOR_TRANSITIONS[CLIENT]
+
+STATE_TRIGGERED_TRANSITIONS = {
+    # (CHANNEL_STATE, CIRCUIT_STATE)
+    CLIENT: {
+        # (SEND_CREATE_CHAN_REQUEST, DISCONNECTED): (CLOSED, DISCONNECTED),
+    },
+    SERVER: {
+        # (SEND_CREATE_CHAN_RESPONSE, DISCONNECTED): (CLOSED, DISCONNECTED),
+    }
+}
+
+
+class ChannelState(_ChannelState):
+    TRANSITIONS = COMMAND_TRIGGERED_CHANNEL_TRANSITIONS
+    STT = STATE_TRIGGERED_TRANSITIONS
+
+    def __init__(self, circuit_state):
+        self.states = {CLIENT: NEVER_CONNECTED,
+                       SERVER: NEVER_CONNECTED}
+        self.circuit_state = circuit_state
+
+    # MERGE
+    def _fire_command_triggered_transitions(self, role, command):
+        command_type = type(command)
+        if command_type._ENDIAN is not None:
+            if command_type.ID in ApplicationCommands:
+                command_type = command_type.__bases__[0]
+                # TODO: HACK! Horrible, horrible hack...
+                # This side-steps putting big- and little-endian messages in
+                # the state transition dictionary. This should be redone.
+
+        current_state = self.states[role]
+        allowed_transitions = self.TRANSITIONS[role][current_state]
+        try:
+            new_state = allowed_transitions[command_type]
+        except KeyError:
+            err_cls = get_exception(role, command)
+            err = err_cls(f"{self} cannot handle command type "
+                          f"{command_type.__name__} when role={role} and "
+                          f"state={self.states[role]}")
+            raise err from None
+        self.states[role] = new_state
+
+
+class CircuitState(_CircuitState):
+    TRANSITIONS = COMMAND_TRIGGERED_CIRCUIT_TRANSITIONS
+
+    def __init__(self, channels):
+        self.states = {CLIENT: INIT, SERVER: INIT}
+        self.channels = channels
+
+    # MERGE
+    def _fire_command_triggered_transitions(self, role, command):
+        command_type = type(command)
+        if command_type._ENDIAN is not None:
+            if command_type.ID in ApplicationCommands:
+                command_type = command_type.__bases__[0]
+                # TODO: HACK! Horrible, horrible hack...
+                # This side-steps putting big- and little-endian messages in
+                # the state transition dictionary. This should be redone.
+
+        current_state = self.states[role]
+        allowed_transitions = self.TRANSITIONS[role][current_state]
+        try:
+            new_state = allowed_transitions[command_type]
+        except KeyError:
+            err_cls = get_exception(role, command)
+            err = err_cls(f"{self} cannot handle command type "
+                          f"{command_type.__name__} when role={role} and "
+                          f"state={self.states[role]}")
+            raise err from None
+        self.states[role] = new_state
+
+
+class RequestState(_BaseState):
+    def __init__(self, is_monitor):
+        self.monitor = is_monitor
+        self.TRANSITIONS = (MONITOR_TRANSITIONS if is_monitor
+                            else SUBCOMMAND_TRANSITIONS)
+        self.states = {CLIENT: NEVER_CONNECTED, SERVER: NEVER_CONNECTED}
+
+    def process_subcommand(self, subcommand):
+        self._fire_command_triggered_transitions(CLIENT, subcommand)
+        self._fire_command_triggered_transitions(SERVER, subcommand)
+
+    # MERGE
+    def _fire_command_triggered_transitions(self, role, subcommand):
+        current_state = self.states[role]
+        allowed_transitions = self.TRANSITIONS[role][current_state]
+        if self.monitor:
+            subcommand = MonitorSubcommands(subcommand)
+        else:
+            subcommand = Subcommands(subcommand)
+
+        try:
+            new_state = allowed_transitions[subcommand]
+        except KeyError:
+            err_cls = get_exception(role, subcommand)
+            err = err_cls(f"{self} cannot handle subcommand type "
+                          f"{subcommand!r} when role={role} and "
+                          f"state={self.states[role]}")
+            raise err from None
+        self.states[role] = new_state
+
+
+# MERGE
+def get_exception(our_role, command):
+    """
+    Return a (Local|Remote)ProtocolError depending on which command this is and
+    which role we are playing.
+
+    Note that this method does not raise; it is up to the caller to raise.
+
+    Parameters
+    ----------
+    our_role: ``CLIENT`` or ``SERVER``
+    command : Message instance or class
+        We will test whether it is a ``REQUEST`` or ``RESPONSE``.
+    """
+    if not hasattr(command, 'direction') and hasattr(command, 'header'):
+        # TODO
+        direction = command.header.direction
+    else:
+        try:
+            direction = command.direction
+        except AttributeError:
+            print('TODO missing in transition dict', type(command), command)
+            direction = MessageFlags.FROM_CLIENT
+
+    if direction == MessageFlags.FROM_CLIENT:
+        party_at_fault = CLIENT
+    elif direction == MessageFlags.FROM_SERVER:
+        party_at_fault = SERVER
+
+    if our_role is party_at_fault:
+        _class = LocalProtocolError
+    else:
+        _class = RemoteProtocolError
+    return _class

--- a/caproto/pva/_typing_compat.py
+++ b/caproto/pva/_typing_compat.py
@@ -8,6 +8,8 @@ import typing
 
 if sys.version_info >= (3, 8):
     from typing import get_args, get_origin
+elif sys.version_info <= (3, 6) or not hasattr(typing, '_GenericAlias'):
+    raise ImportError('Sorry, this is an unsupported version of Python :(')
 else:
     def get_origin(tp):
         """Get the unsubscripted version of a type.

--- a/caproto/pva/_typing_compat.py
+++ b/caproto/pva/_typing_compat.py
@@ -1,0 +1,45 @@
+"""
+typing functions back-ported from 3.8 for Python 3.7 compatibility.
+"""
+
+import collections
+import sys
+import typing
+
+if sys.version_info >= (3, 8):
+    from typing import get_args, get_origin
+else:
+    def get_origin(tp):
+        """Get the unsubscripted version of a type.
+        This supports generic types, Callable, Tuple, Union, Literal, Final and ClassVar.
+        Return None for unsupported types. Examples::
+            get_origin(Literal[42]) is Literal
+            get_origin(int) is None
+            get_origin(ClassVar[int]) is ClassVar
+            get_origin(Generic) is Generic
+            get_origin(Generic[T]) is Generic
+            get_origin(Union[T, int]) is Union
+            get_origin(List[Tuple[T, T]][int]) == list
+        """
+        if isinstance(tp, typing._GenericAlias):
+            return tp.__origin__
+        if tp is typing.Generic:
+            return typing.Generic
+        return None
+
+    def get_args(tp):
+        """Get type arguments with all substitutions performed.
+        For unions, basic simplifications used by Union constructor are performed.
+        Examples::
+            get_args(Dict[str, int]) == (str, int)
+            get_args(int) == ()
+            get_args(Union[int, Union[T, int], str][int]) == (int, str)
+            get_args(Union[int, Tuple[T, int]][str]) == (int, Tuple[str, int])
+            get_args(Callable[[], T][int]) == ([], int)
+        """
+        if isinstance(tp, typing._GenericAlias) and not tp._special:
+            res = tp.__args__
+            if get_origin(tp) is collections.abc.Callable and res[0] is not typing.Ellipsis:
+                res = (list(res[:-1]), res[-1])
+            return res
+        return ()

--- a/caproto/pva/_utils.py
+++ b/caproto/pva/_utils.py
@@ -1,0 +1,104 @@
+import ctypes
+import datetime
+import enum
+import ipaddress
+import uuid
+
+from .._utils import (CLIENT, SERVER, CaprotoError, CaprotoKeyError,
+                      CaprotoRuntimeError, CaprotoValueError,
+                      ErrorResponseReceived, LocalProtocolError,
+                      RemoteProtocolError, Role, ThreadsafeCounter,
+                      _SimpleReprEnum)
+
+# Borrow some items from top-level utils:
+__all__ = [
+    'CLIENT', 'SERVER', 'CaprotoError', 'CaprotoKeyError',
+    'CaprotoRuntimeError', 'CaprotoValueError',
+    'ErrorResponseReceived', 'LocalProtocolError',
+    'RemoteProtocolError', 'Role', 'ThreadsafeCounter',
+
+    # And add on our own:
+    'ConnectionState', 'ChannelLifeCycle', 'ChannelRequest',
+
+    'CONNECTED', 'RESPONSIVE', 'UNRESPONSIVE', 'DISCONNECTED',
+    'NEVER_CONNECTED', 'DESTROYED', 'NEED_DATA', 'CLEAR_SEGMENTS',
+    'INIT', 'READY', 'IN_PROGRESS',
+
+    'ubyte_array_to_ip', 'ip_to_ubyte_array', 'timestamp_to_datetime',
+    'new_guid',
+]
+
+
+class ConnectionState(_SimpleReprEnum):
+    # Connection state
+    CONNECTED = enum.auto()
+    RESPONSIVE = enum.auto()
+    UNRESPONSIVE = enum.auto()
+    DISCONNECTED = enum.auto()
+
+
+class ChannelLifeCycle(_SimpleReprEnum):
+    # Channel life-cycle
+    NEVER_CONNECTED = enum.auto()
+    # also: CONNECTED, DISCONNECTED
+    DESTROYED = enum.auto()
+    NEED_DATA = enum.auto()
+    CLEAR_SEGMENTS = enum.auto()
+
+
+class ChannelRequest(_SimpleReprEnum):
+    # Channel request
+    INIT = enum.auto()
+    READY = enum.auto()
+    IN_PROGRESS = enum.auto()
+    # also: DISCONNECTED, DESTROYED
+
+
+CONNECTED = ConnectionState.CONNECTED
+RESPONSIVE = ConnectionState.RESPONSIVE
+UNRESPONSIVE = ConnectionState.UNRESPONSIVE
+DISCONNECTED = ConnectionState.DISCONNECTED
+
+NEVER_CONNECTED = ChannelLifeCycle.NEVER_CONNECTED
+DESTROYED = ChannelLifeCycle.DESTROYED
+NEED_DATA = ChannelLifeCycle.NEED_DATA
+CLEAR_SEGMENTS = ChannelLifeCycle.CLEAR_SEGMENTS
+
+INIT = ChannelRequest.INIT
+READY = ChannelRequest.READY
+IN_PROGRESS = ChannelRequest.IN_PROGRESS
+
+
+def ubyte_array_to_ip(arr):
+    'Convert an address encoded as a c_ubyte array to a string'
+    addr = ipaddress.ip_address(bytes(arr))
+    ipv4 = addr.ipv4_mapped
+    if ipv4:
+        return str(ipv4)
+    return str(addr)
+
+
+def ip_to_ubyte_array(ip):
+    'Convert an IPv4 or IPv6 to a c_ubyte*16 array'
+    addr = ipaddress.ip_address(ip)
+    packed = addr.packed
+    if len(packed) == 4:
+        # case of IPv4
+        packed = [0] * 10 + [0xff, 0xff] + list(packed)
+
+    return (ctypes.c_ubyte * 16)(*packed)
+
+
+def timestamp_to_datetime(seconds: int,
+                          nanoseconds: int) -> datetime.datetime:
+    """
+    Given seconds and nanoseconds that make up a posix timestamp, return a
+    datetime.datetime.
+    """
+    posix_timestamp = seconds + nanoseconds * 1e-9
+    return datetime.datetime.fromtimestamp(posix_timestamp)
+
+
+def new_guid() -> str:
+    """A pva-compatible UUID (of length 12)."""
+    return str(uuid.uuid4()).replace('-', '')[:12]

--- a/caproto/pva/commandline/__init__.py
+++ b/caproto/pva/commandline/__init__.py
@@ -1,0 +1,3 @@
+from . import get, monitor
+
+__all__ = ['get', 'monitor']

--- a/caproto/pva/commandline/get.py
+++ b/caproto/pva/commandline/get.py
@@ -1,0 +1,72 @@
+import argparse
+import dataclasses
+import logging
+import pprint
+
+from ... import __version__
+from ..._log import _set_handler_with_logger, set_handler
+from ..._utils import ShowVersionAction
+from ..sync.client import read
+
+logger = logging.getLogger('caproto.pva.ctx')
+serialization_logger = logging.getLogger('caproto.pva.serialization')
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Read the value of a PV.',
+        epilog=f'caproto version {__version__}'
+    )
+    parser.register('action', 'show_version', ShowVersionAction)
+    fmt_group = parser.add_mutually_exclusive_group()
+    parser.add_argument('pv_names', type=str, nargs='+',
+                        help="PV (channel) name(s) separated by spaces")
+    parser.add_argument('-r', '--pvrequest', type=str, default='field()',
+                        help=("PVRequest"))
+    fmt_group.add_argument('--terse', '-t', action='store_true',
+                           help=("Display data only. Unpack scalars: "
+                                 "[3.] -> 3."))
+    parser.add_argument('--timeout', '-w', type=float, default=1,
+                        help=("Timeout ('wait') in seconds for server "
+                              "responses."))
+    parser.add_argument('--verbose', '-v', action='count',
+                        help="Show more log messages. (Use -vvv for even more.)")
+    parser.add_argument('--no-color', action='store_true',
+                        help="Suppress ANSI color codes in log messages.")
+    parser.add_argument('--version', '-V', action='show_version',
+                        default=argparse.SUPPRESS,
+                        help="Show caproto version and exit.")
+
+    args = parser.parse_args()
+    if args.verbose:
+        if args.verbose <= 2:
+            for name in ('caproto.pva.ch', 'caproto.pva.ctx'):
+                _set_handler_with_logger(color=not args.no_color, level='DEBUG',
+                                         logger_name=name)
+        else:
+            set_handler(color=not args.no_color, level='DEBUG')
+
+    try:
+        for pv_name in args.pv_names:
+            response = read(pv_name=pv_name, pvrequest=args.pvrequest,
+                            verbose=args.verbose, timeout=args.timeout)
+
+            dcls = response.dataclass_instance
+            if args.terse:
+                dcls = getattr(dcls, 'value', dcls)
+                print(dcls)
+            else:
+                # TODO: make an option, somehow
+                pprint.pprint(dataclasses.asdict(dcls))
+
+    except BaseException as exc:
+        if args.verbose:
+            # Show the full traceback.
+            raise
+        else:
+            # Print a one-line error message.
+            print(exc)
+
+
+if __name__ == '__main__':
+    main()

--- a/caproto/pva/commandline/monitor.py
+++ b/caproto/pva/commandline/monitor.py
@@ -1,0 +1,114 @@
+import argparse
+import datetime
+import logging
+
+from ... import __version__
+from ..._log import _set_handler_with_logger, set_handler
+from ..._utils import ShowVersionAction
+from .._dataclass import fill_dataclass
+from .._utils import timestamp_to_datetime
+from ..sync.client import monitor
+
+logger = logging.getLogger('caproto.pva.ctx')
+serialization_logger = logging.getLogger('caproto.pva.serialization_debug')
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Monitor the value of a PV.',
+        epilog=f'caproto version {__version__}',
+    )
+    parser.register('action', 'show_version', ShowVersionAction)
+    parser.add_argument('pv_names', type=str, nargs='+',
+                        help="PV (channel) name(s) separated by spaces")
+    parser.add_argument('-r', '--pvrequest', type=str, default='field()',
+                        help=("PVRequest"))
+    fmt_group = parser.add_mutually_exclusive_group()
+    fmt_group.add_argument('--terse', '-t', action='store_true',
+                           help=("Display data only. Unpack scalars: "
+                                 "[3.] -> 3."))
+    fmt_group.add_argument('--full', action='store_true',
+                           help=("Print full structure each time"))
+    fmt_group.add_argument('--format', type=str, default='{timestamp} {pv_name} {value}',
+                           help=("Python format string. Available tokens are "
+                                 "{pv_name} and {data}. Additionally, if "
+                                 "this data type includes time, {timestamp} "
+                                 "and usages like "
+                                 "{timestamp:%%Y-%%m-%%d %%H:%%M:%%S} are "
+                                 "supported. "))
+    parser.add_argument('--timeout', '-w', type=float, default=1,
+                        help=("Timeout ('wait') in seconds for server "
+                              "responses."))
+    parser.add_argument('--verbose', '-v', action='count',
+                        help="Show more log messages. (Use -vvv for even more.)")
+    parser.add_argument('--maximum', type=int, default=None,
+                        help="Maximum number of monitor events to display.")
+    parser.add_argument('--no-color', action='store_true',
+                        help="Suppress ANSI color codes in log messages.")
+    parser.add_argument('--version', '-V', action='show_version',
+                        default=argparse.SUPPRESS,
+                        help="Show caproto version and exit.")
+    args = parser.parse_args()
+
+    if args.verbose:
+        if args.verbose <= 2:
+            for name in ('caproto.pva.ch', 'caproto.pva.ctx'):
+                _set_handler_with_logger(color=not args.no_color, level='DEBUG',
+                                         logger_name=name)
+        else:
+            set_handler(color=not args.no_color, level='DEBUG')
+
+    try:
+        pv_name = args.pv_names[0]
+        if args.terse:
+            format_str = '{timestamp} {pv_name} {value}'
+        else:
+            format_str = args.format
+
+        timestamp = '(No timestamp)'
+
+        for idx, event in enumerate(monitor(pv_name=pv_name,
+                                            pvrequest=args.pvrequest,
+                                            verbose=args.verbose,
+                                            timeout=args.timeout,
+                                            maximum_events=args.maximum)):
+            if idx == 0:
+                print(event.dataclass_instance._pva_struct_.summary())
+            else:
+                data = event.dataclass_instance
+                event_data = event.pv_data['value']  # and 'field'
+                fill_dataclass(data, event_data)
+
+                try:
+                    timestamp = timestamp_to_datetime(
+                        data.timeStamp.secondsPastEpoch,
+                        data.timeStamp.nanoseconds,
+                    )
+                except AttributeError:
+                    # May not have a timestamp
+                    timestamp = datetime.datetime.now()
+
+                if args.full:
+                    print(format_str.format(pv_name=pv_name,
+                                            timestamp=timestamp,
+                                            value=data))
+                    continue
+
+                try:
+                    print(format_str.format(pv_name=pv_name,
+                                            timestamp=timestamp,
+                                            value=data))
+                except Exception as ex:
+                    print('(print format failed)', ex, data)
+
+    except BaseException as exc:
+        if args.verbose:
+            # Show the full traceback.
+            raise
+        else:
+            # Print a one-line error message.
+            print(exc)
+
+
+if __name__ == '__main__':
+    main()

--- a/caproto/pva/commandline/put.py
+++ b/caproto/pva/commandline/put.py
@@ -1,0 +1,107 @@
+import argparse
+import ast
+import json
+import logging
+
+from ... import __version__
+from ..._log import _set_handler_with_logger, set_handler
+from ..._utils import ShowVersionAction
+from ..sync.client import read_write_read
+
+logger = logging.getLogger('caproto.pva.ctx')
+serialization_logger = logging.getLogger('caproto.pva.serialization')
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Write a value to a PV.',
+        epilog=f'caproto version {__version__}')
+    parser.register('action', 'show_version', ShowVersionAction)
+    fmt_group = parser.add_mutually_exclusive_group()
+    parser.add_argument('pv_name', type=str,
+                        help="PV (channel) name")
+    parser.add_argument('data', type=str,
+                        help="Value or values to write.")
+    parser.add_argument('--verbose', '-v', action='count',
+                        help="Show more log messages. (Use -vvv for even more.)")
+    fmt_group.add_argument('--format', type=str,
+                           help=("Python format string. Available tokens are "
+                                 "{pv_name}, {response} and {which} (Old/New)."
+                                 "Additionally, "
+                                 "this data type includes time, {timestamp} "
+                                 "and usages like "
+                                 "{timestamp:%%Y-%%m-%%d %%H:%%M:%%S} are "
+                                 "supported."))
+    parser.add_argument('--timeout', '-w', type=float, default=1,
+                        help=("Timeout ('wait') in seconds for server "
+                              "responses."))
+    fmt_group.add_argument('--terse', '-t', action='store_true',
+                           help=("Display data only. Unpack scalars: "
+                                 "[3.] -> 3."))
+    fmt_group.add_argument('--wide', '-l', action='store_true',
+                           help=("Wide mode, showing "
+                                 "'name timestamp value status'"
+                                 "(implies -d 'time')"))
+    parser.add_argument('--file', action='store_true',
+                        help=("Interprets `data` as a file"))
+    parser.add_argument('--no-color', action='store_true',
+                        help="Suppress ANSI color codes in log messages.")
+    parser.add_argument('--version', '-V', action='show_version',
+                        default=argparse.SUPPRESS,
+                        help="Show caproto version and exit.")
+    args = parser.parse_args()
+    if args.verbose:
+        if args.verbose <= 2:
+            _set_handler_with_logger(color=not args.no_color, level='DEBUG',
+                                     logger_name='caproto.pva.ch')
+            _set_handler_with_logger(color=not args.no_color, level='DEBUG',
+                                     logger_name='caproto.pva.ctx')
+        else:
+            set_handler(color=not args.no_color, level='DEBUG')
+    logger = logging.LoggerAdapter(logging.getLogger('caproto.pva.ch'), {'pv': args.pv_name})
+
+    if args.file:
+        with open(str(args.data), mode='r') as file:
+            raw_data = file.read()
+    else:
+        raw_data = args.data
+
+    try:
+        data = json.loads(raw_data)
+    except ValueError:
+        try:
+            data = ast.literal_eval(raw_data)
+        except ValueError:
+            # interpret as string
+            data = raw_data
+            if data.startswith('{'):  # }
+                raise ValueError('You probably meant for this to be JSON')
+
+    logger.debug('Data argument %s parsed as %r (Python type %s).',
+                 args.data, data, type(data).__name__)
+    try:
+        initial, _, final = read_write_read(
+            pv_name=args.pv_name, data=data, timeout=args.timeout,
+        )
+
+        initial = initial.dataclass_instance
+        if args.terse:
+            initial = getattr(initial, 'value', initial)
+
+        print('Old:', initial)
+
+        final = final.dataclass_instance
+        if args.terse:
+            final = getattr(final, 'value', final)
+        print('New:', final)
+    except BaseException as exc:
+        if args.verbose:
+            # Show the full traceback.
+            raise
+        else:
+            # Print a one-line error message.
+            print(exc)
+
+
+if __name__ == '__main__':
+    main()

--- a/caproto/pva/notes.txt
+++ b/caproto/pva/notes.txt
@@ -1,0 +1,11 @@
+TODO
+
+There are a few varieties of Serializable that need cleaning/distinguishing:
+* FieldDescByte (stateful ctypes.structure - no cache required)
+* FieldDesc (stateful, requires cache, has extra optional args)
+* BitSet (stateful, does not require cache)
+* DataSerializer (different, but needs to interact with the above)
+
+
+New changes in the pvAccess documentation are not accounted for:
+    https://github.com/epics-base/pvAccessCPP/wiki/protocol

--- a/caproto/pva/prototype/client.py
+++ b/caproto/pva/prototype/client.py
@@ -1,0 +1,333 @@
+import ctypes
+import pprint
+import random
+import socket
+import sys
+
+from caproto import bcast_socket, get_netifaces_addresses, pva
+
+
+def send_message(sock, client_byte_order, server_byte_order, msg, cache):
+    print('->', msg)
+    header_cls = (pva.MessageHeaderLE
+                  if server_byte_order == pva.LITTLE_ENDIAN
+                  else pva.MessageHeaderBE)
+    endian_flag = (pva.MessageFlags.LITTLE_ENDIAN
+                   if server_byte_order == pva.LITTLE_ENDIAN
+                   else pva.MessageFlags.BIG_ENDIAN)
+
+    payload = msg.serialize(cache=cache)
+    header = header_cls(
+        flags=(pva.MessageFlags.APP_MESSAGE | pva.MessageFlags.FROM_CLIENT |
+               endian_flag),
+        command=msg.ID,
+        payload_size=len(payload)
+    )
+
+    to_send = b''.join((header.serialize(), payload))
+    print('-b>', to_send)
+    sock.sendall(to_send)
+    return header, payload
+
+
+def recv_message(sock, fixed_byte_order, server_byte_order, cache, buf):
+    if not len(buf):
+        buf = bytearray(sock.recv(4096))
+        print('<-', buf)
+
+    header_cls = (pva.MessageHeaderLE
+                  if server_byte_order == pva.LITTLE_ENDIAN
+                  else pva.MessageHeaderBE)
+
+    header = header_cls.from_buffer(buf)
+    assert header.valid
+
+    flags = header.flags
+    if not flags.is_segmented:
+        header, buf, offset = header_cls.deserialize(buf, cache=cache)
+    else:
+        header_size = ctypes.sizeof(header_cls)
+
+        first_header = header
+
+        segmented_payload = []
+        while header.segment != pva.SegmentFlag.LAST:
+            while len(buf) < header_size:
+                buf += sock.recv(4096)
+
+            header = header_cls.from_buffer(buf)
+            assert header.valid
+            # TODO note, control messages can be interspersed here
+            assert first_header.message_command == header.message_command
+
+            buf = buf[header_size:]
+
+            segment_size = header.payload_size
+            while len(buf) < segment_size:
+                buf += sock.recv(max((4096, segment_size - len(buf))))
+
+            segmented_payload.append(buf[:segment_size])
+            buf = buf[segment_size:]
+
+        buf = bytearray(b''.join(segmented_payload))
+        print('Segmented message. Final payload length: {}'
+              ''.format(len(buf)))
+        header.payload_size = len(buf)
+
+    msg_class = header.get_message(pva.MessageFlags.FROM_SERVER,
+                                   use_fixed_byte_order=fixed_byte_order)
+
+    print()
+    print('<-', header)
+
+    assert len(buf) >= header.payload_size
+    return msg_class.deserialize(buf, cache=cache)
+
+
+def search(*pvs):
+    '''Search for a PV over the network by broadcasting over UDP
+
+    Returns: (host, port)
+    '''
+
+    udp_sock = bcast_socket()
+    udp_sock.bind(('', 0))
+    port = udp_sock.getsockname()[1]
+
+    seq_id = random.randint(1, 2 ** 31)
+    search_ids = {pv: random.randint(1, 2 ** 31)
+                  for pv in pvs}
+
+    search_req = pva.SearchRequestLE(
+        sequence_id=seq_id,
+        flags=(pva.SearchFlags.reply_required | pva.SearchFlags.broadcast),
+        response_address='127.0.0.1',   # TODO host ip
+        response_port=port,
+        protocols=['tcp'],
+        channels=[{'id': search_ids[pv], 'channel_name': pv}
+                  for pv in pvs]
+    )
+
+    # NOTE: cache needed here to give interface for channels
+    cache = pva.CacheContext()
+    payload = search_req.serialize(cache=cache)
+
+    header = pva.MessageHeaderLE(
+        flags=(pva.MessageFlags.APP_MESSAGE |
+               pva.MessageFlags.FROM_CLIENT |
+               pva.MessageFlags.LITTLE_ENDIAN),
+        command=search_req.ID,
+        payload_size=len(payload)
+    )
+
+    for addr, bcast_addr in get_netifaces_addresses():
+        search_req.response_address = addr
+        bytes_to_send = bytes(header) + search_req.serialize(cache=cache)
+
+        dest = (addr, pva.PVA_BROADCAST_PORT)
+        print('Sending SearchRequest to', bcast_addr,
+              'requesting response at {}:{}'.format(addr, port))
+        udp_sock.sendto(bytes_to_send, dest)
+
+    response_data, addr = udp_sock.recvfrom(1024)
+    response_data = bytearray(response_data)
+    print('Received from', addr, ':', response_data)
+
+    response_header, buf, offset = pva.MessageHeaderLE.deserialize(
+        response_data, cache=pva.NullCache)
+    assert response_header.valid
+
+    msg_class = response_header.get_message(
+        pva.MessageFlags.FROM_SERVER, use_fixed_byte_order=pva.LITTLE_ENDIAN)
+
+    print('Response header:', response_header)
+    print('Response msg class:', msg_class)
+
+    msg, buf, off = msg_class.deserialize(buf, cache=pva.NullCache)
+    offset += off
+
+    print('Response message:', msg)
+    assert offset == len(response_data)
+
+    if msg.found:
+        id_to_pv = {id_: pv for pv, id_ in search_ids.items()}
+        found_pv = id_to_pv[msg.search_instance_ids[0]]
+        print('Found {} on {}:{}!'
+              ''.format(found_pv, msg.server_address, msg.server_port))
+        return (msg.server_address, msg.server_port)
+    else:
+        # TODO as a simple client, this only grabs the first response from
+        # the quickest server, which is clearly not the right way to do it
+        raise ValueError('PVs {} not found in brief search'
+                         ''.format(pvs))
+
+
+def main(host, server_port, pv):
+    'Directly connect to a host that has a PV'
+    # cache of types from server
+    our_cache = {}
+    # local copy of types cached on server
+    their_cache = {}
+    # locally-defined types
+    # user_types = pva.basic_types.copy()
+
+    cache = pva.CacheContext(ours=our_cache, theirs=their_cache,
+                             ioid_interfaces={})
+
+    sock = socket.create_connection((host, server_port))
+    buf = bytearray(sock.recv(4096))
+
+    # (1)
+    print()
+    print('- 1. initialization: byte order setting')
+    msg, buf, offset = pva.SetByteOrder.deserialize(buf, cache=cache)
+    print('<-', msg, msg.byte_order_setting, msg.byte_order)
+
+    server_byte_order = msg.byte_order
+    client_byte_order = server_byte_order
+
+    cli_messages = pva.messages_grouped[(client_byte_order,
+                                         pva.MessageFlags.FROM_CLIENT)]
+
+    # srv_msgs = pva.messages_grouped[(server_byte_order,
+    #                                  pva.MessageFlags.FROM_SERVER)]
+
+    if msg.byte_order_setting == pva.EndianSetting.use_server_byte_order:
+        fixed_byte_order = server_byte_order
+        print('\n* Using fixed byte order:', server_byte_order)
+    else:
+        fixed_byte_order = None
+        print('\n* Using byte order from individual messages.')
+
+    # convenience functions:
+    def send(msg):
+        return send_message(sock, client_byte_order, server_byte_order, msg,
+                            cache)
+
+    def recv(buf, **kw):
+        return recv_message(sock, fixed_byte_order, server_byte_order, cache,
+                            buf, **kw)
+
+    # (2)
+    print()
+    print('- 2. Connection validation request from server')
+
+    auth_request, buf, off = recv(buf)
+
+    # (3)
+    print()
+    print('- 3. Connection validation response')
+
+    auth_cls = cli_messages[pva.ApplicationCommands.CONNECTION_VALIDATION]
+    auth_resp = auth_cls(
+        client_buffer_size=auth_request.server_buffer_size,
+        client_registry_size=auth_request.server_registry_size,
+        connection_qos=auth_request.server_registry_size,
+        auth_nz='anonymous',  # TODO: 'ca' doesn't actually require a payload?
+    )
+
+    send(auth_resp)
+    auth_ack, buf, off = recv(buf)
+
+    # (4)
+    print()
+    print('- 4. Create channel request')
+    create_cls = cli_messages[pva.ApplicationCommands.CREATE_CHANNEL]
+    create_req = create_cls(count=1, channels=[{'id': 0x01, 'channel_name': pv}])
+    send(create_req)
+
+    create_reply, buf, off = recv(buf)
+    print('\n<-', create_reply)
+
+    assert create_reply.status_type == pva.StatusType.OK
+
+    server_chid = create_reply.server_chid
+
+    # (5)
+    print()
+    print('- 5. Get field interface request')
+    if_cls = cli_messages[pva.ApplicationCommands.GET_FIELD]
+    if_req = if_cls(server_chid=server_chid, ioid=1, sub_field_name='')
+    send(if_req)
+
+    if_reply, buf, off = recv(buf)
+    print(if_reply.field_if.summary())
+
+    pv_interface = if_reply.field_if
+
+    struct_name = pv_interface.struct_name
+    print('Structure name is', struct_name)
+
+    print()
+    print('PV interface cache now contains:')
+    # for i, (key, intf) in enumerate(cache.ours.items()):
+    #     print('{}).'.format(i), key, intf)
+
+    print(', '.join('{} ({})'.format(intf.struct_name, key)
+                    for key, intf in cache.ours.items()))
+
+    reverse_cache = dict((v.struct_name, k) for k, v in cache.ours.items())
+    print('id for structure {} is {}'.format(struct_name,
+                                             reverse_cache[struct_name]))
+
+    # (6)
+    print()
+    print('- 6. Initialize the channel get request')
+    get_ioid = 2
+    get_cls = cli_messages[pva.ApplicationCommands.GET]
+    get_init_req = get_cls(server_chid=server_chid, ioid=get_ioid,
+                           subcommand=pva.Subcommands.INIT,
+                           pv_request='field()',
+                           # or if field() then pv_request ignored
+                           )
+    send(get_init_req)
+    get_init_reply, buf, off = recv(buf)
+    print('init reply', get_init_reply)
+
+    interface = get_init_reply.pv_structure_if
+    cache.ioid_interfaces[get_ioid] = get_init_reply.pv_structure_if
+    print()
+    print('Field info according to init:')
+    print(interface.summary())
+
+    print('bitset descendents')
+    print('------------------')
+    for idx, item in enumerate(interface.descendents, 1):
+        print(idx, item)
+
+    # (7)
+    print()
+    print('- 7. Perform an actual get request')
+    get_cls = cli_messages[pva.ApplicationCommands.GET]
+    get_req = get_cls(server_chid=server_chid, ioid=get_ioid,  # <-- note same ioid
+                      subcommand=pva.Subcommands.GET,
+                      )
+    send(get_req)
+    get_reply, buf, off = recv(buf)
+    get_data = get_reply.pv_data
+
+    print('The response structure')
+    print('----------------------')
+    print(get_data['field'].summary())
+
+    print()
+    print('The structured data')
+    print('-------------------')
+    pprint.pprint(get_data['value'])
+
+    assert len(buf) == 0
+    return get_data
+
+
+if __name__ == '__main__':
+    import logging
+    logging.getLogger('caproto.pva.serialization').setLevel(logging.DEBUG)
+    logging.basicConfig()
+
+    try:
+        pv = sys.argv[1]
+    except IndexError:
+        pv = 'TST:image1:Array'
+
+    host, server_port = search(pv)
+    main(host, server_port, pv)

--- a/caproto/pva/sync/__init__.py
+++ b/caproto/pva/sync/__init__.py
@@ -1,0 +1,3 @@
+from . import client
+
+__all__ = ['client']

--- a/caproto/pva/sync/client.py
+++ b/caproto/pva/sync/client.py
@@ -1,0 +1,455 @@
+import collections
+import dataclasses
+import getpass
+import logging
+import socket
+import time
+import typing
+
+# REBASE TODO this will go away - need to rebase
+from caproto import (MAX_UDP_RECV, bcast_socket, get_address_list,
+                     get_environment_variables, pva)
+from caproto.pva import (CLIENT, CONNECTED, DISCONNECTED, NEED_DATA,
+                         Broadcaster, CaprotoError, ChannelFieldInfoResponse,
+                         ChannelGetResponse, ChannelMonitorResponse,
+                         ChannelPutResponse, ClientChannel,
+                         ConnectionValidatedResponse,
+                         ConnectionValidationRequest, CreateChannelResponse,
+                         ErrorResponseReceived, MonitorSubcommands, QOSFlags,
+                         SearchResponse, Subcommands, VirtualCircuit)
+
+from .._dataclass import (dataclass_from_field_desc, fill_dataclass,
+                          is_pva_dataclass_instance)
+
+# Make a dict to hold our tcp sockets.
+sockets = {}
+global_circuits = {}
+env = get_environment_variables()
+broadcast_port = env['EPICS_PVA_BROADCAST_PORT']
+
+logger = logging.getLogger('caproto.pva.ctx')
+serialization_logger = logging.getLogger('caproto.pva.serialization_debug')
+
+
+# Convenience functions that do both transport and caproto validation/ingest.
+def send(circuit, command, pv_name=None):
+    if pv_name is not None:
+        tags = {'pv': pv_name}
+    else:
+        tags = None
+    buffers_to_send = circuit.send(command, extra=tags)
+    sockets[circuit].sendmsg(buffers_to_send)
+
+    if serialization_logger.isEnabledFor(logging.DEBUG):
+        to_send = b''.join(buffers_to_send)
+        serialization_logger.debug('-> %d bytes: %r', len(to_send), to_send)
+
+
+def recv(circuit):
+    commands = collections.deque()
+    bytes_received = sockets[circuit].recv(4096)
+    for c, remaining in circuit.recv(bytes_received):
+        if c is NEED_DATA:
+            break
+        circuit.process_command(c)
+        commands.append(c)
+
+    return commands
+
+
+def make_broadcaster_socket():
+    'Returns (udp_sock, port)'
+    udp_sock = bcast_socket()
+    udp_sock.bind(('', 0))
+    port = udp_sock.getsockname()[1]
+    logger.debug('Bound to UDP port %d for search', port)
+    return udp_sock, port
+
+
+def search(pv, udp_sock, udp_port, timeout, max_retries=2):
+    '''Search for a PV over the network by broadcasting over UDP
+
+    Returns: (host, port)
+    '''
+    b = Broadcaster(our_role=CLIENT, response_addr=('0.0.0.0', udp_port))
+    cache = pva.CacheContext()
+
+    def send_search(message):
+        payload = message.serialize(cache=cache)
+        header = pva.MessageHeaderLE(
+            flags=(pva.MessageFlags.APP_MESSAGE |
+                   pva.MessageFlags.FROM_CLIENT |
+                   pva.MessageFlags.LITTLE_ENDIAN),
+            command=message.ID,
+            payload_size=len(payload)
+        )
+        bytes_to_send = bytes(header) + payload
+        port = broadcast_port
+        for host in get_address_list(protocol='PVA'):
+            udp_sock.sendto(bytes_to_send, (host, port))
+            logger.debug('Search request sent to %r.', (host, port))
+            logger.debug('%s', bytes_to_send)
+
+    def check_timeout():
+        nonlocal retry_at
+
+        if time.monotonic() >= retry_at:
+            send_search(search_req)
+            retry_at = time.monotonic() + retry_timeout
+
+        if time.monotonic() - t > timeout:
+            raise TimeoutError(
+                f"Timed out while awaiting a response searching for {pv!r}"
+            )
+
+    # Initial search attempt
+    pv_to_cid, search_req = b.search(pv)
+    cid_to_pv = dict((v, k) for k, v in pv_to_cid.items())
+    send_search(search_req)
+
+    # Await a search response, and keep track of registration status
+    retry_timeout = timeout / max((max_retries, 1))
+    t = time.monotonic()
+    retry_at = t + retry_timeout
+
+    try:
+        orig_timeout = udp_sock.gettimeout()
+        udp_sock.settimeout(retry_timeout)
+        while True:
+            try:
+                bytes_received, address = udp_sock.recvfrom(MAX_UDP_RECV)
+            except socket.timeout:
+                check_timeout()
+                continue
+
+            check_timeout()
+
+            commands = b.recv(bytes_received, address)
+            b.process_commands(commands)
+            response_commands = [command for command in commands
+                                 if isinstance(command, SearchResponse)]
+            for command in response_commands:
+                response_pvs = [cid_to_pv.get(cid, None)
+                                for cid in command.search_instance_ids]
+                if not any(response_pvs):
+                    continue
+
+                if command.found:
+                    host_port = (command.server_address,
+                                 command.server_port)
+                    logger.debug('Found %r at %r.', response_pvs,
+                                 host_port)
+                    return host_port
+                else:
+                    logger.debug('Server responded: not found %r.',
+                                 response_pvs)
+    finally:
+        udp_sock.settimeout(orig_timeout)
+
+
+def make_channel(pv_name, udp_sock, udp_port, timeout):
+    # log = logging.LoggerAdapter(logging.getLogger('caproto.pva.ch'),
+    #                             {'pv': pv_name})
+    address = search([pv_name], udp_sock, udp_port, timeout)
+    try:
+        circuit = global_circuits[address]
+    except KeyError:
+        circuit = VirtualCircuit(
+            our_role=CLIENT, address=address,
+            priority=QOSFlags.encode(priority=0, flags=0)
+        )
+        global_circuits[address] = circuit
+
+    chan = ClientChannel(pv_name, circuit)
+
+    if chan.circuit not in sockets:
+        sockets[chan.circuit] = socket.create_connection(chan.circuit.address,
+                                                         timeout)
+        circuit.our_address = sockets[chan.circuit].getsockname()
+
+    try:
+        for command in _receive_commands(circuit, timeout=timeout):
+            if isinstance(command, ConnectionValidationRequest):
+                if command.auth_nz and 'ca' in command.auth_nz:
+                    auth_method = 'ca'
+                    host_name = socket.gethostname()
+                    client_name = getpass.getuser()
+                    auth_args = dict(user=client_name, host=host_name)
+                elif command.auth_nz and 'anonymous' in command.auth_nz:
+                    auth_method = 'anonymous'
+                    auth_args = {}
+                else:
+                    auth_method = ''
+                    auth_args = {}
+
+                response = circuit.validate_connection(
+                    client_buffer_size=command.server_buffer_size,
+                    client_registry_size=command.server_registry_size,
+                    connection_qos=0,
+                    auth_nz=auth_method,
+                    auth_args=auth_args,
+                )
+                send(circuit, response)
+            elif isinstance(command, ConnectionValidatedResponse):
+                logger.debug('Connection validated! Creating channel.')
+                create_chan = chan.create()
+                send(circuit, create_chan)
+            elif isinstance(command, CreateChannelResponse):
+                logger.debug('Channel created.')
+                return chan
+
+        # if chan.states[CLIENT] is CONNECTED:
+        #     break
+
+        logger.debug('Channel created.')
+    except Exception:
+        sockets[chan.circuit].close()
+        raise
+
+
+def _receive_commands(circuit, timeout):
+    t = time.monotonic()
+    while True:
+        try:
+            commands = recv(circuit)
+        except socket.timeout:
+            commands = []
+
+        for command in commands:
+            yield command
+            if command is DISCONNECTED:
+                raise CaprotoError(
+                    'Disconnected while waiting for a response'
+                )
+
+        if timeout is not None and time.monotonic() - t > timeout:
+            raise TimeoutError("Timeout while awaiting reading.")
+
+
+def _read(chan, timeout, pvrequest):
+    interface_req = chan.read_interface()
+    send(chan.circuit, interface_req)
+
+    init_req = chan.read_init(pvrequest=pvrequest)
+    ioid = init_req.ioid
+
+    send(chan.circuit, init_req)
+
+    for command in _receive_commands(chan.circuit, timeout):
+        if isinstance(command, ChannelFieldInfoResponse):
+            # interface = command.field_if
+            ...
+        elif isinstance(command, ChannelGetResponse):
+            if not command.is_successful:
+                raise ErrorResponseReceived(command.message)
+            if command.has_message:
+                logger.info('Message from server: %s', command.message)
+
+            if command.subcommand == Subcommands.INIT:
+                interface = command.pv_structure_if
+                read_req = chan.read(ioid, interface=interface)
+                send(chan.circuit, read_req)
+            elif command.subcommand == Subcommands.GET:
+                interface = command.pv_data['field']
+                value = command.pv_data['value']
+                dataclass = dataclass_from_field_desc(interface)
+                instance = dataclass()
+                fill_dataclass(instance, value)
+                command.dataclass_instance = instance
+                return command
+
+
+def read(pv_name, *, pvrequest, verbose=False, timeout=1):
+    """
+    Read a Channel.
+
+    Parameters
+    ----------
+    pv_name : str
+        The PV name.
+
+    pvrequest : str
+        The PVRequest, such as 'field(value)'.
+
+    verbose : boolean, optional
+        Verbose logging. Default is False.
+
+    timeout : float, optional
+        Default is 1 second.
+
+    Returns
+    -------
+
+    Examples
+    --------
+    Get the value of a Channel named 'cat'.
+    >>> get('cat')
+    """
+    udp_sock, udp_port = make_broadcaster_socket()
+    try:
+        udp_sock.settimeout(timeout)
+        chan = make_channel(pv_name, udp_sock, udp_port, timeout)
+    finally:
+        udp_sock.close()
+
+    try:
+        return _read(chan, timeout, pvrequest=pvrequest)
+    finally:
+        try:
+            if chan.states[CLIENT] is CONNECTED:
+                send(chan.circuit, chan.disconnect())
+        finally:
+            sockets[chan.circuit].close()
+            del sockets[chan.circuit]
+            del global_circuits[chan.circuit.address]
+
+
+def _monitor(chan, timeout, pvrequest, maximum_events):
+    """Monitor a channel, using pvrequest, up to maximum_events."""
+    interface_req = chan.read_interface()
+    send(chan.circuit, interface_req)
+
+    init_req = chan.subscribe_init(pvrequest=pvrequest)
+    ioid = init_req.ioid
+    send(chan.circuit, init_req)
+
+    dataclass = None
+    instance = None
+    event_count = 0
+    for command in _receive_commands(chan.circuit, timeout=None):
+        if isinstance(command, ChannelMonitorResponse):
+            if command.subcommand == Subcommands.INIT:
+                monitor_start_req = chan.subscribe_control(
+                    ioid=ioid, subcommand=MonitorSubcommands.START)
+                send(chan.circuit, monitor_start_req)
+
+                field_desc = command.pv_structure_if
+                dataclass = dataclass_from_field_desc(field_desc)
+                instance = dataclass()
+                command.dataclass_instance = instance
+                yield command
+            else:
+                event_count += 1
+                # fill_dataclass(instance, command.pv_data['value'])
+                command.dataclass_instance = instance
+                yield command
+                if maximum_events is not None:
+                    if event_count >= maximum_events:
+                        break
+
+
+def monitor(pv_name, *, pvrequest, verbose=False, timeout=1,
+            maximum_events=None):
+    """
+    Monitor a Channel.
+
+    Parameters
+    ----------
+    pv_name : str
+        The PV name.
+
+    pvrequest : str
+        The PVRequest, such as 'field(value)'.
+
+    verbose : boolean, optional
+        Verbose logging. Default is False.
+
+    timeout : float, optional
+        Default is 1 second.
+
+    Returns
+    -------
+
+    Examples
+    --------
+    """
+    udp_sock, udp_port = make_broadcaster_socket()
+    try:
+        udp_sock.settimeout(timeout)
+        chan = make_channel(pv_name, udp_sock, udp_port, timeout)
+    finally:
+        udp_sock.close()
+
+    try:
+        yield from _monitor(chan, timeout, pvrequest=pvrequest,
+                            maximum_events=maximum_events)
+    finally:
+        try:
+            if chan.states[CLIENT] is CONNECTED:
+                send(chan.circuit, chan.disconnect())
+        finally:
+            sockets[chan.circuit].close()
+            del sockets[chan.circuit]
+            del global_circuits[chan.circuit.address]
+
+
+def _write(chan, timeout, value):
+    """
+    Write structured data to channel.
+    """
+    # TODO: validate dictionary keys against the interface.
+    init_req = chan.write_init(pvrequest='field()')
+    ioid = init_req.ioid
+    send(chan.circuit, init_req)
+    if is_pva_dataclass_instance(value):
+        value = dataclasses.asdict(value)
+
+    for command in _receive_commands(chan.circuit, timeout):
+        if isinstance(command, ChannelFieldInfoResponse):
+            # interface = command.field_if
+            ...
+        elif isinstance(command, ChannelPutResponse):
+            if not command.is_successful:
+                raise ErrorResponseReceived(command.message)
+            if command.has_message:
+                logger.info('Message from server: %s', command.message)
+            if command.subcommand == Subcommands.INIT:
+                interface = command.put_structure_if
+                instance = dataclass_from_field_desc(interface)()
+                # TODO logic can move up to the circuit
+                bitset = fill_dataclass(instance, value)
+                write_req = chan.write(ioid, interface, instance, bitset)
+                send(chan.circuit, write_req)
+            elif command.subcommand == Subcommands.DEFAULT:
+                return command
+
+
+def read_write_read(pv_name: str, data: dict, *,
+                    options: typing.Optional[dict] = None,
+                    pvrequest: str = 'field()',
+                    timeout=1):
+    """
+    Write to a Channel, but sandwich the write between two reads.
+
+    Parameters
+    ----------
+    pv_name : str
+        The PV name.
+
+    data : dict or Mapping
+        The structured data to write.
+
+    options : dict, optional
+        Options to use in the pvRequest.
+    """
+    udp_sock, udp_port = make_broadcaster_socket()
+    try:
+        udp_sock.settimeout(timeout)
+        chan = make_channel(pv_name, udp_sock, udp_port, timeout)
+    finally:
+        udp_sock.close()
+
+    try:
+        initial = _read(chan, timeout, pvrequest=pvrequest)
+        res = _write(chan, timeout, data)
+        final = _read(chan, timeout, pvrequest=pvrequest)
+    finally:
+        try:
+            if chan.states[CLIENT] is CONNECTED:
+                send(chan.circuit, chan.disconnect())
+        finally:
+            sockets[chan.circuit].close()
+            del sockets[chan.circuit]
+            del global_circuits[chan.circuit.address]
+
+    return initial, res, final

--- a/caproto/tests/test_pva.py
+++ b/caproto/tests/test_pva.py
@@ -6,6 +6,8 @@ from array import array
 import pytest
 from numpy.testing import assert_array_almost_equal
 
+pytest.importorskip('caproto.pva')
+
 from caproto import pva
 from caproto.pva._fields import FieldArrayType, FieldType
 

--- a/caproto/tests/test_pva.py
+++ b/caproto/tests/test_pva.py
@@ -1,0 +1,614 @@
+import binascii
+import logging
+import textwrap
+from array import array
+
+import pytest
+from numpy.testing import assert_array_almost_equal
+
+from caproto import pva
+from caproto.pva._fields import FieldArrayType, FieldType
+
+logger = logging.getLogger(__name__)
+
+
+def setup_module():
+    logger.setLevel('DEBUG')
+    for name in ('caproto.pva.serialization',
+                 'caproto.pva.introspection',
+                 ):
+        logging.getLogger(name).setLevel('DEBUG')
+    # logging.basicConfig()
+
+
+def _fromhex(s):
+    s = ''.join(s.strip().split('\n'))
+    s = s.replace(' ', '')
+    return binascii.unhexlify(s)
+
+
+def test_status_example():
+    status_example = _fromhex(
+        "FF010A4C6F77206D656D6F727900022A4661696C656420746F20"
+        "6765742C2064756520746F20756E657870656374656420657863"
+        "657074696F6EDB6A6176612E6C616E672E52756E74696D654578"
+        "63657074696F6E0A096174206F72672E65706963732E63612E63"
+        "6C69656E742E6578616D706C652E53657269616C697A6174696F"
+        "6E4578616D706C65732E7374617475734578616D706C65732853"
+        "657269616C697A6174696F6E4578616D706C65732E6A6176613A"
+        "313138290A096174206F72672E65706963732E63612E636C6965"
+        "6E742E6578616D706C652E53657269616C697A6174696F6E4578"
+        "616D706C65732E6D61696E2853657269616C697A6174696F6E45"
+        "78616D706C65732E6A6176613A313236290A"
+    )
+
+    buf = bytearray(status_example)
+
+    print('\n- status 1')
+    status, buf, consumed = pva.StatusBE.deserialize(buf)
+    assert pva.StatusType(status.status_type) == pva.StatusType.OK
+    assert consumed == 1
+
+    print('\n- status 2')
+    status, buf, consumed = pva.StatusBE.deserialize(buf)
+    assert pva.StatusType(status.status_type) == pva.StatusType.WARNING
+    assert consumed == 13
+
+    print('\n- status 3')
+    status, buf, consumed = pva.StatusBE.deserialize(buf)
+    assert pva.StatusType(status.status_type) == pva.StatusType.ERROR
+    assert consumed == 264
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        pytest.param(
+            _fromhex(
+                "FD0001800B74696D655374616D705F74"  # .... .tim eSta mp_t
+                "03107365636F6E64735061737445706F"  # ..se cond sPas tEpo
+                "6368230B6E616E6F5365636F6E647322"  # ch#. nano Seco nds"
+                "077573657254616722"                # .use rTag "
+            ),
+            textwrap.dedent('''
+            struct timeStamp_t
+                int64 secondsPastEpoch
+                int32 nanoSeconds
+                int32 userTag
+            '''.rstrip()),
+            id='example1'
+        ),
+
+        pytest.param(
+            _fromhex(
+                "FD000180106578616D706C6553747275"  # .... .exa mple Stru
+                "6374757265070576616C75652810626F"  # ctur e..v alue ..bo
+                "756E64656453697A6541727261793010"  # unde dSiz eArr ay0.
+                "0E666978656453697A65417272617938"  # .fix edSi zeAr ray8
+                "040974696D655374616D70FD00028006"  # ..ti meSt amp. ....
+                "74696D655F7403107365636F6E647350"  # time _t.. seco ndsP
+                "61737445706F6368230B6E616E6F7365"  # astE poch #.na nose
+                "636F6E64732207757365725461672205"  # cond s".u serT ag".
+                "616C61726DFD00038007616C61726D5F"  # alar m... ..al arm_
+                "74030873657665726974792206737461"  # t..s ever ity" .sta
+                "74757322076D657373616765600A7661"  # tus" .mes sage `.va
+                "6C7565556E696F6EFD00048100030B73"  # lueU nion .... ...s
+                "7472696E6756616C75656008696E7456"  # trin gVal ue`. intV
+                "616C7565220B646F75626C6556616C75"  # alue ".do uble Valu
+                "65430C76617269616E74556E696F6EFD"  # eC.v aria ntUn ion.
+                "000582"                            # ...
+            ),
+            textwrap.dedent('''
+                struct exampleStructure
+                    byte[1] value
+                    byte<16> boundedSizeArray
+                    byte[4] fixedSizeArray
+                    struct timeStamp
+                        int64 secondsPastEpoch
+                        int32 nanoseconds
+                        int32 userTag
+                    struct alarm
+                        int32 severity
+                        int32 status
+                        string message
+                    union valueUnion
+                        string stringValue
+                        int32 intValue
+                        float64 doubleValue
+                    any variantUnion
+            '''.rstrip()),
+            id='example2'
+        ),
+    ]
+)
+def test_fielddesc_examples(data, expected):
+    cache = pva.CacheContext()
+    info, buf, offset = pva.FieldDesc.deserialize(data, endian='<', cache=cache)
+
+    print(info.summary() == expected)
+
+
+repr_with_data = [
+    pytest.param(
+        textwrap.dedent('''\
+        struct my_struct
+            byte[] value
+            byte<16> boundedSizeArray
+            byte[4] fixedSizeArray
+            struct timeStamp_t timeStamp
+                long secondsPastEpoch
+                uint nanoSeconds
+                uint userTag
+            struct alarm_t alarm
+                int severity
+                int status
+                string message
+            union valueUnion
+                string not_selected
+                uint selected
+            any variantUnion
+        '''.strip()),
+        {
+            'value': [1, 2, 3],
+            'boundedSizeArray': [4, 5, 6, 7, 8],
+            'fixedSizeArray': [9, 10, 11, 12],
+            'timeStamp': {
+                'secondsPastEpoch': 0x1122334455667788,
+                'nanoSeconds': 0xAABBCCDD,
+                'userTag': 0xEEEEEEEE,
+            },
+            'alarm': {
+                'severity': 0x11111111,
+                'status': 0x22222222,
+                'message': "Allo, Allo!",
+            },
+            'valueUnion': {
+                # 'not_selected': "not selected",
+                'selected': 0x33333333,
+            },
+            'variantUnion': "String inside variant union.",
+        },
+
+        # TODO_DOCS: example is strictly speaking incorrect, the value 0xAABBCCDD
+        # will not fit in an int32, so changed to uint for now
+        # NOTE: selector added as 'value' after union
+        (_fromhex('03010203' '05040506' '0708090A' '0B0C1122'  # .... .... .... ..."
+                  '33445566' '7788AABB' 'CCDDEEEE' 'EEEE1111'  # 3DUf w... .... ....
+                  '11112222' '22220B41' '6C6C6F2C' '20416C6C'  # .."" "".A llo,  All
+                  '6F210133' '33333360' '1C537472' '696E6720'  # o!.3 333` .Str ing
+                  '696E7369' '64652076' '61726961' '6E742075'  # insi de v aria nt u
+                  '6E696F6E' '2E')),                           # nion .
+
+        pva.BIG_ENDIAN,
+        id='first_test'
+    ),
+
+]
+
+
+@pytest.mark.parametrize("struct_repr, structured_data, expected_serialized, endian",
+                         repr_with_data)
+def test_serialize_from_repr(struct_repr, structured_data, expected_serialized, endian):
+    field = pva.structure_from_repr(struct_repr)
+
+    print(field.summary())
+
+    cache = pva.CacheContext()
+    serialized = pva.Data.serialize(field, value=structured_data,
+                                    endian=endian, cache=cache, bitset=None)
+    serialized = b''.join(serialized)
+    assert serialized == expected_serialized
+
+    result, buf, offset = pva.Data.deserialize(
+        field, serialized, cache=cache, endian=endian, bitset=None)
+
+    for key, value in result.items():
+        if isinstance(value, array):
+            result[key] = value.tolist()
+
+    assert result == structured_data
+
+
+@pytest.mark.parametrize(
+    "field_type, value, array_type",
+    [(FieldType.long, 1, FieldArrayType.scalar),
+     (FieldType.long, [1, 2, 3], FieldArrayType.variable_array),
+     (FieldType.boolean, True, FieldArrayType.scalar),
+     (FieldType.boolean, [True, True, False], FieldArrayType.variable_array),
+     (FieldType.double, 1.0, FieldArrayType.scalar),
+     (FieldType.double, [2.0, 2.0, 3.0], FieldArrayType.variable_array),
+     (FieldType.double, array('d', [2.0, 2.0, 3.0]), FieldArrayType.variable_array),
+     (FieldType.string, 'abcdefghi', FieldArrayType.scalar),
+     (FieldType.string, ['abc', 'def'], FieldArrayType.variable_array),
+     ]
+)
+def test_variant_types_and_serialization(field_type, value, array_type):
+    fd = pva.FieldDesc(name='test', field_type=field_type,
+                       array_type=array_type, size=1)
+
+    cache = pva.CacheContext()
+    for endian in (pva.LITTLE_ENDIAN, pva.BIG_ENDIAN):
+        serialized = pva.Data.serialize(fd, value=value, cache=cache,
+                                        endian=endian)
+        serialized = b''.join(serialized)
+        print(field_type, value, '->', serialized)
+
+        res = pva.Data.deserialize(fd, data=serialized, cache=cache,
+                                   endian=endian)
+        deserialized, buf, offset = res
+
+        assert len(buf) == 0
+        assert offset == len(serialized)
+        if field_type.name == 'string':
+            assert deserialized == value
+        else:
+            assert_array_almost_equal(deserialized, value)
+
+
+def test_pvrequest_test_two():
+    data = _fromhex(
+        '''
+        80 00 02 05 66 69 65 6c 64 80 00 01 05 76 61 6c
+        75 65 80 00 00 06 72 65 63 6f 72 64 80 00 01 08
+        5f 6f 70 74 69 6f 6e 73 80 00 00
+        '''
+    )
+
+    res = pva.PVRequest.deserialize(field=None, data=data,
+                                    endian=pva.LITTLE_ENDIAN)
+    field = res.data['field']
+    value = res.data['value']
+    print('field desc')
+    print('----------')
+    print(field.summary())
+    print('value')
+    print('-----')
+    print(value)
+
+    res = pva.PVRequest.serialize(
+        field=None, value=res.data, endian=pva.LITTLE_ENDIAN
+    )
+    assert data == b''.join(res)
+
+
+pvrequests = [
+    ["field(value)",
+     _fromhex(
+         'fd010080000105'
+         '6669656c64fd02008000010576616c75'  # field.......valu
+         '65fd0300800000'                    # e......
+     ),
+     # TODO: looks like we have to be smart about caching even empty
+     #       structs
+     ],
+
+    "record[]field()getField()putField()",
+    "record[a=b,x=y]field(a) getField(a)putField(a)",
+    "field(a.b[x=y])",
+    "field(a.b{c.d})",
+    "field(a.b[x=y]{c.d})",
+    "field(a.b[x=y]{c.d[x=y]})",
+
+    pytest.param([
+        "record[a=b,c=d] field(a.a[a=b]{C.D[a=b]},b.a[a=b]{E,F})",
+        _fromhex(
+            'fd 01 00 80 00 02 06'
+            '72 65 63 6f 72 64 fd 02 00 80 00 01 08 5f 6f 70'  # record......._op
+            '74 69 6f 6e 73 fd 03 00 80 00 02 01 61 60 01 63'  # tions.......a`.c
+            '60 05 66 69 65 6c 64 fd 04 00 80 00 02 01 61 fd'  # `.field.......a.
+            '05 00 80 00 01 01 61 fd 06 00 80 00 02 08 5f 6f'  # ......a......._o
+            '70 74 69 6f 6e 73 fd 07 00 80 00 01 01 61 60 01'  # ptions.......a`.
+            '43 fd 08 00 80 00 01 01 44 fd 09 00 80 00 01 08'  # C.......D.......
+            '5f 6f 70 74 69 6f 6e 73 fe 07 00 01 62 fd 0a 00'  # _options....b...
+            '80 00 01 01 61 fd 0b 00 80 00 03 08 5f 6f 70 74'  # ....a......._opt
+            '69 6f 6e 73 fe 07 00 01 45 fd 0c 00 80 00 00 01'  # ions....E.......
+            '46 fe 0c 00                                    '  # F....
+
+            # TODO check serialized data (values):
+            # 01 62 01 64 01 62 01 62 01 62
+        ),
+    ]),
+    "alarm,timeStamp,power.value",
+    "record[process=true]field(alarm,timeStamp,power.value)",
+    ("record[process=true]"
+     "field(alarm,timeStamp[algorithm=onChange,causeMonitor=false],"
+     "power{value,alarm})"),
+    ("record[int=2,float=3.14159]"
+     "field(alarm,timeStamp[shareData=true],power.value)"),
+    ("record[process=true,xxx=yyy]"
+     "getField(alarm,timeStamp,power{value,alarm},"
+     "current{value,alarm},voltage{value,alarm})"
+     "putField(power.value)"
+     ),
+    ("field(alarm,timeStamp,supply{"
+     "zero{voltage.value,current.value,power.value},"
+     "one{voltage.value,current.value,power.value}"
+     "})"),
+    ("record[process=true,xxx=yyy]"
+     "getField(alarm,timeStamp,power{value,alarm},"
+     "current{value,alarm},voltage{value,alarm},"
+     "ps0{alarm,timeStamp,power{value,alarm},current{value,alarm},voltage{value,alarm}},"
+     "ps1{alarm,timeStamp,power{value,alarm},current{value,alarm},voltage{value,alarm}})"
+     "putField(power.value)"
+     ),
+    "a{b{c{d}}}",
+    "field(alarm.status,alarm.severity)",
+
+]
+
+
+pvrequests_with_bad_syntax = [
+    "a{b[c}d]",
+
+    ("record[process=true,xxx=yyy]"
+     "putField(power.value)"
+     "getField(alarm,timeStamp,power{value,alarm},"
+     "current{value,alarm},voltage{value,alarm},"
+     "ps0{alarm,timeStamp,power{value,alarm},current{value,alarm},voltage{value,alarm}},"
+     "ps1{alarm,timeStamp,power{value,alarm},current{value,alarm},voltage{value,alarm}"
+     ")"),
+
+    "record[process=true,power.value",
+
+    # TODO: i don't know why this is supposed to be an expected failure
+    # "field(alarm.status,alarm.severity)",
+    ":field(record[process=false]power.value)",
+]
+
+
+@pytest.mark.parametrize("req", pvrequests_with_bad_syntax)
+@pytest.mark.xfail(strict=True)
+def test_pvrequests_bad_syntax(req):
+    pva.PVRequestStruct.from_string(req)
+
+
+@pytest.mark.parametrize("req", pvrequests)
+def test_pvrequests(req):
+    # from caproto.pva.serialization import serialize_pvrequest
+
+    if isinstance(req, list):
+        req, expected_serialized = req
+    else:
+        expected_serialized = None
+
+    parsed = pva.PVRequestStruct.from_string(req)
+
+    print()
+    print('PVRequest is', req)
+
+    print()
+    print('parsed:')
+    print(parsed.summary())
+    print('expected', expected_serialized)
+    return  # TODO
+
+    # # pprint.pprint(line, indent=4)
+    # print()
+    # print('Comparing original vs stringified:')
+    # print(req)
+    # print(pva.pvrequest_to_string(parsed))
+
+    # req = req.replace(' ', '')
+    # stringified = pva.pvrequest_to_string(parsed)
+    # if 'field({})'.format(stringified) == req:
+    #     ...
+    # elif req == 'record[]field()getField()putField()':
+    #     ...
+    #     # allowed failure, this isn't useful
+    # else:
+    #     assert req == stringified
+
+    # print()
+    # print('as a structure:')
+    # struct = pva.pvrequest_to_structure(parsed)
+
+    # pva.print_field_info(struct, user_types={})
+
+    # if expected_serialized is not None:
+    #     cache = SerializeCache({}, {}, {}, {})
+    #     info, buf, consumed = deserialize_introspection_data(
+    #         expected_serialized, endian='<', cache=cache,
+    #         nested_types=dict(getField={},
+    #                           putField={},
+    #                           )
+    #     )
+
+    #     print('expected deserialized:')
+    #     pva.print_field_info(info, user_types={})
+
+    #     assert consumed == len(expected_serialized)
+
+    #     serialized = serialize_pvrequest(req, endian='<', cache=cache)
+    #     serialized = b''.join(serialized)
+    #     print('serialized:')
+    #     print(serialized)
+    #     print('expected serialized:')
+    #     print(expected_serialized)
+    #     assert serialized == expected_serialized
+
+
+bitsets = [
+    (set(),
+     _fromhex('00')),
+    ({0},
+     _fromhex('01 01')),
+    ({1},
+     _fromhex('01 02')),
+    ({7},
+     _fromhex('01 80')),
+    ({8},
+     _fromhex('02 00 01')),
+    ({15},
+     _fromhex('02 00 80')),
+    ({55},
+     _fromhex('07 00 00 00  00 00 00 80')),
+    ({56},
+     _fromhex('08 00 00 00  00 00 00 00  01')),
+    ({63},
+     _fromhex('08 00 00 00  00 00 00 00  80')),
+    ({64},
+     _fromhex('09 00 00 00  00 00 00 00  00 01')),
+    ({65},
+     _fromhex('09 00 00 00  00 00 00 00  00 02')),
+    ({0, 1, 2, 4},
+     _fromhex('01 17')),
+    ({0, 1, 2, 4, 8},
+     _fromhex('02 17 01')),
+    ({8, 17, 24, 25, 34, 40, 42, 49, 50},
+     _fromhex('07 00 01 02  03 04 05 06')),
+    ({8, 17, 24, 25, 34, 40, 42, 49, 50, 56, 57, 58},
+     _fromhex('08 00 01 02  03 04 05 06  07')),
+    ({8, 17, 24, 25, 34, 40, 42, 49, 50, 56, 57, 58, 67},
+     _fromhex('09 00 01 02  03 04 05 06  07 08')),
+    ({8, 17, 24, 25, 34, 40, 42, 49, 50, 56, 57, 58, 67, 72, 75},
+     _fromhex('0A 00 01 02  03 04 05 06  07 08 09')),
+    ({8, 17, 24, 25, 34, 40, 42, 49, 50, 56, 57, 58, 67, 72, 75, 81, 83},
+     _fromhex('0B 00 01 02  03 04 05 06  07 08 09 0A')),
+]
+
+
+@pytest.mark.parametrize("bitset", bitsets)
+def test_bitset(bitset):
+    bitset, expected_serialized = bitset
+
+    deserialized_bitset, buf, consumed = pva.BitSet.deserialize(
+        expected_serialized, endian='<')
+    assert consumed == len(expected_serialized)
+    assert deserialized_bitset == bitset
+
+    print('serialized', pva.BitSet(bitset).serialize(endian='<'))
+    assert b''.join(pva.BitSet(bitset).serialize(endian='<')) == expected_serialized
+
+
+def test_search():
+    # uses nonstandard array type, so custom code path
+    from caproto.pva import SearchRequestLE
+
+    addr = '127.0.0.1'
+    pv = 'TST:image1:Array'
+
+    channel1 = {'id': 0x01, 'channel_name': pv}
+    req = SearchRequestLE(
+        sequence_id=1,
+        flags=(pva.SearchFlags.reply_required | pva.SearchFlags.unicast),
+        response_address=addr,
+        response_port=8080, protocols=['tcp'],
+        channels=[channel1],)
+
+    # NOTE: cache needed here to give interface for channels
+    cache = pva.CacheContext()
+    serialized = req.serialize(cache=cache)
+
+    assert req.response_address == addr
+    assert req.channel_count == 1
+    assert serialized == (
+        b'\x01\x00\x00\x00\x81\x00\x00\x00'
+        b'\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+        b'\x00\xff\xff\x7f\x00\x00\x01\x90\x1f'
+        b'\x01\x03tcp\x01\x00\x01\x00\x00\x00'
+        b'\x10TST:image1:Array'
+    )
+
+    deserialized, buf, consumed = SearchRequestLE.deserialize(
+        bytearray(serialized), cache=cache)
+    assert consumed == len(serialized)
+    assert deserialized.channel_count == 1
+    assert deserialized.channels == [channel1]
+    assert deserialized.response_address == addr
+
+    channel2 = {'id': 0x02, 'channel_name': pv + '2'}
+    req.channels = [channel1, channel2]
+    serialized = req.serialize(cache=cache)
+    assert req.channel_count == 2
+    assert serialized == (
+        b'\x01\x00\x00\x00\x81\x00\x00\x00'
+        b'\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+        b'\x00\xff\xff\x7f\x00\x00\x01\x90\x1f'
+        b'\x01\x03tcp'
+        b'\x02\x00'
+        b'\x01\x00\x00\x00'
+        b'\x10TST:image1:Array'
+        b'\x02\x00\x00\x00'
+        b'\x11TST:image1:Array2'
+    )
+
+    deserialized, buf, consumed = SearchRequestLE.deserialize(
+        bytearray(serialized), cache=cache)
+    assert consumed == len(serialized)
+    assert deserialized.channel_count == 2
+    assert deserialized.channels == [channel1, channel2]
+
+
+@pytest.mark.skip(reason='refactored this out; redo test')
+@pytest.mark.parametrize(
+    "bitset, expected, message",
+    [[{0}, {i for i in range(1, 18)}, 'full'],
+     [{12}, {12, 13, 14, 15}, 'alarm'],
+     [{4}, {4, 5, 6, 7, 8, 9, 10, 11}, 'timestamp+below'],
+     [{4, 7}, {4, 5, 6, 7, 8, 9, 10, 11}, 'timestamp+below'],
+     [{4, 7, 12}, {4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, 'timestamp+alarm'],
+     ]
+    # TODO unions explicitly not tested here
+)
+def test_bitset_fill(bitset, expected, message):
+    struct_repr = '''\
+    struct testStruct
+        uint8[] value
+        uint8<16> boundedSizeArray
+        uint8[4] fixedSizeArray
+        struct timeStamp_t timeStamp
+            int64 secondsPastEpoch
+            uint32 nanoSeconds
+            uint32 userTag
+            struct test_t test
+                int32 severity
+                int32 status
+                string message
+        struct alarm_t alarm
+            int32 severity
+            int32 status
+            string message
+        any variantUnion
+        int32 replacement_for_alarms
+    '''
+    # TODO referring to struct-defined types
+    # alarm_t[] alarms
+
+    '''
+        # Bitset for reference:
+        [  0]  struct testStruct
+        [  1]   byte value
+        [  2]   byte boundedSizeArray
+        [  3]   byte fixedSizeArray
+        [  4]   struct timeStamp
+        [  5]    long secondsPastEpoch
+        [  6]    uint nanoSeconds
+        [  7]    uint userTag
+        [  8]    struct alarm
+        [  9]     int severity
+        [ 10]     int status
+        [ 11]     string message
+        [ 12]   struct alarm
+        [ 13]    int severity
+        [ 14]    int status
+        [ 15]    string message
+        [ 16]   any variantUnion
+        [ 17]   int replacement_for_alarms
+    '''
+    fd = pva.structure_from_repr(struct_repr)
+
+    print(fd.summary())
+    assert fd.summary() == textwrap.dedent(struct_repr.rstrip())
+    # lines = fd.summary().splitlines()
+
+    # filled_bitset = {idx for idx, attr, field in
+    #                  fd.fields_by_bitset(pva.BitSet(bitset))}
+
+
+def test_broadcaster_messages_smoke():
+    bcast = pva.Broadcaster(our_role=pva.Role.SERVER,
+                            response_addr=('0.0.0.0', 5))
+    pv_to_cid, request = bcast.search(['abc', 'def'])
+    request.serialize()
+    response = bcast.search_response({'abc': 5, 'def': 6})
+    response.serialize()

--- a/caproto/tests/test_pva_dataclass.py
+++ b/caproto/tests/test_pva_dataclass.py
@@ -1,0 +1,135 @@
+import logging
+import textwrap
+import typing
+
+from caproto import pva
+from caproto.pva._fields import FieldArrayType, FieldType  # noqa
+
+logger = logging.getLogger(__name__)
+
+
+def test_basic():
+    @pva.pva_dataclass
+    class TimeStamp:
+        secondsPastEpoch: FieldType.int64
+        nanoseconds: FieldType.int32
+        userTag: FieldType.int32
+
+    expected = textwrap.dedent(
+        '''\
+        struct TimeStamp
+            int64 secondsPastEpoch
+            int32 nanoseconds
+            int32 userTag
+        '''.rstrip()
+    )
+
+    print('summary')
+    print(TimeStamp._pva_struct_.summary())
+    print('expected')
+    print(expected)
+
+    assert TimeStamp._pva_struct_.summary() == expected
+    assert TimeStamp().nanoseconds == 0
+
+
+def test_basic_array():
+    @pva.pva_dataclass
+    class TimeStampArray:
+        secondsPastEpoch: typing.List[pva.Int64]
+        nanoseconds: typing.List[pva.Int32]
+        userTag: typing.List[pva.Int32]
+
+    expected = textwrap.dedent(
+        '''\
+        struct TimeStampArray
+            int64[] secondsPastEpoch
+            int32[] nanoseconds
+            int32[] userTag
+        '''.rstrip()
+    )
+
+    print('summary')
+    print(TimeStampArray._pva_struct_.summary())
+    print('expected')
+    print(expected)
+
+    assert TimeStampArray._pva_struct_.summary() == expected
+    assert TimeStampArray().nanoseconds == []
+
+
+def test_nesting_dataclasses():
+    @pva.pva_dataclass
+    class TimeStamp:
+        secondsPastEpoch: FieldType.int64
+        nanoseconds: FieldType.int32
+        userTag: FieldType.int32
+
+    @pva.pva_dataclass
+    class Alarm:
+        severity: FieldType.int32
+        status: FieldType.int32
+        message: FieldType.string
+
+    @pva.pva_dataclass
+    class exampleStructure:
+        value: typing.List[pva.Int32]
+        timeStamp: TimeStamp
+        alarm: Alarm
+
+    expected = textwrap.dedent(
+        '''\
+        struct exampleStructure
+            int32[] value
+            struct TimeStamp timeStamp
+                int64 secondsPastEpoch
+                int32 nanoseconds
+                int32 userTag
+            struct Alarm alarm
+                int32 severity
+                int32 status
+                string message
+        '''.rstrip()
+    )
+    # union valueUnion
+    #     string stringValue
+    #     int32 intValue
+    #     float64 doubleValue
+    # any variantUnion
+
+    print('summary')
+    print(exampleStructure._pva_struct_.summary())
+    print('expected')
+    print(expected)
+
+    assert exampleStructure._pva_struct_.summary() == expected
+
+    # Check that the defaults actually work:
+    assert exampleStructure().timeStamp.nanoseconds == 0
+    assert exampleStructure().alarm.message == ''
+
+
+def test_union():
+    @pva.pva_dataclass
+    class exampleStructure:
+        value: typing.Union[pva.Int32, pva.String]
+
+    expected = textwrap.dedent(
+        '''\
+        struct exampleStructure
+            union value
+                int32 Int32
+                string String
+        '''.rstrip()
+    )
+
+    print('summary')
+    print(exampleStructure._pva_struct_.summary())
+    print('expected')
+    print(expected)
+
+    assert exampleStructure._pva_struct_.summary() == expected
+
+    # Check that the defaults actually work:
+    assert exampleStructure().value.Int32 is None
+    assert exampleStructure().value.String is None

--- a/caproto/tests/test_pva_dataclass.py
+++ b/caproto/tests/test_pva_dataclass.py
@@ -2,6 +2,10 @@ import logging
 import textwrap
 import typing
 
+import pytest
+
+pytest.importorskip('caproto.pva')
+
 from caproto import pva
 from caproto.pva._fields import FieldArrayType, FieldType  # noqa
 

--- a/caproto/tests/test_utils.py
+++ b/caproto/tests/test_utils.py
@@ -1,5 +1,7 @@
 import os
+
 import pytest
+
 import caproto as ca
 from caproto._headers import MessageHeader
 
@@ -143,3 +145,19 @@ def test_parse_record_bad_filters(pvname, expected_tuple):
         ...
     else:
         raise ValueError(f'Expected failure, instead returned {filter_}')
+
+
+@pytest.mark.parametrize('protocol', list(ca.Protocol))
+def test_env_util_smoke(protocol):
+    ca.get_environment_variables()
+    try:
+        ca.get_netifaces_addresses()
+    except RuntimeError:
+        # Netifaces may be unavailable
+        ...
+
+    ca.get_address_list(protocol=protocol)
+    ca.get_beacon_address_list(protocol=protocol)
+    ca._utils.get_manually_specified_beacon_addresses(protocol=protocol)
+    ca._utils.get_manually_specified_client_addresses(protocol=protocol)
+    ca.get_server_address_list(protocol=protocol)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,7 @@ dpkt
 epics-pypdb
 flake8
 netifaces
+parsimonious
 pyepics >=3.4.2
 pytest
 numpy

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
+import sys
 from distutils.core import setup
 from os import path
-import setuptools  # noqa F401
-import sys
-import versioneer
 
+import setuptools  # noqa F401
+
+import versioneer
 
 # NOTE: This file must remain Python 2 compatible for the foreseeable future,
 # to ensure that we error out properly for people with outdated setuptools
@@ -39,11 +40,18 @@ with open(path.join(here, 'requirements-test.txt')) as requirements_file:
     test_requirements = [line for line in requirements_file.read().splitlines()
                          if not line.startswith('#')]
 
-
 extras_require = {
     'standard': ['netifaces', 'numpy', 'dpkt'],
     'async': ['curio>=1.2', 'trio>=0.12.1'],
 }
+
+if sys.version_info == (3, 6):
+    # For PVA support of dataclasses
+    extras_require['standard'].append('dataclasses')
+
+# TODO this is hard requirement at the moment:
+extras_require['standard'].append('parsimonious')
+
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 extras_require['test'] = sorted(set(sum(extras_require.values(), test_requirements)))
 
@@ -62,6 +70,7 @@ setup(name='caproto',
                 'caproto.curio',
                 'caproto.examples',
                 'caproto.ioc_examples',
+                'caproto.pva',
                 'caproto.server',
                 'caproto.sync',
                 'caproto.tests',
@@ -77,6 +86,9 @@ setup(name='caproto',
               'caproto-shark = caproto.commandline.shark:main',
               'caproto-defaultdict-server = caproto.ioc_examples.defaultdict_server:main',
               'caproto-spoof-beamline = caproto.ioc_examples.spoof_beamline:main',
+              'caproto-pva-get = caproto.pva.commandline.get:main',
+              'caproto-pva-monitor = caproto.pva.commandline.monitor:main',
+              'caproto-pva-put = caproto.pva.commandline.put:main',
           ],
       },
       include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -41,16 +41,13 @@ with open(path.join(here, 'requirements-test.txt')) as requirements_file:
                          if not line.startswith('#')]
 
 extras_require = {
-    'standard': ['netifaces', 'numpy', 'dpkt'],
+    'standard': ['netifaces', 'numpy', 'dpkt', 'parsimonious'],
     'async': ['curio>=1.2', 'trio>=0.12.1'],
 }
 
 if sys.version_info == (3, 6):
     # For PVA support of dataclasses
     extras_require['standard'].append('dataclasses')
-
-# TODO this is hard requirement at the moment:
-extras_require['standard'].append('parsimonious')
 
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 extras_require['test'] = sorted(set(sum(extras_require.values(), test_requirements)))


### PR DESCRIPTION
I recently became curious about how Python `dataclasses` would fit into EPICS/Python/pvAccess, and it led me to resurrect and wrangle this nearly 3 year-old branch into something that actually (mostly) works in a couple weeks of after-work coding sessions (and some on the weekends, too - what can you do when inspiration strikes?)

Regardless of your thoughts on whether pvAccess itself should exist or not, it's here to stay in the EPICS world.  And perhaps with this we can start making some decent tools to work with it.

What does a dataclass look like?
--------------------------------

A structure that looks like:
```
struct TimeStampArray
    int64[] secondsPastEpoch
    int32[] nanoseconds
    int32[] userTag
```

can be pretty easily represented as:

```python
@pva.pva_dataclass
class TimeStampArray:
    secondsPastEpoch: List[pva.Int64]
    nanoseconds: List[pva.Int32]
    userTag: List[pva.Int32]
```

These generated "field description" structures are made to be frozen and hashable.

This can be readily instantiated, modified, and serialized by the supporting code.  Nested structures are also supported:

<details>
<summary>Nesting</summary>

```
struct exampleStructure
    int32[] value
    struct TimeStamp timeStamp
        int64 secondsPastEpoch
        int32 nanoseconds
        int32 userTag
    struct Alarm alarm
        int32 severity
        int32 status
        string message
```

Is:
```python
@pva.pva_dataclass
class TimeStamp:
    secondsPastEpoch: FieldType.int64
    nanoseconds: FieldType.int32
    userTag: FieldType.int32

@pva.pva_dataclass
class Alarm:
    severity: FieldType.int32
    status: FieldType.int32
    message: FieldType.string

@pva.pva_dataclass
class exampleStructure:
    value: typing.List[pva.Int32]
    timeStamp: TimeStamp
    alarm: Alarm
```

</details>

Lists of nested structures also work. Union types, in my limited testing,
appear to as well.

What this is
------------

* A simple synchronous client, with at least some attempt at the logging support we all love from caproto.
* Adds `caproto-pva-get`, `caproto-pva-put`, and `caproto-pva-monitor` command-line tools.  These have worked in my limited testing.
* Adds utilities to easily convert from pva structures to Python dataclasses and back.
* Adds a parser dependency (`parsimonious`) for interpreting these ugly things known as 'pvRequests'.  I don't like this, but these are arbitrarily complex strings (check out the test suite to see what I mean).
* There is some vestigial code for converting from structure representations such as the ones shown above, also using parsimonious.  I think this can be removed straightaway, but is used in the test suite at the moment.
* (Largely) Minimally invasive to the core codebase - for better or worse.

Depending on how this is used, it seems like the PVRequest code be refactored out.

What this isn't
---------------

* Fully integrated with caproto-base/caproto-v3.
* Not all messages nor all forms of pva messages are supported.
* There is no threaded or async client implementation.
* There is no server implementation.
* The state machine needs work.
* This is not tested with 3.6 (dataclasses are on PyPI for 3.6, but part of 3.7's standard library)
* This is not consistent with its user-facing API.

Bugs
----

* I'm absolutely certain there will be serialization bugs that people will run into with some real-world testing.  For a library like this, that's a real show-stopper.  But I think the basis here is solid enough that it can be fixed without major refactoring, unlike my awful first attempt.

Command-line Examples
---------------------

<details>
<summary>Command line output</summary>

```bash
$ caproto-pva-get test
{'alarm': {'message': '', 'severity': 0, 'status': 0},
 'timeStamp': {'nanoseconds': 842779874,
               'secondsPastEpoch': 1597278660,
               'userTag': 0},
 'value': 5}

$ caproto-pva-get -t test
5

$ caproto-pva-put -t test '{"value": 5}'
Old: 0
New: 5

$ caproto-pva-get test
{'alarm': {'message': '', 'severity': 0, 'status': 0},
 'timeStamp': {'nanoseconds': 842779874,
               'secondsPastEpoch': 1597278660,
               'userTag': 0},
 'value': 5}

$ caproto-pva-monitor test
struct epics:nt/NTScalar:1.0
    int32 value
    struct alarm_t alarm
        int32 severity
        int32 status
        string message
    struct time_t timeStamp
        int64 secondsPastEpoch
        int32 nanoseconds
        int32 userTag
2020-08-12 17:31:00.842780 test epics:nt/NTScalar:1.0(value=0, alarm=alarm_t(severity=0, status=0, message=''), timeStamp=time_t(secondsPastEpoch=1597278660, nanoseconds=842779874, userTag=0))
2020-08-12 17:31:00.842780 test epics:nt/NTScalar:1.0(value=5, alarm=alarm_t(severity=0, status=0, message=''), timeStamp=time_t(secondsPastEpoch=1597278660, nanoseconds=842779874, userTag=0))

```
</details>

The monitoring tools are showing the structure from the dataclass instance, whereas (currently) the get and put tools are showing the dictionary structure.


Path forward
------------

* Remove or somehow make optional the parsimonious requirement, perhaps moving it to lark instead
* Fully implement the remaining messages
* Test against proven servers
* Threaded or async client
* Async server
* See how this could possibly be integrated with caproto-v3 things in a not-kludged together fashion

So
---

So, @danielballan, @tacaswell, given the state of things here, what would your requirements be to sigh and begrudgingly click the merge button? 😉 