### PR TITLE
Raise ValueError when assigning a startup if one already exists.

### DIFF
--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -705,6 +705,10 @@ class pvproperty:
         """
         Usually used as a decorator, this sets ``startup`` in the PVSpec.
         """
+        if self.pvspec.startup:
+            raise ValueError(f'A startup function had already been assigned '
+                             f'to {self.pvspec}.')
+
         self.pvspec = self.pvspec._replace(startup=startup)
         return self
 


### PR DESCRIPTION
In response to https://github.com/caproto/caproto/issues/691

