### PR TITLE
Add support for -# in caproto-get and -monitor.

### DIFF
--- a/caproto/commandline/get.py
+++ b/caproto/commandline/get.py
@@ -12,12 +12,13 @@ Python session, do not import this module; instead import caproto.sync.client.
 """
 import argparse
 from datetime import datetime
-from .. import ChannelType, set_handler, field_types, __version__
-from ..sync.client import read
+
+from .. import ChannelType, __version__, field_types, set_handler
 from .._log import _set_handler_with_logger
 from .._utils import ShowVersionAction
-from .cli_print_formats import (format_response_data, gen_data_format,
-                                clean_format_args, format_str_adjust)
+from ..sync.client import read
+from .cli_print_formats import (clean_format_args, format_response_data,
+                                format_str_adjust, gen_data_format)
 
 
 def main():
@@ -81,6 +82,8 @@ def main():
                               "strings)."))
     parser.add_argument('-S', dest="array_as_str", action='store_true',
                         help=("Print array of char as a string (long string)"))
+    parser.add_argument('-#', dest="data_count", type=int, metavar="COUNT",
+                        help=("Print first COUNT elements of an array"))
     parser.add_argument('--no-color', action='store_true',
                         help="Suppress ANSI color codes in log messages.")
     parser.add_argument('--no-repeater', action='store_true',
@@ -166,6 +169,7 @@ def main():
 
             response = read(pv_name=pv_name,
                             data_type=data_type,
+                            data_count=args.data_count,
                             timeout=args.timeout,
                             priority=args.priority,
                             force_int_enums=args.n,

--- a/caproto/commandline/monitor.py
+++ b/caproto/commandline/monitor.py
@@ -11,14 +11,15 @@ For access to the underlying functionality from a Python script or interactive
 Python session, do not import this module; instead import caproto.sync.client.
 """
 import argparse
-from datetime import datetime
 import time
-from ..sync.client import subscribe, block
-from .. import SubscriptionType, set_handler, __version__
+from datetime import datetime
+
+from .. import SubscriptionType, __version__, set_handler
 from .._log import _set_handler_with_logger
 from .._utils import ShowVersionAction
-from .cli_print_formats import (format_response_data, gen_data_format,
-                                clean_format_args, format_str_adjust)
+from ..sync.client import block, subscribe
+from .cli_print_formats import (clean_format_args, format_response_data,
+                                format_str_adjust, gen_data_format)
 
 
 def main():
@@ -60,6 +61,8 @@ def main():
                               "strings)."))
     parser.add_argument('-S', dest="array_as_str", action='store_true',
                         help=("Print array of char as a string (long string)"))
+    parser.add_argument('-#', dest="data_count", type=int, metavar="COUNT",
+                        help=("Print first COUNT elements of an array"))
     parser.add_argument('--no-color', action='store_true',
                         help="Suppress ANSI color codes in log messages.")
     parser.add_argument('--no-repeater', action='store_true',
@@ -186,6 +189,7 @@ def main():
         for pv_name in args.pv_names:
             sub = subscribe(pv_name,
                             mask=mask,
+                            data_count=args.data_count,
                             priority=args.priority)
             sub.add_callback(callback)
             cbs.append(callback)  # Hold ref to keep it from being garbage collected.

--- a/caproto/tests/test_cli_scripts.py
+++ b/caproto/tests/test_cli_scripts.py
@@ -1,8 +1,9 @@
-import sys
-import pytest
 import subprocess
+import sys
 
-from caproto.sync.client import read, write, subscribe, block
+import pytest
+
+from caproto.sync.client import block, read, subscribe, write
 
 from .conftest import dump_process_output
 
@@ -147,6 +148,8 @@ fmt3 = '{response.data}'
                           ('caproto-get', ('waveform', '-F', "'-'")),
                           # Test separator (multiple characters, not supported by EPICS caget)
                           ('caproto-get', ('float', '--wide', '-F', "' = '")),
+                          # Test data_count limiter.
+                          ('caproto-get', ('waveform', '-#', '1')),
                           ])
 def test_cli(command, args, ioc, ):
     args = fix_arg_prefixes(ioc, args)
@@ -199,6 +202,8 @@ def test_cli(command, args, ioc, ):
                           ('waveform', '-F', "'-'"),
                           # Test separator (multiple characters, not supported by EPICS monitor)
                           ('float', '-F', "' = '"),
+                          # Test data_count limiter.
+                          ('waveform', '-#', '1'),
                           ])
 def test_monitor(args, ioc):
     args = fix_arg_prefixes(ioc, args)


### PR DESCRIPTION
A minor but long-standing thing: the last commandline argument that brings us
up to parity with `caget` and `camonitor`.

Closes #147