### PR TITLE
CI/DOC: do not update index.html in NSLS-II.github.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,7 @@ script:
         DEPLOY_DIR="caproto/${TRAVIS_TAG:=master}"
         doctr deploy --command=doctr-versions-menu --build-tags --deploy-repo caproto/caproto.github.io --deploy-branch-name master ${DEPLOY_DIR}
 
-        # Avoid updating /index.html in the caproto/caproto.github.io repo.
+        # Avoid updating /index.html in the NSLS-II/NSLS-II.github.io repo.
         # See https://goerz.github.io/doctr_versions_menu/v0.3.0/command.html#customizing-index-html
         # for details.
         export DOCTR_VERSIONS_MENU_WRITE_INDEX_HTML=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,10 +104,16 @@ script:
   # Upload the docs to gh-pages.
   - |
     if [[ $PUBLISH_DOCS && ! -z "$DOCTR_DEPLOY_ENCRYPTION_KEY_NSLS_II_NSLS_II_GITHUB_IO" ]]; then
-       doctr deploy --deploy-repo NSLS-II/NSLS-II.github.io --deploy-branch-name master caproto
+        doctr deploy --deploy-repo NSLS-II/NSLS-II.github.io --deploy-branch-name master caproto
 
-       # A fix for doctr-versions-menu:
-       pip install pyparsing --upgrade
-       DEPLOY_DIR="caproto/${TRAVIS_TAG:=master}"
-       doctr deploy --command=doctr-versions-menu --build-tags --deploy-repo caproto/caproto.github.io --deploy-branch-name master ${DEPLOY_DIR}
+        # A fix for doctr-versions-menu:
+        pip install pyparsing --upgrade
+        DEPLOY_DIR="caproto/${TRAVIS_TAG:=master}"
+
+        # Avoid updating /index.html in the caproto/caproto.github.io repo.
+        # See https://goerz.github.io/doctr_versions_menu/v0.3.0/command.html#customizing-index-html
+        # for details.
+        export DOCTR_VERSIONS_MENU_WRITE_INDEX_HTML=false
+
+        doctr deploy --command=doctr-versions-menu --build-tags --deploy-repo caproto/caproto.github.io --deploy-branch-name master ${DEPLOY_DIR}
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,16 +104,15 @@ script:
   # Upload the docs to gh-pages.
   - |
     if [[ $PUBLISH_DOCS && ! -z "$DOCTR_DEPLOY_ENCRYPTION_KEY_NSLS_II_NSLS_II_GITHUB_IO" ]]; then
-        doctr deploy --deploy-repo NSLS-II/NSLS-II.github.io --deploy-branch-name master caproto
 
         # A fix for doctr-versions-menu:
         pip install pyparsing --upgrade
         DEPLOY_DIR="caproto/${TRAVIS_TAG:=master}"
+        doctr deploy --command=doctr-versions-menu --build-tags --deploy-repo caproto/caproto.github.io --deploy-branch-name master ${DEPLOY_DIR}
 
         # Avoid updating /index.html in the caproto/caproto.github.io repo.
         # See https://goerz.github.io/doctr_versions_menu/v0.3.0/command.html#customizing-index-html
         # for details.
         export DOCTR_VERSIONS_MENU_WRITE_INDEX_HTML=false
-
-        doctr deploy --command=doctr-versions-menu --build-tags --deploy-repo caproto/caproto.github.io --deploy-branch-name master ${DEPLOY_DIR}
+        doctr deploy --command=doctr-versions-menu --build-tags --deploy-repo NSLS-II/NSLS-II.github.io --deploy-branch-name master ${DEPLOY_DIR}
     fi


### PR DESCRIPTION
This PR fixed overwritten `index.html` in https://github.com/caproto/caproto.github.io. I'll leave it to @klauer to fix the file itself in the docs repo.

xref https://github.com/bluesky/hklpy/pull/39#issuecomment-700949731.