### PR TITLE
[PVA] ENH: initial scalar/scalararray normative type support

### DIFF
--- a/caproto/pva/_core.py
+++ b/caproto/pva/_core.py
@@ -198,7 +198,30 @@ class FieldType(enum.IntEnum):
 
     @property
     def is_complex(self) -> bool:
+        """Is the FieldType a union, struct, or any field?"""
         return self in {FieldType.union, FieldType.struct, FieldType.any}
+
+    @property
+    def is_numeric(self) -> bool:
+        """Is the FieldType integer or floating point?"""
+        return self.is_integral or self.is_floating
+
+    @property
+    def is_integral(self) -> bool:
+        """Is the FieldType integer-based?"""
+        return self in {
+            FieldType.uint64, FieldType.int64, FieldType.uint32,
+            FieldType.int32, FieldType.uint16, FieldType.int16,
+            FieldType.uint8, FieldType.int8,
+        }
+
+    @property
+    def is_floating(self) -> bool:
+        """Is the FieldType floating point?"""
+        return self in {
+            FieldType.float16, FieldType.float32, FieldType.float64,
+            FieldType.float128,
+        }
 
     @property
     def has_value(self) -> bool:

--- a/caproto/pva/_dataclass.py
+++ b/caproto/pva/_dataclass.py
@@ -1,6 +1,6 @@
 """
-Create a new PVAccess-compatible dataclass given a type-annotated class, and
-vice-versa.
+Tools for taking type-annotated classes and creating PVAccess-compatible
+dataclasses.
 """
 
 import dataclasses
@@ -21,9 +21,40 @@ def new_struct(fields: dict,
                name: str = '',
                array_type: FieldArrayType = FieldArrayType.scalar,
                size: Optional[int] = 1,
-               field_type=FieldType.struct,
+               field_type: FieldType = FieldType.struct,
                metadata: Optional[dict] = None,
                ) -> StructuredField:
+    """
+    Create a new `StructuredField` structure description.
+
+    Parameters
+    ----------
+    fields : dict
+        Fields of the structure.
+
+    struct_name :
+        The name of the structure.
+
+    name : str
+        If in a class hierarchy, the attribute name of the structure instance.
+
+    array_type : FieldArrayType, optional
+        The array type of the structure, defaulting to scalar.
+
+    size : int, optional
+        The number of elements in the array (relating to array_type).
+
+    field_type : FieldType, optional
+        The field type - struct or union.
+
+    metadata : dict, optional
+        Non-hashed metadata to attach to the StructuredField instance.
+
+    Returns
+    -------
+    StructuredField
+    """
+
     return StructuredField(
         field_type=field_type,
         array_type=array_type,
@@ -36,9 +67,29 @@ def new_struct(fields: dict,
     )
 
 
-def _field_from_annotation(attr, annotation,
-                           array_type=FieldArrayType.scalar,
-                           ):
+def _field_from_annotation(attr: str,
+                           annotation,
+                           array_type: FieldArrayType = FieldArrayType.scalar,
+                           ) -> FieldDesc:
+    """
+    Create a SimpleField or a StruturedField, given annotation information.
+
+    Parameters
+    ----------
+    attr : str
+        The attribute name.
+
+    annotation : any
+        Annotation information, according to `__annotations__`
+
+    array_type : FieldArrayType, optional
+        The array type to generate.
+
+    Returns
+    -------
+    FieldDesc
+        Structured or simple field information, based on the annotation.
+    """
     annotation = annotation_type_map.get(annotation, annotation)
     if isinstance(annotation, SimpleField):
         annotation = typing.cast(SimpleField, annotation)

--- a/caproto/pva/_fields.py
+++ b/caproto/pva/_fields.py
@@ -32,10 +32,6 @@ class FieldDesc(CoreSerializableWithCache):
     size: Optional[int] = 1
     metadata: Dict = field(default_factory=dict, hash=False, repr=False)
 
-    @property
-    def type_name(self) -> str:
-        return self.field_type.name
-
     def serialize(self, endian: Endian, cache=None) -> List[bytes]:
         raise NotImplementedError(
             "Implemented in SimpleField, StructuredField only."

--- a/caproto/pva/_normative.py
+++ b/caproto/pva/_normative.py
@@ -1,56 +1,192 @@
 # TODO: class-based definitions + usual introspection abilities as well?
 # TODO: NTValue class which helps handle a structured value of an NTType?
 
+import dataclasses
 import logging
+from typing import Tuple, Type
 
-from ._annotations import Float64, Int32, Int64
-from ._dataclass import pva_dataclass
+from ._annotations import Int32, Int64
+from ._dataclass import (get_pv_structure, is_pva_dataclass,
+                         is_pva_dataclass_instance, pva_dataclass)
+from ._fields import FieldType
 
 logger = logging.getLogger(__name__)
 
 
-@pva_dataclass
-class time_t:
+@dataclasses.dataclass
+class NormativeTypeName:
+    type_name: str
+    namespace: str = 'epics:nt'
+    version_number: str = '1.0'
+
+    @property
+    def struct_name(self):
+        """The packed, single-string name."""
+        return f'{self.namespace}/{self.type_name}:{self.version_number}'
+
+    @classmethod
+    def from_struct_name(cls, struct_name) -> 'NormativeTypeName':
+        """Split a normative type struct_name into its parts."""
+        namespace, type_and_version = struct_name.split('/', 1)
+        type_name, version = type_and_version.rsplit(':', 1)
+        return NormativeTypeName(
+            namespace=namespace,
+            type_name=type_name,
+            version=version,
+        )
+
+
+class _NTMeta(type):
+    def __instancecheck__(cls, instance):
+        if not is_pva_dataclass_instance(instance):
+            return False
+
+        return issubclass(type(instance), cls)
+
+    def __subclasscheck__(cls, subclass):
+        # 1. Ensure it's a dataclass
+        if not is_pva_dataclass(subclass):
+            return False
+
+        # 2. Ensure it's an epics:nt/...:1.0
+        try:
+            st = get_pv_structure(subclass)
+            type_name = NormativeTypeName.from_struct_name(st.struct_name)['type_name']
+            if type_name != cls._base_type_name_:
+                return False
+        except Exception:
+            return False
+
+        # 3. Check the value type
+        value_type = cls._value_type_
+        if value_type is None:
+            # Checking against NTScalarBase
+            return 'value' in st.children
+
+        try:
+            return value_type == st.children['value'].field_type
+        except Exception:
+            return False
+
+
+class NTScalarBase(metaclass=_NTMeta):
+    _base_type_name_ = 'NTScalar'
+    _value_type_ = None
+
+
+@pva_dataclass(name='time_t')
+class NTTimestamp:
     secondsPastEpoch: Int64
     nanoseconds: Int32
     userTag: Int32
 
 
-@pva_dataclass
-class alarm_t:
-    severity: Int32 = Int32(0)
+@pva_dataclass(name='alarm_t')
+class NTAlarm:
+    severity: Int32
     status: Int32
     message: str
 
 
-@pva_dataclass
-class display_t:
-    limitLow: Float64  # TODO: type depends on value (isnumeric)
-    limitHigh: Float64  # TODO: type depends on value
-    description: str
-    format: str
-    units: str
+def _create_nt_scalar(name: str,
+                      field_type: FieldType
+                      ) -> Tuple[Type[NTScalarBase], Type[NTScalarBase]]:
+    """
+    Creates two classes - a base normative scalar type and a "full" one.
+
+    Parameters
+    ----------
+    name : str
+        The "full" class name.
+
+    field_type : FieldType
+        The primitive type for "value" to hold.
+
+    Example
+    -------
+
+    Example return value, based on a name of "NTScalarInt64", and a field_type
+    of FieldType.int64:
+
+        @pva_dataclass(name='epics:nt/NTScalar:1.0')
+        class NTScalarInt64Base(NTScalarInt64Base):
+            value: int64
+
+        @pva_dataclass(name='epics:nt/NTScalar:1.0')
+        class NTScalarInt64(NTScalarInt64Base):
+            descriptor: str
+            alarm: NTAlarm
+            timeStamp: NTTimestamp
+            display: generated_display_t
+            control: generated_control_t
+
+    """
+
+    base_dict = {
+        '_value_type_': field_type,
+        '__annotations__': {
+            'value': field_type,
+        }
+    }
+
+    wrapper = pva_dataclass(name=NormativeTypeName('NTScalar').struct_name)
+    base_cls = wrapper(type(f'{name}Base', (NTScalarBase, ), base_dict))
+
+    if field_type.is_numeric:
+        @pva_dataclass(name='display_t')
+        class DisplayStruct:
+            limitLow: field_type
+            limitHigh: field_type
+            description: str
+            format: str
+            units: str
+    else:
+        @pva_dataclass(name='display_t')
+        class DisplayStruct:
+            # limitLow: field_type
+            # limitHigh: field_type
+            description: str
+            format: str
+            units: str
+
+    @pva_dataclass(name='control_t')
+    class ControlStruct:
+        limitLow: field_type
+        limitHigh: field_type
+        minStep: field_type
+
+    @pva_dataclass(name='valueAlarm_t')
+    class ValueAlarmStruct:
+        active: FieldType.boolean
+        lowAlarmLimit: field_type
+        lowWarningLimit: field_type
+        highWarningLimit: field_type
+        highAlarmLimit: field_type
+        lowAlarmSeverity: FieldType.int32
+        lowWarningSeverity: FieldType.int32
+        highWarningSeverity: FieldType.int32
+        highAlarmSeverity: FieldType.int32
+        hysteresis: FieldType.float64
+
+    annotations = {
+        # 'value': field_type,
+        'descriptor': str,
+        'alarm': NTAlarm,
+        'timeStamp': NTTimestamp,
+        'display': DisplayStruct,
+        'control': ControlStruct,
+        'valueAlarm': ValueAlarmStruct,
+    }
+
+    if not field_type.is_numeric:
+        annotations.pop('control')
+
+    full_dict = {
+        '__annotations__': annotations,
+    }
+
+    full_cls = wrapper(type(name, (base_cls, ), full_dict))
+    return base_cls, full_cls
 
 
-@pva_dataclass
-class control_t:
-    limitLow: Float64
-    limitHigh: Float64
-    minStep: Float64
-
-
-# class combined(metaclass=PvaStruct):
-#     time: time_t
-#     alarm: alarm_t
-#     display: display_t
-#     control: control_t
-
-
-# ? epics:nt/NTScalar:1.0
-# ? epics:nt/NTScalarArray:1.0
-# value
-# alarm_t
-# time_t
-# display_t
-# control_t
-# value alarm?
+NTScalarInt64Base, NTScalarInt64 = _create_nt_scalar('NTScalarInt64', FieldType.int64)

--- a/caproto/pva/_normative.py
+++ b/caproto/pva/_normative.py
@@ -115,7 +115,7 @@ def _create_nt(name: str,
     of FieldType.int64:
 
         @pva_dataclass(name='epics:nt/NTScalar:1.0')
-        class NTScalarInt64Base(NTScalarInt64Base):
+        class NTScalarInt64Base(NTScalarBase):
             value: int64
 
         @pva_dataclass(name='epics:nt/NTScalar:1.0')

--- a/caproto/pva/ioc_examples/normative.py
+++ b/caproto/pva/ioc_examples/normative.py
@@ -7,7 +7,9 @@ from caproto.pva.server import ioc_arg_parser, run
 
 
 class MyIOC(pva.PVAGroup):
-    int_nt = pva.pvaproperty(value=32, name='int')
+    int_nt = pva.pvaproperty(value=42, name='int')
+    float_nt = pva.pvaproperty(value=42.1, name='float')
+    string_nt = pva.pvaproperty(value='test', name='str')
 
 
 def main():

--- a/caproto/pva/ioc_examples/normative.py
+++ b/caproto/pva/ioc_examples/normative.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""
+A basic caproto-pva test server with normative types.
+"""
+import caproto.pva as pva
+from caproto.pva.server import ioc_arg_parser, run
+
+
+class MyIOC(pva.PVAGroup):
+    int_nt = pva.pvaproperty(value=32, name='int')
+
+
+def main():
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix='caproto:pva:',
+        desc='A basic caproto-pva test server.'
+    )
+
+    ioc = MyIOC(**ioc_options)
+    server_info = pva.ServerRPC(prefix='', server_instance=ioc)
+    ioc.pvdb.update(server_info.pvdb)
+    run(ioc.pvdb, **run_options)
+
+
+if __name__ == '__main__':
+    main()

--- a/caproto/pva/ioc_examples/normative.py
+++ b/caproto/pva/ioc_examples/normative.py
@@ -7,15 +7,19 @@ from caproto.pva.server import ioc_arg_parser, run
 
 
 class MyIOC(pva.PVAGroup):
+    bool_nt = pva.pvaproperty(value=True, name='bool')
     int_nt = pva.pvaproperty(value=42, name='int')
     float_nt = pva.pvaproperty(value=42.1, name='float')
     string_nt = pva.pvaproperty(value='test', name='str')
+    int_array = pva.pvaproperty(value=[42])
+    float_array = pva.pvaproperty(value=[42.1])
+    string_array = pva.pvaproperty(value=['test'])
 
 
 def main():
     ioc_options, run_options = ioc_arg_parser(
         default_prefix='caproto:pva:',
-        desc='A basic caproto-pva test server.'
+        desc='A basic caproto-pva test server for normative types.'
     )
 
     ioc = MyIOC(**ioc_options)

--- a/caproto/pva/server/magic.py
+++ b/caproto/pva/server/magic.py
@@ -12,7 +12,8 @@ from typing import Dict, List, Optional
 
 from ... import pva
 from .._dataclass import get_pv_structure, pva_dataclass
-from .._normative import NTScalarInt64
+from .._normative import (NTScalarBoolean, NTScalarFloat64, NTScalarInt64,
+                          NTScalarString)
 from .common import AuthOperation, DataWrapperBase
 
 module_logger = logging.getLogger(__name__)
@@ -659,6 +660,9 @@ class PVAGroup(metaclass=PVAGroupMeta):
 
     type_map = {
         int: NTScalarInt64,
+        float: NTScalarFloat64,
+        str: NTScalarString,
+        bool: NTScalarBoolean,
     }
 
     def __init__(self, prefix, *, macros=None, parent=None, name=None):

--- a/caproto/tests/test_pva_normative.py
+++ b/caproto/tests/test_pva_normative.py
@@ -1,0 +1,27 @@
+import logging
+
+import pytest
+
+pytest.importorskip('caproto.pva')
+
+from caproto import pva  # isort: skip
+from caproto.pva._normative import NTScalarBase, alarm_t, nt_name, time_t
+
+logger = logging.getLogger(__name__)
+
+
+def test_subclasscheck():
+    @pva.pva_dataclass(name=nt_name('NTScalar'))
+    class NTScalarInt64Test:
+        value: pva.Int64
+        descriptor: str
+        alarm: alarm_t
+        timeStamp: time_t
+
+    # While these are not direct subclasses, they are normative type
+    # equivalents:
+    assert issubclass(NTScalarInt64Test, NTScalarBase)
+    assert issubclass(NTScalarInt64Test, pva.NTScalarInt64)
+
+    assert isinstance(NTScalarInt64Test(), NTScalarBase)
+    assert isinstance(NTScalarInt64Test(), pva.NTScalarInt64)

--- a/caproto/tests/test_pva_normative.py
+++ b/caproto/tests/test_pva_normative.py
@@ -1,11 +1,13 @@
 import logging
+import typing
 
 import pytest
 
 pytest.importorskip('caproto.pva')
 
 from caproto import pva  # isort: skip
-from caproto.pva._normative import NormativeTypeName, NTScalarBase
+from caproto.pva._normative import (NormativeTypeName, NTScalarArrayBase,
+                                    NTScalarBase)
 
 logger = logging.getLogger(__name__)
 
@@ -23,3 +25,18 @@ def test_subclasscheck():
 
     assert isinstance(NTScalarInt64Test(), NTScalarBase)
     assert isinstance(NTScalarInt64Test(), pva.NTScalarInt64)
+
+
+def test_subclasscheck_array():
+    @pva.pva_dataclass(name=NormativeTypeName('NTScalarArray').struct_name)
+    class NTScalarArrayInt64Test:
+        value: typing.List[pva.Int64]
+        descriptor: str
+
+    # While these are not direct subclasses, they are normative type
+    # equivalents:
+    assert issubclass(NTScalarArrayInt64Test, NTScalarArrayBase)
+    assert issubclass(NTScalarArrayInt64Test, pva.NTScalarArrayInt64)
+
+    assert isinstance(NTScalarArrayInt64Test(), NTScalarArrayBase)
+    assert isinstance(NTScalarArrayInt64Test(), pva.NTScalarArrayInt64)

--- a/caproto/tests/test_pva_normative.py
+++ b/caproto/tests/test_pva_normative.py
@@ -5,18 +5,16 @@ import pytest
 pytest.importorskip('caproto.pva')
 
 from caproto import pva  # isort: skip
-from caproto.pva._normative import NTScalarBase, alarm_t, nt_name, time_t
+from caproto.pva._normative import NormativeTypeName, NTScalarBase
 
 logger = logging.getLogger(__name__)
 
 
 def test_subclasscheck():
-    @pva.pva_dataclass(name=nt_name('NTScalar'))
+    @pva.pva_dataclass(name=NormativeTypeName('NTScalar').struct_name)
     class NTScalarInt64Test:
         value: pva.Int64
         descriptor: str
-        alarm: alarm_t
-        timeStamp: time_t
 
     # While these are not direct subclasses, they are normative type
     # equivalents:


### PR DESCRIPTION
(WIP, still playing around with this)

* `PVAGroup` with `attr = pvaproperty(value=0)` implies creating an attribute with `NTScalarInt64` (including the control struct, etc.)
* `PVAGroup` with `attr = pvaproperty(value=[0])` implies creating an attribute with `NTScalarArrayInt64` (including the control struct, etc.)