### PR TITLE
[PVA] ENH: server put/monitor/rpc and high-level `pvaproperty` support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.2.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -21,7 +21,7 @@ repos:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.5.3
+    rev: 5.6.1
     hooks:
     -   id: isort
 

--- a/caproto/pva/_fields.py
+++ b/caproto/pva/_fields.py
@@ -440,12 +440,29 @@ class BitSet(set, CoreSerializable):
         """
         Add the given offset to this bitset, returning a new bitset.
         """
-        if 0 in self or offset in self:
+        if 0 in self:
+            # TODO: This isn't true in all cases, depends on what the caller is
+            # after
             return BitSet({0})
 
         return BitSet({idx + offset for idx in self
                        if idx + offset >= 0}
                       )
+
+    def __and__(self, other):
+        """And/intersection with other set, with special handling for {0}."""
+        if 0 in self:
+            return BitSet(other)
+        if 0 in other:
+            return self
+        return type(self)(super().__and__(other))
+
+    def __or__(self, other):
+        """Or/Union with other set, including special handling for {0}."""
+        result = super().__or__(other)
+        if 0 in result:
+            return type(self)({0})
+        return result
 
     def serialize(self, endian: Endian) -> List[bytes]:
         if not len(self):

--- a/caproto/pva/_utils.py
+++ b/caproto/pva/_utils.py
@@ -51,7 +51,9 @@ class ChannelRequest(_SimpleReprEnum):
     INIT = enum.auto()
     READY = enum.auto()
     IN_PROGRESS = enum.auto()
-    # also: DISCONNECTED, DESTROYED
+    DESTROY_AFTER = enum.auto()
+    DISCONNECTED = enum.auto()
+    DESTROYED = enum.auto()
 
 
 CONNECTED = ConnectionState.CONNECTED

--- a/caproto/pva/commandline/get.py
+++ b/caproto/pva/commandline/get.py
@@ -44,17 +44,17 @@ def main():
 
     try:
         for pv_name in args.pv_names:
-            response = read(pv_name=pv_name, pvrequest=args.pvrequest,
-                            verbose=args.verbose, timeout=args.timeout)
+            response, data = read(
+                pv_name=pv_name, pvrequest=args.pvrequest,
+                verbose=args.verbose, timeout=args.timeout
+            )
 
-            dcls = response.dataclass_instance
             if args.terse:
-                dcls = getattr(dcls, 'value', dcls)
-                print(dcls)
+                print(getattr(data, 'value', data))
             else:
-                print(dcls)
-                # TODO: make an option, somehow?
-                # pprint.pprint(dataclasses.asdict(dcls))
+                if (args.verbose or 0) > 1:
+                    print(response)
+                print(data)
 
     except BaseException as exc:
         if args.verbose:

--- a/caproto/pva/commandline/put.py
+++ b/caproto/pva/commandline/put.py
@@ -83,7 +83,6 @@ def main():
 
         print('Old:', initial)
 
-        final = final.dataclass_instance
         if args.terse:
             final = getattr(final, 'value', final)
         print('New:', final)

--- a/caproto/pva/ioc_examples/basic.py
+++ b/caproto/pva/ioc_examples/basic.py
@@ -44,44 +44,60 @@ pvdb = {
 }
 
 
-class AuthenticationError(RuntimeError):
-    ...
+class BasicDataWrapper(pva.DataWrapperBase):
+    """
+    A basic wrapper for dataclasses to support caproto-pva's server API.
 
+    Parameters
+    ----------
+    data : PvaStruct
+        The dataclass holding the data.
 
-class DataWrapper:
-    def __init__(self, pvname, data):
-        self.pvname = pvname
-        self.data = data
+    pvname : str
+        The associated name of the data.
+    """
 
-    def authenticate(self, authorization):
+    async def authorize(self,
+                        operation: pva.AuthOperation, *,
+                        authorization,
+                        request=None):
+        """
+        Authenticate `operation`, given `authorization` information.
+
+        In the event of successful authorization, a dataclass defining the data
+        contained here must be returned.
+
+        In the event of a failed authorization, `AuthenticationError` or
+        similar should be raised.
+
+        Returns
+        -------
+        data
+
+        Raises
+        ------
+        AuthenticationError
+        """
+        # TODO: add functionality here
         if authorization['method'] == 'ca':
             # user = authorization['data'].user
             # if user != 'klauer':
             #     raise AuthenticationError(f'No, {user}.')
-            return
-
-        if authorization['method'] in {'anonymous', ''}:
+            ...
+        elif authorization['method'] in {'anonymous', ''}:
             ...
 
-    async def auth_write(self, request, *, authorization):
-        self.authenticate(authorization)
         return self.data
-
-    async def auth_read_interface(self, *, authorization):
-        self.authenticate(authorization)
-        return self.data
-
-    async def auth_read(self, request, *, authorization):
-        self.authenticate(authorization)
-        return await self.read(request)
 
     async def read(self, request):
-        # self.data.value += 1
-        return self.data
+        # TODO: add functionality here
+        # print('Saw read', self.name, request)
+        return await super().read(request)
 
-    async def write(self, update):
-        print('saw a write!', update)
-        pva.fill_dataclass(self.data, update.data)
+    async def write(self, update: pva.DataWithBitSet):
+        # TODO: add functionality here
+        # print('Saw write', self.name, update)
+        return await super().write(update)
 
 
 def main():
@@ -92,7 +108,7 @@ def main():
 
     prefix = ioc_options['prefix']
     prefixed_pvdb = {
-        prefix + key: DataWrapper(prefix + key, value)
+        prefix + key: BasicDataWrapper(name=prefix + key, data=value)
         for key, value in pvdb.items()
     }
     warnings.warn("The parsed IOC options are ignored by this IOC for now.")

--- a/caproto/pva/ioc_examples/group.py
+++ b/caproto/pva/ioc_examples/group.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+A basic caproto-pva test server.
+
+This is very much preliminary API.
+"""
+import typing
+
+import caproto.pva as pva
+from caproto.pva.server import ioc_arg_parser, run
+
+
+@pva.pva_dataclass
+class MyData:
+    value: int
+    info: str
+
+
+@pva.pva_dataclass
+class NestedData:
+    my_data: MyData
+    value: float
+
+
+class MyIOC(pva.PVAGroup):
+    test = pva.pvaproperty(value=MyData(value=5, info='a string'))
+    test2 = pva.pvaproperty(value=MyData(value=6, info='a different string'))
+    test3 = pva.pvaproperty(value=NestedData)
+    long_write = pva.pvaproperty(value=MyData())
+    rpc = pva.pvaproperty(value=MyData())
+
+    @test.putter  # (accepts=['value'])   (potential API?)
+    async def test(self, instance, update: pva.WriteUpdate):
+        """
+        Put handler.
+
+        Default handling: `update.accept()` (take everything)
+
+        The following also work::
+
+            1. update.accept('value', 'info')
+            2. update.reject('info')
+            3. if 'value' in update:
+                  instance.value = update.instance.value
+        """
+        ...
+
+    @test.startup
+    async def test(self, instance, async_lib):
+        self.async_lib = async_lib
+
+        while True:
+            async with self.test as test:
+                test.value = test.value + 1
+                test.info = f'testing {test.value}'
+
+            await async_lib.library.sleep(0.5)
+
+    @test.shutdown
+    async def test(self, instance, async_lib):
+        print('shutdown')
+
+    @test2.startup
+    async def test2(self, instance, async_lib):
+        while True:
+            async with self.test2 as test2, self.test3 as test3:
+                # Swap values
+                test2.value, test3.value = int(test3.value), float(test2.value)
+
+            await async_lib.library.sleep(2.0)
+
+    @rpc.call
+    async def rpc(self, instance, data):
+        # Some awf... nice normative type stuff comes through here (NTURI):
+        print('RPC call data is', data)
+        print('Scheme:', data.scheme)
+        print('Query:', data.query)
+        print('Path:', data.path)
+
+        # Echo back the query value, if available:
+        query = data.query
+        value = int(getattr(query, 'value', '1234'))
+        return MyData(value=value)
+
+    @long_write.putter
+    async def long_write(self, instance, update: pva.WriteUpdate):
+        await self.async_lib.library.sleep(10)
+
+
+class ServerRPC(pva.PVAGroup):
+    """
+    Helper group for supporting ``pvlist`` and other introspection tools.
+    """
+
+    @pva.pva_dataclass
+    class HelpInfo:
+        # TODO: technically epics:nt/NTScalar
+        value: str
+
+    @pva.pva_dataclass
+    class ChannelListing:
+        # TODO: technically epics:nt/NTScalarArray
+        value: typing.List[str]
+
+    @pva.pva_dataclass
+    class ServerInfo:
+        # responseHandlers.cpp
+        version: str
+        implLang: str
+        host: str
+        process: str
+        startTime: str
+
+    # This is the special
+    server = pva.pvaproperty(value=ServerInfo(), name='server')
+
+    def __init__(self, *args, server_instance, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.server_instance = server_instance
+
+    @server.call
+    async def server(self, instance, data):
+        # Some awf... nice normative type stuff comes through here (NTURI):
+        self.log.debug('RPC call data is: %s', data)
+        self.log.debug('Scheme: %s', data.scheme)
+        self.log.debug('Query: %s', data.query)
+        self.log.debug('Path: %s', data.path)
+
+        # Echo back the query value, if available:
+        try:
+            operation = data.query.op
+        except AttributeError:
+            raise ValueError('Malformed request (expected .query.op)')
+
+        if operation == 'help':
+            return self.HelpInfo(value='Me too')
+
+        if operation == 'info':
+            return self.ServerInfo()
+
+        if operation == 'channels':
+            pvnames = list(sorted(self.server_instance.pvdb))
+            pvnames.remove(self.server.name)
+            return self.ChannelListing(value=pvnames)
+
+
+def main():
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix='caproto:pva:',
+        desc='A basic caproto-pva test server.'
+    )
+
+    ioc = MyIOC(**ioc_options)
+    server_info = ServerRPC(prefix='', server_instance=ioc)
+    ioc.pvdb.update(server_info.pvdb)
+    run(ioc.pvdb, **run_options)
+
+
+if __name__ == '__main__':
+    main()

--- a/caproto/pva/server/__init__.py
+++ b/caproto/pva/server/__init__.py
@@ -1,2 +1,3 @@
 from .commandline import *  # noqa
 from .common import *  # noqa
+from .magic import *  # noqa

--- a/caproto/pva/server/commandline.py
+++ b/caproto/pva/server/commandline.py
@@ -102,12 +102,19 @@ def template_arg_parser(*, desc, default_prefix, argv=None, macros=None,
         else:
             ca._log._set_handler_with_logger(logger_name='caproto.pva.ctx', level='INFO')
 
-        return ({'prefix': args.prefix,
-                 'macros': {key: getattr(args, key) for key in macros}},
+        return (
+            # IOC options
+            dict(prefix=args.prefix,
+                 macros={key: getattr(args, key) for key in macros},
+                 ),
 
-                {'module_name': f'caproto.pva.{args.async_lib}.server',
-                 'log_pv_names': args.list_pvs,
-                 'interfaces': args.interfaces})
+            # Run options
+            dict(
+                module_name=f'caproto.pva.{args.async_lib}.server',
+                log_pv_names=args.list_pvs,
+                interfaces=args.interfaces,
+            ),
+        )
 
     return parser, split_args
 

--- a/caproto/pva/server/magic.py
+++ b/caproto/pva/server/magic.py
@@ -1,0 +1,734 @@
+"""
+PVAGroup-based server code. It's a big magical - maybe not in a good way...
+"""
+import contextlib
+import copy
+import functools
+import inspect
+import logging
+import types
+from contextvars import ContextVar
+from typing import Dict, Optional
+
+from ... import pva
+from .._dataclass import get_pv_structure
+from .common import AuthOperation, DataWrapperBase
+
+module_logger = logging.getLogger(__name__)
+
+
+class AuthenticationError(RuntimeError):
+    ...
+
+
+class DatabaseDefinitionError(RuntimeError):
+    ...
+
+
+class SignatureDefinitionError(DatabaseDefinitionError):
+    ...
+
+
+def expand_macros(pv, macros):
+    'Expand a PV name with Python {format-style} macros'
+    return pv.format(**macros)
+
+
+def verify_getter(attr: str, get: callable) -> callable:
+    """Verify a getter's call signature."""
+    if not inspect.iscoroutinefunction(get):
+        raise SignatureDefinitionError('required async def get')
+
+    sig = inspect.signature(get)
+    try:
+        sig.bind('group', 'instance', 'request')
+    except Exception:
+        raise SignatureDefinitionError(
+            f'{attr}: Invalid signature for getter {get}: {sig}'
+        )
+    return get
+
+
+def verify_putter(attr: str,
+                  put: callable,
+                  *,
+                  read_only: bool = False) -> callable:
+    """Verify a putter's call signature."""
+    if not inspect.iscoroutinefunction(put):
+        raise SignatureDefinitionError('required async def put')
+
+    if read_only:
+        raise SignatureDefinitionError(
+            'Read-only signal cannot have putter'
+        )
+
+    sig = inspect.signature(put)
+    try:
+        sig.bind('group', 'instance', 'write_update')
+    except Exception:
+        raise SignatureDefinitionError(
+            f'{attr}: Invalid signature for putter {put}: {sig}'
+        )
+    return put
+
+
+def verify_rpc_call(attr: str,
+                    call: callable,
+                    *,
+                    read_only: bool = False) -> callable:
+    """Verify an RPC call handler's signature."""
+    if not inspect.iscoroutinefunction(call):
+        raise SignatureDefinitionError('required async def call')
+
+    if read_only:
+        raise SignatureDefinitionError(
+            'Read-only signal cannot have an RPC call'
+        )
+
+    sig = inspect.signature(call)
+    try:
+        sig.bind('group', 'instance', 'data')
+    except Exception:
+        raise SignatureDefinitionError(
+            f'{attr}: Invalid signature for RPC call {call}: {sig}'
+        )
+    return call
+
+
+def verify_startup(attr: str, method: callable) -> callable:
+    """Verify a startup method's call signature."""
+    if not inspect.iscoroutinefunction(method):
+        raise SignatureDefinitionError('required async def method')
+
+    sig = inspect.signature(method)
+    try:
+        sig.bind('group', 'instance', 'async_lib')
+    except Exception:
+        raise SignatureDefinitionError(
+            f'{attr}: Invalid signature for startup {method}: {sig}'
+        )
+    return method
+
+
+def verify_shutdown(attr: str, method: callable) -> callable:
+    """Verify a shutdown method's call signature."""
+    if not inspect.iscoroutinefunction(method):
+        raise SignatureDefinitionError('required async def method')
+
+    sig = inspect.signature(method)
+    try:
+        sig.bind('group', 'instance', 'async_lib')
+    except Exception:
+        raise SignatureDefinitionError(
+            f'{attr}: Invalid signature for shutdown {method}: {sig}'
+        )
+    return method
+
+
+class DataclassOverlayInstance:
+    _reserved = (
+        '_struct_', '_instance_', '_children_', '_root_', '_changes_',
+        '_prefix_', '_owner_',
+    )
+    _changes_ = None
+    _children_ = None
+    _instance_ = None
+    _prefix_ = None
+    _root_ = None
+    _struct_ = None
+    _owner_ = None
+
+    def __init__(self, instance, *, attr=None, parent=None,
+                 owner=None, changes=None):
+        self._struct_ = get_pv_structure(instance)
+        self._instance_ = instance
+        self._children_ = self._struct_.children
+        self._owner_ = owner
+        self._changes_ = changes if changes is not None else {}
+
+        if parent is not None:
+            self._root_ = parent._root_ or parent
+            self._prefix_ = parent._prefix_ + [attr]
+        else:
+            self._root_ = self
+            self._prefix_ = []
+
+    def __repr__(self):
+        return repr(self._instance_)
+
+    def __dir__(self):
+        return dir(self._instance_)
+
+    def __getattr__(self, attr):
+        try:
+            return self._changes_[attr]
+        except KeyError:
+            ...
+
+        value = getattr(self._instance_, attr)
+        if hasattr(value, '_pva_struct_'):
+            if attr not in self._changes_:
+                self._changes_[attr] = {}
+            sub_overlay = DataclassOverlayInstance(
+                value, attr=attr, parent=self, owner=self._owner_,
+                changes=self._changes_[attr],
+            )
+            self.__dict__[attr] = sub_overlay
+            return sub_overlay
+
+        return value
+
+    def __setattr__(self, attr, value):
+        if attr in self._reserved:
+            # For initialization-related things
+            self.__dict__[attr] = value
+            return
+
+        if attr in self._children_:
+            self._changes_[attr] = value
+        else:
+            setattr(self._instance_, attr, value)
+
+    def __delattr__(self, attr):
+        if attr in self._reserved:
+            return
+
+        # with self._change_lock_:
+            # TODO fix rejection of entire sub-structure
+            # this breaks it entirely
+        assert not isinstance(self._changes_.pop(attr, None), dict)
+
+
+class WriteUpdate:
+    def __init__(self,
+                 owner,
+                 overlay: DataclassOverlayInstance,
+                 changes: dict):
+        self._cls = type(owner.data)
+        self._owner = owner
+        self.instance = overlay
+        self._changes = changes  # overlay._changes_
+
+    def __repr__(self):
+        return (
+            f'<WriteUpdate for {self._cls} changes={self._changes}>'
+        )
+
+    @property
+    def changes(self):
+        # TODO: deep copy would be appropriate; or just trust the caller :(
+        return dict(self._changes)
+
+    def __contains__(self, attr):
+        changes = self._changes
+        try:
+            for part in attr.split('.'):
+                changes = changes[part]
+        except KeyError:
+            return False
+
+        return True
+
+    def accept(self, *keys):
+        """
+        Accept only the provided keys.
+        """
+        if not keys:
+            # accept() -> reject
+            self.reject()
+            return
+
+        def add_accepted(changes, accepted, parts):
+            part, *parts = parts
+            if part not in changes:
+                # warn? error?
+                return
+
+            if len(parts):
+                if part not in accepted:
+                    accepted[part] = {}
+                return add_accepted(changes[part], accepted[part], parts)
+            accepted[part] = changes[part]
+
+        accepted_changes = {}
+        for key in keys:
+            add_accepted(self._changes, accepted_changes, key.split('.'))
+
+        # TODO: this is pretty inefficient and bad
+        # TODO: accessing the overlay after this can fail in nested structs
+        self.instance._changes_ = accepted_changes
+        self._changes = accepted_changes
+
+    def reject(self, *keys):
+        """
+        Reject the provided keys, accepting the remainder.
+        """
+        if not keys:
+            # reject() -> reject all
+            self._changes.clear()
+            self.instance._changes_ = self._changes
+            return
+
+        def remove_rejected(changes, parts):
+            part, *parts = parts
+            if part not in changes:
+                # warn? error?
+                return
+
+            if len(parts):
+                return remove_rejected(changes[part], parts)
+
+            changes.pop(part, None)
+
+        for key in keys:
+            remove_rejected(self._changes, key.split('.'))
+
+        self.instance._changes_ = self._changes
+
+
+def _method_or_fallback(group: 'PVAGroup',
+                        user_specified_method: Optional[callable],
+                        fallback: Optional[callable]):
+    if user_specified_method is not None:
+        return types.MethodType(user_specified_method, group)
+    return fallback
+
+
+# These context variables are pretty magical in their own right:
+#   * The following context variable holds a DataclassOverlayInstance in each
+#     "context"
+#   * The context is defined below in `GroupDataWrapper`
+#   * When one uses `async with GroupDataWrapper()`, it calls `__aenter__` and
+#     generates a new context and context variable
+#   * When that context exits, `__aexit__` is called, and `GroupDataWrapper`
+#     can find the correct overlay that relates to the given context by way of
+#     retrieving the context variable.
+# More here: https://docs.python.org/3/library/contextvars.html
+_overlays_context_var = ContextVar('overlays')
+_overlays_context_var: ContextVar[Dict[str, DataclassOverlayInstance]]
+
+
+class GroupDataWrapper(DataWrapperBase):
+    """
+    A base class to wrap dataclasses and support caproto-pva's server API.
+
+    Two easy methods are provided for writing multiple changes to a data
+    structure in one block.
+
+    .. code::
+
+        async with group.prop as prop:
+            prop.attr1 = 1
+            prop.attr2 = 2
+
+    .. code::
+
+        async with group.prop(changes={'attr1': 1}) as prop:
+            prop.attr2 = 2
+
+    When the context manager exits, the values written will be committed
+    and sent out over pvAccess.
+
+    Parameters
+    ----------
+    name : str
+        The associated name of the data.
+
+    data : PvaStruct
+        The dataclass holding the data.
+
+    group : PVAGroup
+        The group associated with the data.
+
+    prop : pvaproperty
+        The group's property which help in binding user hooks.
+    """
+
+    write_update_class = WriteUpdate
+
+    def __init__(self,
+                 name: str,
+                 data,
+                 *,
+                 group: 'PVAGroup',
+                 prop: 'pvaproperty',
+                 ):
+        super().__init__(name=name, data=data)
+        self.prop = prop
+
+        self.user_read = _method_or_fallback(
+            group, prop._get, fallback=group.group_read
+        )
+
+        self.user_write = _method_or_fallback(
+            group, prop._put, fallback=group.group_write
+        )
+
+        self.user_call = _method_or_fallback(group, prop._call, fallback=None)
+
+        if prop._startup is not None:
+            self.server_startup = functools.partial(
+                types.MethodType(prop._startup, group),
+                self,
+            )
+
+        if prop._shutdown is not None:
+            self.server_shutdown = functools.partial(
+                types.MethodType(prop._shutdown, group),
+                self,
+            )
+
+    @contextlib.asynccontextmanager
+    async def __call__(self, *, changes=None):
+        overlay = DataclassOverlayInstance(self.data, owner=self,
+                                           changes=changes)
+        yield overlay
+        await self.commit(overlay._changes_)
+
+    async def __aenter__(self):
+        # For more information on this, see `_overlays_context_var` above.
+        overlays = _overlays_context_var.get({})
+        _overlays_context_var.set(overlays)
+
+        # Nesting of these blocks is not yet supported
+        overlay = DataclassOverlayInstance(self.data, owner=self)
+        overlays[self.name] = overlay
+        return overlay
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        overlays = _overlays_context_var.get()
+        overlay: DataclassOverlayInstance = overlays.pop(self.name)
+        if exc_type is None:
+            await self.commit(overlay._changes_)
+
+    async def authorize(self,
+                        operation: AuthOperation, *,
+                        authorization,
+                        request=None):
+        """
+        Authenticate `operation`, given `authorization` information.
+
+        In the event of successful authorization, a dataclass defining the data
+        contained here must be returned.
+
+        In the event of a failed authorization, `AuthenticationError` or
+        similar should be raised.
+
+        Returns
+        -------
+        data
+
+        Raises
+        ------
+        AuthenticationError
+        """
+        if authorization['method'] == 'ca':
+            # user = authorization['data'].user
+            # if user != 'klauer':
+            #     raise AuthenticationError(f'No, {user}.')
+            ...
+        elif authorization['method'] in {'anonymous', ''}:
+            ...
+
+        return self.data
+
+    async def read(self, request):
+        """A read request."""
+        async with self() as overlay:
+            await self.user_read(overlay, request)
+        return self.data
+
+    async def write(self, update: pva.DataWithBitSet):
+        """A write request."""
+        async with self(changes=update.data) as overlay:
+            write_update = self.write_update_class(
+                owner=self, overlay=overlay, changes=update.data)
+            await self.user_write(overlay, write_update)
+
+    async def call(self, request: pva.PVRequest, data: pva.FieldDescAndData):
+        """An rpc-call request."""
+        async with self() as overlay:
+            # TODO: update state or not?
+            # is_nturi = type(data).__name__.startswith('epics:nt/NTURI:')
+            return await self.user_call(overlay, data.data)
+
+
+class pvaproperty:
+    """
+    A property-like descriptor for specifying a PV in a `PVGroup`.
+
+    Parameters
+    ----------
+    get : async callable, optional
+        Called when PV is read through channel access
+
+    put : async callable, optional
+        Called when PV is written to through channel access
+
+    startup : async callable, optional
+        Called at start of server; a hook for initialization and background
+        processing
+
+    shutdown : async callable, optional
+        Called at shutdown of server; a hook for cleanup
+
+    value : pva dataclass or instance
+        The initial value - either an instantiated pva dataclass.
+
+    name : str, optional
+        The PV name (defaults to the attribute name of the pvproperty)
+
+    alarm_group : str, optional
+        The alarm group the PV should be attached to
+
+    read_only : bool, optional
+        Read-only PV over channel access
+
+    doc : str, optional
+        Docstring associated with the property
+
+    **cls_kwargs :
+        Keyword arguments for the dataclass.
+
+    Attributes
+    ----------
+    attr : str
+        The attribute name of the pvproperty.
+    """
+
+    def __init__(self,
+                 get=None, put=None, startup=None, shutdown=None, call=None,
+                 *,
+                 value, name=None, alarm_group=None, doc=None, read_only=None,
+                 **cls_kwargs):
+        self.attr = None  # to be set later
+
+        if doc is None and get is not None:
+            doc = get.__doc__
+
+        self.__doc__ = doc
+        self._get = get
+        self._put = put
+        self._startup = startup
+        self._shutdown = shutdown
+        self._call = call
+        self._name = name
+        self._value = value
+        self._alarm_group = alarm_group
+        self._read_only = read_only
+        self._cls_kwargs = cls_kwargs
+
+    def __get__(self, instance, owner):
+        """Descriptor method: get the pvproperty instance from a group."""
+        if instance is None:
+            # `class.pvproperty`
+            return self
+
+        return instance.attr_pvdb[self.attr]
+
+    def __set__(self, instance, value):
+        """Descriptor method: set the pvproperty instance in a group."""
+        instance.attr_pvdb[self.attr] = value
+
+    def __delete__(self, instance):
+        """Descriptor method: delete the pvproperty instance from a group."""
+        del instance.attr_pvdb[self.attr]
+
+    def __set_name__(self, owner, name):
+        """Descriptor method: auto-called to set the attribute name."""
+        self.attr = name
+        if self._name is None:
+            self._name = name
+
+    @property
+    def name(self):
+        """The pvname suffix."""
+        return self._name
+
+    @property
+    def read_only(self):
+        """Is the pvaproperty read-only?"""
+        return self._read_only
+
+    @property
+    def cls_kwargs(self):
+        """Keyword arguments to use on creation of the value instance."""
+        return dict(self._cls_kwargs)
+
+    @property
+    def value(self):
+        """The default value."""
+        return self._value
+
+    def getter(self, get):
+        """
+        Usually used as a decorator, this sets the ``getter`` method.
+        """
+        self._get = verify_getter(self.attr, get=get)
+        return self
+
+    def putter(self, put):
+        """
+        Usually used as a decorator, this sets the ``putter`` method.
+        """
+        self._put = verify_putter(self.attr, put=put,
+                                  read_only=self._read_only)
+        return self
+
+    def startup(self, startup):
+        """
+        Usually used as a decorator, this sets ``startup`` method.
+        """
+        self._startup = verify_startup(self.attr, startup)
+        return self
+
+    def shutdown(self, shutdown):
+        """
+        Usually used as a decorator, this sets ``shutdown`` method.
+        """
+        self._shutdown = verify_shutdown(self.attr, shutdown)
+        return self
+
+    def call(self, call):
+        """
+        Usually used as a decorator, this sets the RPC ``call`` method.
+        """
+        self._call = verify_rpc_call(
+            self.attr, call=call, read_only=self._read_only)
+        return self
+
+    def __call__(self, get, put=None, startup=None, shutdown=None):
+        # Handles use case: pvproperty(**info)(getter, putter, startup).
+        raise NotImplementedError('TODO')
+
+
+class PVAGroupMeta(type):
+    'Metaclass that finds all pvaproperties'
+    @staticmethod
+    def find_pvaproperties(dct):
+        for attr, value in dct.items():
+            if attr.startswith('_'):
+                continue
+
+            if isinstance(value, pvaproperty):
+                yield attr, value
+
+    def __new__(metacls, name, bases, dct):
+        dct['_pvs_'] = pvs = {}
+
+        cls = super().__new__(metacls, name, bases, dct)
+
+        # Propagate any PVs from base classes
+        for base in bases:
+            if hasattr(base, '_pvs_'):
+                dct['_pvs_'].update(**base._pvs_)
+
+        for attr, prop in metacls.find_pvaproperties(dct):
+            module_logger.debug(
+                'class %s pvaproperty attr %s: %r', name, attr, prop
+            )
+            pvs[attr] = prop
+
+        # Ensure group_read/group_write are valid before proceeding:
+        verify_getter('group_read', cls.group_read)
+        verify_putter('group_write', cls.group_write, read_only=False)
+        return cls
+
+
+class PVAGroup(metaclass=PVAGroupMeta):
+    """
+    Class which groups a set of PVs for a high-level caproto server
+
+    Parameters
+    ----------
+    prefix : str
+        Prefix for all PVs in the group.
+
+    macros : dict, optional
+        Dictionary of macro name to value.
+
+    parent : PVGroup, optional
+        Parent PVGroup.
+
+    name : str, optional
+        Name for the group, defaults to the class name.
+    """
+
+    _wrapper_class_ = GroupDataWrapper
+
+    type_map = {
+        # int: NormativeInt,
+    }
+
+    # Auto-generate the read-only class specification:
+    type_map_read_only = {
+        dtype: globals()[f'{cls.__name__}RO']
+        for dtype, cls in type_map.items()
+    }
+
+    def __init__(self, prefix, *, macros=None, parent=None, name=None):
+        self.parent = parent
+        self.macros = macros if macros is not None else {}
+        self.prefix = prefix  # expand_macros(prefix, self.macros)
+        self.pvdb = {}
+        self.attr_pvdb = {}
+        self.attr_to_pvname = {}
+        self.groups = {}
+
+        # Create logger name from parent or from module class
+        self.name = (self.__class__.__name__
+                     if name is None
+                     else name)
+        log_name = type(self).__name__
+        if self.parent is not None:
+            base = self.parent.log.name
+            parent_log_prefix = f'{base}.'
+            if log_name.startswith(parent_log_prefix):
+                log_name = log_name[parent_log_prefix:]
+        else:
+            base = self.__class__.__module__
+
+        # Instantiate the logger
+        self.log = logging.getLogger(f'{base}.{log_name}')
+        self._create_pvdb()
+
+    def _instantiate_value_from_pvproperty(self, attr, prop):
+        if pva.is_pva_dataclass_instance(prop.value):
+            return copy.deepcopy(prop.value)
+
+        return prop.value(**prop.cls_kwargs)
+
+    def _create_pv(self, attr: str, prop: pvaproperty):
+        value = self._instantiate_value_from_pvproperty(attr, prop)
+        pvname = expand_macros(self.prefix + prop.name, self.macros)
+        wrapped_data = self._wrapper_class_(
+            name=pvname, data=value, group=self, prop=prop)
+
+        previous_definition = self.pvdb.get(pvname, None)
+        if previous_definition is not None:
+            raise DatabaseDefinitionError(
+                f'{pvname} defined multiple times: now in attr: {attr} '
+                f'originally: {previous_definition}'
+            )
+
+        # full pvname -> wrapped data instance
+        self.pvdb[pvname] = wrapped_data
+
+        # attribute -> PV instance mapping for quick access by pvaproperty
+        self.attr_pvdb[attr] = wrapped_data
+
+        # and a convenient map of attr -> pvname
+        self.attr_to_pvname[attr] = pvname
+        return wrapped_data
+
+    def _create_pvdb(self):
+        'Create the PV database for all pvaproperties'
+        for attr, prop in self._pvs_.items():
+            self._create_pv(attr, prop)
+
+    async def group_read(self, instance, request):
+        'Generic read called for channels without `get` defined'
+
+    async def group_write(self, instance, update: WriteUpdate):
+        'Generic write called for channels without `put` defined'
+        self.log.debug('group_write: %s = %s', instance, update)

--- a/caproto/tests/test_pva.py
+++ b/caproto/tests/test_pva.py
@@ -441,3 +441,9 @@ def test_broadcaster_messages_smoke():
     request.serialize()
     response = bcast.search_response(pv_to_cid={'abc': 5, 'def': 6})
     response.serialize()
+
+
+def test_qos_flags_encode():
+    assert pva.QOSFlags.decode(
+        pva.QOSFlags.encode(priority=0, flags=pva.QOSFlags.low_latency)
+    ) == (0, pva.QOSFlags.low_latency)

--- a/caproto/tests/test_pva_circuit.py
+++ b/caproto/tests/test_pva_circuit.py
@@ -1,9 +1,11 @@
-import dataclasses
 import logging
 
 import pytest
 
+pytest.importorskip('dataclasses')
 pytest.importorskip('caproto.pva')
+
+import dataclasses  # isort: noqa
 
 from caproto import pva
 from caproto.pva import BitSet


### PR DESCRIPTION
I've been puzzling over how to handle serving dataclass information from the server in a not-so-terrible way for a long time.  

This PR is a first pass at that, paving the way for better support in the future. It's roughly the past month of updates, condensed to remove all of my "wip" "temp" "fix fix fix"-style commits and not pollute the caproto repo history.

Changes
-------

* Get, put, monitor, and RPC support in the server
   - No pipelining monitors just yet
   - Writes can be canceled by client request
* Split data wrapper utilities into low- and high-level wrappers
    - Low level wrapper reasonably easy to build on; has no ties to
      `pvaproperty` et al
    - Added user-friendlyish ~PVGroup~ `PVAGroup` + `pvaproperty`
        - Similar form compared to V3 API
        - Batched updates of data by way of async context managers
        - Example: https://github.com/klauer/caproto/blob/pva_overlay/caproto/pva/ioc_examples/group.py (ServerRPC will be moved out of there)
        - Data only accessible to PVA clients for now (CA hook could be added)
        - No `SubGroup` just yet
* Rework of authorization handling
* Cleaned sync client API a bit - first-class support for dataclasses


Interactive testing
-------------------
Tested and working:
* epics-base: `pvget`, `pvget -m` (monitor), `pvput`, `pvlist` (*)
* pvxs: `pvxget`, `pvxmonitor`, `pvxcall` (rpc)
* Of course, caproto.pva.sync (get, put, monitor)

(*) lists PVs and gets server info via RPC call

Non-working clients:
* pvxs: `pvxput` (haven't figured out why yet)

Not yet tested:
* p4p, pvapy (didn't want their Python API influencing ours; will have to test soon)
