### PR TITLE
FIX: caproto-get/monitor char array

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.4.2
+    rev: 5.5.0
     hooks:
     -   id: isort
 

--- a/caproto/commandline/cli_print_formats.py
+++ b/caproto/commandline/cli_print_formats.py
@@ -5,8 +5,8 @@ This module contains functions for formatting data output for CLI utilities
 '''
 
 import numbers
-import sys
 import re
+import sys
 
 
 class _DataPrintFormat:
@@ -132,6 +132,10 @@ def gen_data_format(args=None, data=None):
     if(isinstance(data[0], str) or isinstance(data[0], bytes)):
         df.format = "s"
 
+    if args.float_s and isinstance(data[0], numbers.Integral):
+        df.format = 's'
+        return df
+
     # 'data' contains an array of floats
     if(isinstance(data[0], float)):
         # Check if any of the format specification arguments were passed
@@ -238,6 +242,9 @@ def format_response_data(data=None, data_fmt=None):
     # Round floating point numbers and convert to nearest integers (if required)
     if(isinstance(data[0], float) and data_fmt.float_round):
         data = [int(round(v)) for v in data]
+    if isinstance(data[0], numbers.Integral) and data_fmt.format == 's':
+        return ''.join(chr(c) for c in data)
+
     # Convert to strings by printing values using selected format and prefix (0x, 0o or 0b)
     data_str = [("{}{:" + data_fmt.format + "}").format(data_fmt.prefix, v) for v in data]
     s = sep.join(data_str)

--- a/caproto/commandline/cli_print_formats.py
+++ b/caproto/commandline/cli_print_formats.py
@@ -128,14 +128,6 @@ def gen_data_format(args=None, data=None):
     # If no format was specified, the default is "g" (as in EPICS caget)
     df.format = "g"
 
-    # 'data' contains a list (or array) of strings
-    if(isinstance(data[0], str) or isinstance(data[0], bytes)):
-        df.format = "s"
-
-    if args.float_s and isinstance(data[0], numbers.Integral):
-        df.format = 's'
-        return df
-
     # 'data' contains an array of floats
     if(isinstance(data[0], float)):
         # Check if any of the format specification arguments were passed
@@ -164,17 +156,24 @@ def gen_data_format(args=None, data=None):
             df.prefix = "0b"
             df.float_round = True
 
+    # 'data' contains a list (or array) of strings
+    if(isinstance(data[0], str) or isinstance(data[0], bytes)):
+        df.format = "s"
+
     # 'data' contains an array of integers
     if(isinstance(data[0], numbers.Integral)):
-        if args.int_0x:
-            df.format = "X"   # Hexadecimal
-            df.prefix = "0x"
-        elif args.int_0o:
-            df.format = "o"   # Octal
-            df.prefix = "0o"
-        elif args.int_0b:
-            df.format = "b"   # Binary
-            df.prefix = "0b"
+        if args.array_as_str:  # Format array as string
+            df.format = 's'
+        else:  # Print as array
+            if args.int_0x:
+                df.format = "X"   # Hexadecimal
+                df.prefix = "0x"
+            elif args.int_0o:
+                df.format = "o"   # Octal
+                df.prefix = "0o"
+            elif args.int_0b:
+                df.format = "b"   # Binary
+                df.prefix = "0b"
 
     # Separator: may be a single character (quoted or not quoted) or quoted multiple characters
     #          including spaces. EPICS caget allows only single character separators.

--- a/caproto/commandline/get.py
+++ b/caproto/commandline/get.py
@@ -79,6 +79,8 @@ def main():
     parser.add_argument('-n', action='store_true',
                         help=("Retrieve enums as integers (default is "
                               "strings)."))
+    parser.add_argument('-S', dest="array_as_str", action='store_true',
+                        help=("Print array of char as a string (long string)"))
     parser.add_argument('--no-color', action='store_true',
                         help="Suppress ANSI color codes in log messages.")
     parser.add_argument('--no-repeater', action='store_true',

--- a/caproto/commandline/monitor.py
+++ b/caproto/commandline/monitor.py
@@ -58,6 +58,8 @@ def main():
     parser.add_argument('-n', action='store_true',
                         help=("Retrieve enums as integers (default is "
                               "strings)."))
+    parser.add_argument('-S', dest="array_as_str", action='store_true',
+                        help=("Print array of char as a string (long string)"))
     parser.add_argument('--no-color', action='store_true',
                         help="Suppress ANSI color codes in log messages.")
     parser.add_argument('--no-repeater', action='store_true',


### PR DESCRIPTION
I thought this worked before but frustratingly couldn't find a way to get an array of bytes to format a string.

With this PR, long strings are no problem:
```
$ caproto-get -s AT2L0:CALC:STATS:TraceDiffResults.VAL$
AT2L0:CALC:STATS:TraceDiffResults.VAL$    /Users/klauer/mc/envs/hxr-attenuator/lib/python3.7/tracemalloc.py:65: size=70.5 KiB (-70.5 KiB), count=902 (-902), average=80 B
```

Unclear if this will have any side effects - I don't really understand much of the CLI formatting code.