### PR TITLE
Reduce the minimum requirements to run tests

### DIFF
--- a/caproto/benchmarking/util.py
+++ b/caproto/benchmarking/util.py
@@ -5,11 +5,22 @@ import subprocess
 import shutil
 import logging
 from contextlib import contextmanager
+import functools
 
 from .._utils import named_temporary_file
 
 
 logger = logging.getLogger(__name__)
+
+
+@functools.lru_cache(1)
+def has_softioc():
+    try:
+        subprocess.run(['softIoc'])
+    except FileNotFoundError:
+        return False
+    else:
+        return True
 
 
 def find_dbd_path():

--- a/caproto/tests/conftest.py
+++ b/caproto/tests/conftest.py
@@ -18,9 +18,6 @@ import caproto.benchmarking  # noqa
 import caproto.threading  # noqa
 from caproto.sync.client import read
 
-# DBD parsing-related fixtures:
-from .dbd import record_type_to_fields, test_dbd_file  # noqa
-
 _repeater_process = None
 
 REPEATER_PORT = 5065

--- a/caproto/tests/conftest.py
+++ b/caproto/tests/conftest.py
@@ -168,6 +168,8 @@ def prefix():
 
 
 def _epics_base_ioc(prefix, request):
+    if not ca.benchmarking.has_softioc():
+        pytest.skip('no softIoc')
     name = 'Waveform and standard record IOC'
     db = {
         ('{}waveform'.format(prefix), 'waveform'):

--- a/caproto/tests/dbd.py
+++ b/caproto/tests/dbd.py
@@ -10,10 +10,8 @@ import pathlib
 
 import caproto
 import pytest
-import pyPDB.dbd.ast
-import pyPDB.dbd.yacc as _yacc
-import pyPDB.dbdlint as _dbdlint
 
+pyPDB = pytest.importorskip('pyPDB')
 
 TEST_ROOT = pathlib.Path(__file__).parent
 
@@ -72,6 +70,8 @@ class DbdFile:
             self._walk_menu(node)
 
     def _walk_field(self, node):
+        import pyPDB.dbd.ast
+
         field_name, field_type = node.args
 
         def block_value(block):
@@ -171,6 +171,9 @@ class DbdFile:
         parsed : list
             pyPDB parsed dbd nodes
         '''
+        import pyPDB.dbd.yacc as _yacc
+        import pyPDB.dbdlint as _dbdlint
+
         if hasattr(fn, 'read'):
             contents = fn.read()
         else:

--- a/caproto/tests/epics_test_utils.py
+++ b/caproto/tests/epics_test_utils.py
@@ -2,6 +2,8 @@
 Helper functions for dealing with EPICS base binaries (caget, caput, catest)
 '''
 
+import functools
+
 import os
 import sys
 import datetime
@@ -14,6 +16,26 @@ import curio.subprocess
 import trio
 
 import caproto as ca
+
+
+@functools.lru_cache(1)
+def has_caget():
+    try:
+        subprocess.run(['caget'])
+    except FileNotFoundError:
+        return False
+    else:
+        return True
+
+
+@functools.lru_cache(1)
+def has_caput():
+    try:
+        subprocess.run(['put'])
+    except FileNotFoundError:
+        return False
+    else:
+        return True
 
 
 async def run_epics_base_binary(backend, *args, max_attempts=3):

--- a/caproto/tests/test_pyepics_compat.py
+++ b/caproto/tests/test_pyepics_compat.py
@@ -947,6 +947,10 @@ def access_security_softioc(request, prefix, context):
     '''
 
     from .conftest import run_softioc, poll_readiness
+    from ..benchmarking.util import has_softioc
+
+    if not has_softioc():
+        pytest.skip("no softIoc")
 
     handler = run_softioc(request, db=access_rights_db,
                           access_rules_text=access_rights_asg_rules,

--- a/caproto/tests/test_record_compliance.py
+++ b/caproto/tests/test_record_compliance.py
@@ -36,8 +36,10 @@ type_equal = {
 }
 
 
-def test_record_compliance(request, prefix, record_type_name,
-                           record_type_to_fields):
+def test_record_compliance(request,
+                           prefix,
+                           record_type_name,
+                           record_type_to_fields):  # noqa
     fields = record_type_to_fields[record_type_name]
 
     # host a caproto record to test(you could also try this test on a real record).

--- a/caproto/tests/test_record_compliance.py
+++ b/caproto/tests/test_record_compliance.py
@@ -6,14 +6,12 @@
 # - all the enums of the .* can be read
 import time
 
-import epics
-from epics import ca
 import pytest
 
 from . import conftest
 # DBD parsing-related fixtures:
 from .dbd import record_type_to_fields, test_dbd_file  # noqa
-
+epics = pytest.importorskip('epics')
 
 # type equality between pyepics and "real" epics, **this is assumed **
 type_equal = {
@@ -89,7 +87,7 @@ def test_record_compliance(request, prefix, record_type_name,
 
             try:
                 # normally it is time_char so we add time_
-                ca.get(pv_temp.chid, as_string=('$' in field))
+                epics.ca.get(pv_temp.chid, as_string=('$' in field))
             except Exception as ex:
                 issues[field] = f"can't be read ({ex})"
 

--- a/caproto/tests/test_record_compliance.py
+++ b/caproto/tests/test_record_compliance.py
@@ -11,6 +11,8 @@ from epics import ca
 import pytest
 
 from . import conftest
+# DBD parsing-related fixtures:
+from .dbd import record_type_to_fields, test_dbd_file  # noqa
 
 
 # type equality between pyepics and "real" epics, **this is assumed **

--- a/caproto/tests/test_repeater.py
+++ b/caproto/tests/test_repeater.py
@@ -1,14 +1,16 @@
 import logging
+import pytest
 
 import curio
 
 import caproto as ca
-from .epics_test_utils import run_caget
+from .epics_test_utils import run_caget, has_caget
 
 
 REPEATER_PORT = 5065
 
 
+@pytest.mark.skipif(not has_caget(), reason='no caget')
 def test_sync_repeater(ioc):
     logging.getLogger('caproto').setLevel(logging.DEBUG)
     logging.basicConfig()

--- a/caproto/tests/test_server.py
+++ b/caproto/tests/test_server.py
@@ -40,6 +40,7 @@ caget_checks += [('char', ChannelType.CHAR),
                  ('str', ChannelType.CLASS_NAME),
                  ]
 
+
 @pytest.mark.skipif(not has_caget(), reason='No caget binary')
 @pytest.mark.parametrize('pv, dbr_type', caget_checks)
 def test_with_caget(backends, prefix, pvdb_from_server_example, server, pv,

--- a/caproto/tests/test_server.py
+++ b/caproto/tests/test_server.py
@@ -10,7 +10,7 @@ import pytest
 import caproto as ca
 
 from caproto import ChannelType
-from .epics_test_utils import (run_caget, run_caput)
+from .epics_test_utils import (run_caget, run_caput, has_caget, has_caput)
 from .conftest import array_types, run_example_ioc
 from caproto.sync.client import write, read, ErrorResponseReceived
 
@@ -40,7 +40,7 @@ caget_checks += [('char', ChannelType.CHAR),
                  ('str', ChannelType.CLASS_NAME),
                  ]
 
-
+@pytest.mark.skipif(not has_caget(), reason='No caget binary')
 @pytest.mark.parametrize('pv, dbr_type', caget_checks)
 def test_with_caget(backends, prefix, pvdb_from_server_example, server, pv,
                     dbr_type):
@@ -186,6 +186,7 @@ caput_checks = [('int', '1', 1),
                 ]
 
 
+@pytest.mark.skipif(not has_caput(), reason='No caput binary')
 @pytest.mark.parametrize('pv, put_value, check_value', caput_checks)
 def test_with_caput(backends, prefix, pvdb_from_server_example, server, pv,
                     put_value, check_value):
@@ -283,6 +284,7 @@ def test_empties_with_caproto_client(request, caproto_ioc):
     assert list(read(caproto_ioc.pvs['empty_float']).data) == []
 
 
+@pytest.mark.skipif(not has_caget(), reason='No caget binary')
 def test_empties_with_caget(request, caproto_ioc):
     async def test():
         info = await run_caget('asyncio', caproto_ioc.pvs['empty_string'])

--- a/caproto/tests/test_shark.py
+++ b/caproto/tests/test_shark.py
@@ -1,5 +1,7 @@
 from pathlib import Path
-from ..sync.shark import shark
+import pytest
+
+pytest.importorskip('dpkt')
 
 
 data_dir = Path(__file__).parent / 'data'
@@ -9,12 +11,15 @@ data_dir = Path(__file__).parent / 'data'
 
 
 def test_tcp_traffic():
+    from ..sync.shark import shark
+
     # tcpdump -U -w example_tcp_data.pcap port <TCP PORT>
     with open(data_dir / 'example_tcp_data.pcap', 'rb') as file:
         list(shark(file))
 
 
 def test_udp_traffic():
+    from ..sync.shark import shark
     # tcpdump -U -w example_udp_data.pcap port 5064
     with open(data_dir / 'example_udp_data.pcap', 'rb') as file:
         list(shark(file))


### PR DESCRIPTION
Make the tests more forgiving of missing dependencies.

Without pyepics or epics_base you can still test that caproto can talk to its self.  Early on I think we needed the safety blanket of always testing against the reference, but at this point I think we can, at least locally, bootstrap the testing.