### PR TITLE
REF/FIX: use new `get_client_address_list`; do not use hard-coded ports

### DIFF
--- a/caproto/_utils.py
+++ b/caproto/_utils.py
@@ -351,12 +351,20 @@ def get_client_address_list(*, protocol=Protocol.ChannelAccess):
     Get channel access client address list in the form of (host, port) based on
     environment variables.
 
+    For CA, the default port is ``EPICS_CA_SERVER_PORT``.
+    For PVA, the default port is ``EPICS_PVA_BROADCAST_PORT``.
+
     See Also
     --------
     :func:`get_address_list`
     '''
     protocol = Protocol(protocol)
-    default_port = get_environment_variables()[f'EPICS_{protocol}_SERVER_PORT']
+    env = get_environment_variables()
+    if protocol == Protocol.ChannelAccess:
+        default_port = env['EPICS_CA_SERVER_PORT']
+    else:
+        default_port = env['EPICS_PVA_BROADCAST_PORT']
+
     return list(set(
         get_address_and_port_from_string(addr, default_port)
         for addr in get_address_list(protocol=protocol)

--- a/caproto/_utils.py
+++ b/caproto/_utils.py
@@ -346,7 +346,7 @@ def get_address_list(*, protocol=Protocol.ChannelAccess):
     return list(set(addresses + auto_addr_list))
 
 
-def get_client_address_list(port=None, *, protocol=Protocol.ChannelAccess):
+def get_client_address_list(*, protocol=Protocol.ChannelAccess):
     '''
     Get channel access client address list in the form of (host, port) based on
     environment variables.
@@ -356,12 +356,9 @@ def get_client_address_list(port=None, *, protocol=Protocol.ChannelAccess):
     :func:`get_address_list`
     '''
     protocol = Protocol(protocol)
-
-    if port is None:
-        port = get_environment_variables()[f'EPICS_{protocol}_SERVER_PORT']
-
+    default_port = get_environment_variables()[f'EPICS_{protocol}_SERVER_PORT']
     return list(set(
-        get_address_and_port_from_string(addr, port)
+        get_address_and_port_from_string(addr, default_port)
         for addr in get_address_list(protocol=protocol)
     ))
 

--- a/caproto/_utils.py
+++ b/caproto/_utils.py
@@ -46,7 +46,6 @@ __all__ = (  # noqa F822
     'apply_arr_filter',
     'ChannelFilter',
     'get_environment_variables',
-    'get_address_and_port_from_string',
     'get_address_list',
     'get_local_address',
     'get_beacon_address_list',

--- a/caproto/asyncio/client.py
+++ b/caproto/asyncio/client.py
@@ -116,21 +116,15 @@ class SharedBroadcaster:
                 'our_address': self.broadcaster.client_address,
                 'direction': '--->>>'}
 
-        for host in ca.get_address_list():
-            if ':' in host:
-                host, _, port_as_str = host.partition(':')
-                specified_port = int(port_as_str)
-            else:
-                specified_port = port
-
-            tags['their_address'] = (host, specified_port)
+        for host_tuple in ca.get_client_address_list(port):
+            tags['their_address'] = host_tuple
             self.log.debug(
                 '%d commands %dB',
                 len(commands), len(bytes_to_send), extra=tags)
             try:
-                await self.wrapped_transport.sendto(bytes_to_send,
-                                                    (host, specified_port))
+                await self.wrapped_transport.sendto(bytes_to_send, host_tuple)
             except OSError as ex:
+                host, specified_port = host_tuple
                 raise ca.CaprotoNetworkError(
                     f'{ex} while sending {len(bytes_to_send)} bytes to '
                     f'{host}:{specified_port}') from ex

--- a/caproto/pva/sync/client.py
+++ b/caproto/pva/sync/client.py
@@ -8,7 +8,7 @@ import typing
 from typing import Dict, Tuple
 
 # REBASE TODO this will go away - need to rebase
-from caproto import (MAX_UDP_RECV, bcast_socket, get_address_list,
+from caproto import (MAX_UDP_RECV, bcast_socket, get_client_address_list,
                      get_environment_variables, pva)
 from caproto.pva import (CLIENT, CONNECTED, DISCONNECTED, NEED_DATA,
                          Broadcaster, CaprotoError, ChannelFieldInfoResponse,
@@ -30,8 +30,6 @@ sockets: Dict[VirtualCircuit, socket.socket] = {}
 global_circuits: Dict[AddressTuple, VirtualCircuit] = {}
 
 env = get_environment_variables()
-broadcast_port = env['EPICS_PVA_BROADCAST_PORT']
-
 logger = logging.getLogger('caproto.pva.ctx')
 serialization_logger = logging.getLogger('caproto.pva.serialization_debug')
 
@@ -92,9 +90,9 @@ def search(pv, udp_sock, udp_port, timeout, max_retries=2):
 
     def send_search(message):
         bytes_to_send = broadcaster.send(message)
-        for host in get_address_list(protocol='PVA'):
-            udp_sock.sendto(bytes_to_send, (host, broadcast_port))
-            logger.debug('Search request sent to %r.', (host, broadcast_port))
+        for host, port in get_client_address_list(protocol='PVA'):
+            udp_sock.sendto(bytes_to_send, (host, port))
+            logger.debug('Search request sent to %r.', (host, port))
             logger.debug('%s', bytes_to_send)
 
     def check_timeout():

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -61,12 +61,13 @@ def search(pv_name, udp_sock, timeout, *, max_retries=2):
     repeater_port = env['EPICS_CA_REPEATER_PORT']
 
     client_address_list = ca.get_client_address_list()
-    for host, _ in client_address_list:
-        # Ignore the client address port and use the repeater port here.
-        try:
-            udp_sock.sendto(bytes_to_send, (host, repeater_port))
-        except OSError as exc:
-            raise ca.CaprotoNetworkError(f"Failed to send to {host}:{repeater_port}") from exc
+    local_address = ca.get_local_address()
+
+    try:
+        udp_sock.sendto(bytes_to_send, (local_address, repeater_port))
+    except OSError as exc:
+        raise ca.CaprotoNetworkError(
+            f"Failed to send to {local_address}:{repeater_port}") from exc
 
     logger.debug("Searching for %r....", pv_name)
     commands = (

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -2,8 +2,8 @@
 # as three top-level functions: read, write, subscribe. They are comparatively
 # simple and naive, with no caching or concurrency, and therefore less
 # performant but more robust.
-import inspect
 import getpass
+import inspect
 import logging
 import selectors
 import socket
@@ -12,18 +12,16 @@ import time
 import weakref
 
 import caproto as ca
-from .._dbr import (field_types, ChannelType, native_type, SubscriptionType)
-from .._utils import (adapt_old_callback_signature,
-                      ErrorResponseReceived, CaprotoError, CaprotoTimeoutError,
-                      get_environment_variables, safe_getsockname)
-from .repeater import spawn_repeater
 
+from .._dbr import ChannelType, SubscriptionType, field_types, native_type
+from .._utils import (CaprotoError, CaprotoTimeoutError, ErrorResponseReceived,
+                      adapt_old_callback_signature, get_environment_variables,
+                      safe_getsockname)
+from .repeater import spawn_repeater
 
 __all__ = ('read', 'write', 'subscribe', 'block', 'interrupt',
            'read_write_read')
 logger = logging.getLogger('caproto.ctx')
-
-CA_SERVER_PORT = 5064  # just a default
 
 # Make a dict to hold our tcp sockets.
 sockets = {}
@@ -59,8 +57,12 @@ def search(pv_name, udp_sock, timeout, *, max_retries=2):
     logger.debug('Registering with the Channel Access repeater.')
     bytes_to_send = b.send(ca.RepeaterRegisterRequest())
 
-    repeater_port = get_environment_variables()['EPICS_CA_REPEATER_PORT']
-    for host in ca.get_address_list():
+    env = get_environment_variables()
+    repeater_port = env['EPICS_CA_REPEATER_PORT']
+
+    client_address_list = ca.get_client_address_list()
+    for host, _ in client_address_list:
+        # Ignore the client address port and use the repeater port here.
         try:
             udp_sock.sendto(bytes_to_send, (host, repeater_port))
         except OSError as exc:
@@ -76,12 +78,7 @@ def search(pv_name, udp_sock, timeout, *, max_retries=2):
             'direction': '--->>>'}
 
     def send_search():
-        for host in ca.get_address_list():
-            if ':' in host:
-                host, _, specified_port = host.partition(':')
-                dest = (host, int(specified_port))
-            else:
-                dest = (host, CA_SERVER_PORT)
+        for dest in client_address_list:
             tags['their_address'] = dest
             b.log.debug(
                 '%d commands %dB',

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -3,19 +3,20 @@
 
 import collections
 import functools
+import getpass
+import socket
+import threading
+import time
+
+import pytest
+
 import caproto
+import caproto as ca
 import caproto._utils
 import caproto.threading.client
-import time
-import socket
-import getpass
-import threading
-
-from caproto.threading.client import (Context, SharedBroadcaster, Batch,
-                                      ContextDisconnectedError)
 from caproto import ChannelType
-import caproto as ca
-import pytest
+from caproto.threading.client import (Batch, Context, ContextDisconnectedError,
+                                      SharedBroadcaster)
 
 from .conftest import default_setup_module as setup_module  # noqa
 from .conftest import default_teardown_module as teardown_module  # noqa
@@ -94,7 +95,7 @@ def test_specified_port(monkeypatch, context, ioc):
     address_list = list(caproto.get_address_list())
     address_list.append('{}:{}'.format(circuit.host, circuit.port))
 
-    def get_address_list():
+    def get_address_list(*, protocol='CA'):
         return address_list
 
     for module in (caproto._utils, caproto, caproto.threading.client):

--- a/caproto/tests/test_utils.py
+++ b/caproto/tests/test_utils.py
@@ -173,10 +173,10 @@ def test_env_util_smoke(protocol):
 def test_split_address(addr, default_port, expected):
     if expected in {ValueError, }:
         with pytest.raises(expected):
-            ca.get_address_and_port_from_string(addr, default_port)
+            ca._utils.get_address_and_port_from_string(addr, default_port)
         return
 
-    assert ca.get_address_and_port_from_string(addr, default_port) == expected
+    assert ca._utils.get_address_and_port_from_string(addr, default_port) == expected
 
 
 def patch_env(monkeypatch, env_vars):

--- a/caproto/tests/test_utils.py
+++ b/caproto/tests/test_utils.py
@@ -252,7 +252,10 @@ def test_client_addresses(monkeypatch, protocol, default_port, env_auto,
 
     env[f'EPICS_{protocol}_ADDR_LIST'] = env_addr
     env[f'EPICS_{protocol}_AUTO_ADDR_LIST'] = env_auto
-    env[f'EPICS_{protocol}_SERVER_PORT'] = int(default_port)
+    if protocol == 'CA':
+        env['EPICS_CA_SERVER_PORT'] = int(default_port)
+    elif protocol == 'PVA':
+        env['EPICS_PVA_BROADCAST_PORT'] = int(default_port)
 
     patch_env(monkeypatch, env)
     assert set(ca.get_client_address_list(protocol=protocol)) == set(expected)

--- a/caproto/tests/test_utils.py
+++ b/caproto/tests/test_utils.py
@@ -12,8 +12,8 @@ def test_broadcast_auto_address_list():
     try:
         os.environ['EPICS_CA_ADDR_LIST'] = ''
         os.environ['EPICS_CA_AUTO_ADDR_LIST'] = 'YES'
-        expected = [bcast for addr, bcast in ca.get_netifaces_addresses()]
-        assert ca.get_address_list() == expected
+        expected = set(bcast for addr, bcast in ca.get_netifaces_addresses())
+        assert set(ca.get_address_list()) == expected
     finally:
         os.environ.clear()
         os.environ.update(env)
@@ -161,3 +161,122 @@ def test_env_util_smoke(protocol):
     ca._utils.get_manually_specified_beacon_addresses(protocol=protocol)
     ca._utils.get_manually_specified_client_addresses(protocol=protocol)
     ca.get_server_address_list(protocol=protocol)
+
+
+@pytest.mark.parametrize(
+    'addr, default_port, expected',
+    [pytest.param('1.2.3.4:56', 8, ('1.2.3.4', 56)),
+     pytest.param('1.2.3.4', 8, ('1.2.3.4', 8)),
+     pytest.param('[::]:34', 8, ValueError),
+     ]
+)
+def test_split_address(addr, default_port, expected):
+    if expected in {ValueError, }:
+        with pytest.raises(expected):
+            ca.get_address_and_port_from_string(addr, default_port)
+        return
+
+    assert ca.get_address_and_port_from_string(addr, default_port) == expected
+
+
+def patch_env(monkeypatch, env_vars):
+    """Patch `get_environment_variables` for testing below."""
+    def get_env():
+        return env_vars
+
+    monkeypatch.setattr(ca._utils, 'get_environment_variables', get_env)
+
+
+@pytest.mark.parametrize('protocol', list(ca.Protocol))
+@pytest.mark.parametrize(
+    'default_port, env_auto, env_addr, expected',
+    [
+        pytest.param(
+            8088, 'YES', '1.2.3.4 1.2.3.4:556',
+            [('1.2.3.4', 8088),
+             ('1.2.3.4', 556),
+             ('255.255.255.255', 8088),
+             ]
+        ),
+
+        pytest.param(
+            8088, 'NO', '1.2.3.4 1.2.3.4:556',
+            [('1.2.3.4', 8088),
+             ('1.2.3.4', 556),
+             ]
+        ),
+    ],
+)
+def test_beacon_addresses(monkeypatch, protocol, default_port, env_auto,
+                          env_addr, expected):
+    env = ca.get_environment_variables()
+
+    key = ca.Protocol(protocol).server_env_key
+    env[f'EPICS_{key}_BEACON_ADDR_LIST'] = env_addr
+    env[f'EPICS_{key}_AUTO_BEACON_ADDR_LIST'] = env_auto
+    if protocol == ca.Protocol.ChannelAccess:
+        env['EPICS_CAS_BEACON_PORT'] = int(default_port)
+    else:
+        env['EPICS_PVAS_BROADCAST_PORT'] = int(default_port)
+
+    patch_env(monkeypatch, env)
+    assert set(ca.get_beacon_address_list(protocol=protocol)) == set(expected)
+
+
+@pytest.mark.parametrize('protocol', list(ca.Protocol))
+@pytest.mark.parametrize(
+    'default_port, env_auto, env_addr, expected',
+    [
+        pytest.param(
+            8088, 'YES', '1.2.3.4 1.2.3.4:556',
+            [('1.2.3.4', 8088),
+             ('1.2.3.4', 556),
+             ('255.255.255.255', 8088),
+             ]
+        ),
+
+        pytest.param(
+            8088, 'NO', '1.2.3.4 1.2.3.4:556',
+            [('1.2.3.4', 8088),
+             ('1.2.3.4', 556),
+             ]
+        ),
+    ],
+)
+def test_client_addresses(monkeypatch, protocol, default_port, env_auto,
+                          env_addr, expected):
+    env = ca.get_environment_variables()
+
+    # Easier to test without netifaces
+    monkeypatch.setattr(ca._utils, 'netifaces', None)
+
+    env[f'EPICS_{protocol}_ADDR_LIST'] = env_addr
+    env[f'EPICS_{protocol}_AUTO_ADDR_LIST'] = env_auto
+    env[f'EPICS_{protocol}_SERVER_PORT'] = int(default_port)
+
+    patch_env(monkeypatch, env)
+    assert set(ca.get_client_address_list(protocol=protocol)) == set(expected)
+
+
+@pytest.mark.parametrize('protocol', list(ca.Protocol))
+@pytest.mark.parametrize(
+    'env_addr, expected',
+    [
+        pytest.param('1.2.3.4', {'1.2.3.4'}, id='normal'),
+        pytest.param('1.2.3.4 1.2.3.4:556', {'1.2.3.4'}, id='ignore-port',
+                     marks=pytest.mark.filterwarnings("ignore:Port specified"),
+                     ),
+        pytest.param('1.2.3.4 5.6.7.8:556', {'1.2.3.4', '5.6.7.8'},
+                     id='ignore-port-1',
+                     marks=pytest.mark.filterwarnings("ignore:Port specified"),
+                     ),
+        pytest.param('', ['0.0.0.0'], id='empty-list'),
+    ],
+)
+def test_server_addresses(monkeypatch, protocol, env_addr, expected):
+    env = ca.get_environment_variables()
+    key = ca.Protocol(protocol).server_env_key
+    env[f'EPICS_{key}_INTF_ADDR_LIST'] = env_addr
+
+    patch_env(monkeypatch, env)
+    assert set(ca.get_server_address_list(protocol=protocol)) == set(expected)

--- a/caproto/trio/client.py
+++ b/caproto/trio/client.py
@@ -11,16 +11,16 @@
 import getpass
 import logging
 import time
+from collections import OrderedDict, defaultdict
+
+import trio
+from trio import socket
 
 import caproto as ca
-import trio
 
-from collections import OrderedDict, defaultdict
-from trio import socket
-from .._utils import (batch_requests, CaprotoError, ThreadsafeCounter,
+from .._constants import SEARCH_MAX_DATAGRAM_BYTES, STALE_SEARCH_EXPIRATION
+from .._utils import (CaprotoError, ThreadsafeCounter, batch_requests,
                       get_environment_variables, safe_getsockname)
-from .._constants import (STALE_SEARCH_EXPIRATION, SEARCH_MAX_DATAGRAM_BYTES)
-
 from .util import open_memory_channel
 
 
@@ -35,7 +35,8 @@ class ChannelReadError(TrioClientError):
 if not hasattr(trio.SocketStream, 'sendmsg'):
     # monkey-patch in sendmsg in trio
     async def sendmsg(self, buffers):
-        from trio._highlevel_socket import _translate_socket_errors_to_stream_errors  # noqa
+        from trio._highlevel_socket import \
+            _translate_socket_errors_to_stream_errors  # noqa
         if self.socket.did_shutdown_SHUT_WR:
             await trio._core.checkpoint()
             raise trio.ClosedStreamError("can't send data after sending EOF")
@@ -291,20 +292,15 @@ class SharedBroadcaster:
         tags = {'role': 'CLIENT',
                 'our_address': self.broadcaster.client_address,
                 'direction': '--->>>'}
-        for host in ca.get_address_list():
-            if ':' in host:
-                host, _, port_as_str = host.partition(':')
-                specified_port = int(port_as_str)
-            else:
-                specified_port = port
-            tags['their_address'] = (host, specified_port)
+        for host_tuple in ca.get_client_address_list(port):
+            tags['their_address'] = host_tuple
             self.broadcaster.log.debug(
                 '%d commands %dB',
                 len(commands), len(bytes_to_send), extra=tags)
             try:
-                await self.udp_sock.sendto(bytes_to_send,
-                                           (host, specified_port))
+                await self.udp_sock.sendto(bytes_to_send, host_tuple)
             except OSError as ex:
+                host, specified_port = host_tuple
                 raise ca.CaprotoNetworkError(
                     f'{ex} while sending {len(bytes_to_send)} bytes to '
                     f'{host}:{specified_port}') from ex
@@ -333,7 +329,7 @@ class SharedBroadcaster:
         await self.udp_sock.bind(('', 0))
         self.broadcaster.our_address = safe_getsockname(self.udp_sock)
         command = self.broadcaster.register('127.0.0.1')
-        await self.send(ca.EPICS_CA2_PORT, command)
+        await self.send(self.environ['EPICS_CA_REPEATER_PORT'], command)
         task_status.started()
 
         while True:


### PR DESCRIPTION
* Leaves `ca.get_address_list` behind for (mostly) back-compat
* Adds `get_client_address_list`, which pairs well enough with `get_server_address_list` and `get_beacon_address_list` 
* Removes hard-coded ports in some places

Badly in need of double-checking. ~Will mark draft until I can find the time.~

~Logic in broadcasters particularly could use further refactoring, as we require the broadcaster instance to know which port it wants to send information on, rather than just saying `"send this to the address list with whatever the configured {repeater, ca server port} is"`~

Repeater registration with local address, removing `port` from `broadcaster.send(port)`.
- [x] asyncio client
- [x] threading client
- [x] sync client
- [x] curio, trio clients

Respecting ports by using `caproto.get_client_address_list`
- [x] asyncio client
- [x] threading client
- [x] sync client
- [x] curio, trio clients
- [x] `x:1234` as `EPICS_CA_SERVER_PORT` means to listen on udp/tcp on `1234`; so this is the appropriate port for broadcasts
- [x] PVA uses `EPICS_PVA_BROADCAST_PORT`; though it does not appear that setting `EPICS_PVAS_SERVER_PORT` alone effects the same broadcast port change, instead requiring `EPICS_PVAS_BROADCAST_PORT` (meaning caproto-pva will still be buggy with custom ports)

Closes #645 
Closes #639 