### PR TITLE
CI: cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ script:
   - rm -f `which caRepeater`
 
   - pip install git+https://github.com/klauer/catvs.git@py3k
-  # Work around pip bug that fails to respect trio's pin of attr
+  # Work around pip bug that fails to respect trio's pin of attrs.
   - pip install -U attrs
 
   - caproto-repeater &

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,26 +86,17 @@ script:
   - rm -f `which caRepeater`
 
   - pip install git+https://github.com/klauer/catvs.git@py3k
-  # Work around pip bug that fails to respect trio's pin of attrs.
-  - pip install -U attrs
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
-        pip install dataclasses;
-    fi
 
   - caproto-repeater &
+
   - coverage run --parallel-mode run_tests.py -v
   - coverage combine --append
-
   - coverage report -m
   - codecov
+
   - set -e
   # Install deps for building the docs.
-  - pip install --quiet --upgrade --global-option='--without-libyaml' pyyaml
-  # directly install second layer deps to work around easy_install bug
-  - pip install --quiet cryptography cffi pycparser
   - pip install --quiet --upgrade -r requirements-doc.txt
-  # Run a CA Repeater for the docs examples to use.
-  - caproto-repeater &
   # Build the docs.
   - make -C doc html
   # Upload the docs to gh-pages.

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,8 @@ script:
   - rm -f `which caRepeater`
 
   - pip install git+https://github.com/klauer/catvs.git@py3k
+  # Work around pip bug that fails to respect trio's pin of attr
+  - pip install -U attrs
 
   - caproto-repeater &
 


### PR DESCRIPTION
`dataclasses` definitely is not necessary; repeater is started twice; unclear about the others. Let's see what happens.