### PR TITLE
Avoid multiple passes of macro expansion, such that {{ is sufficient to "escape".

### DIFF
--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -1356,7 +1356,7 @@ def data_class_from_pvspec(group, pvspec):
 
 def channeldata_from_pvspec(group, pvspec):
     'Create a ChannelData instance based on a PVSpec'
-    full_pvname = expand_macros(group.prefix + pvspec.name, group.macros)
+    full_pvname = group.prefix + expand_macros(pvspec.name, group.macros)
     value = (pvspec.value
              if pvspec.value is not None
              else group.default_values[pvspec.dtype]

--- a/caproto/tests/test_macros.py
+++ b/caproto/tests/test_macros.py
@@ -1,0 +1,49 @@
+from caproto.server import PVGroup, pvproperty
+
+
+def test_no_double_braces():
+    class ParentGroup(PVGroup):
+        placeholder1 = pvproperty(value=0, name="{beamline}:{det}.VAL")
+        placeholder2 = pvproperty(value=0, name="{beamline}:{det}.RBV")
+
+    class ChildGroup(ParentGroup):
+        placeholder3 = pvproperty(value=0, name="{det}:{beamline}.VAL")
+        placeholder4 = pvproperty(value=0, name="{det}:{beamline}.RBV")
+
+    child_group = ChildGroup(
+        prefix="{prefix}:",
+        macros={"prefix": "PREFIX", "beamline": "BEAMLINE", "det": "DET"},
+    )
+
+    assert "PREFIX:BEAMLINE:DET.VAL" in child_group.pvdb
+    assert "PREFIX:BEAMLINE:DET.RBV" in child_group.pvdb
+    assert "PREFIX:DET:BEAMLINE.VAL" in child_group.pvdb
+    assert "PREFIX:DET:BEAMLINE.RBV" in child_group.pvdb
+
+
+def test_double_braces():
+    class ParentGroup(PVGroup):
+        placeholder1 = pvproperty(
+            value=0, name="{{beamline}}:{beamline}:{{det}}:{det}.VAL"
+        )
+        placeholder2 = pvproperty(
+            value=0, name="{{beamline}}:{beamline}:{{det}}:{det}.RBV"
+        )
+
+    class ChildGroup(ParentGroup):
+        placeholder3 = pvproperty(
+            value=0, name="{{beamline}}:{beamline}:{det}:{{det}}.VAL"
+        )
+        placeholder4 = pvproperty(
+            value=0, name="{{beamline}}:{beamline}:{det}:{{det}}.RBV"
+        )
+
+    child_group = ChildGroup(
+        prefix="{{prefix}}:{prefix}:",
+        macros={"prefix": "PREFIX", "beamline": "BEAMLINE", "det": "DET"},
+    )
+
+    assert "{prefix}:PREFIX:{beamline}:BEAMLINE:{det}:DET.VAL" in child_group.pvdb
+    assert "{prefix}:PREFIX:{beamline}:BEAMLINE:{det}:DET.RBV" in child_group.pvdb
+    assert "{prefix}:PREFIX:{beamline}:BEAMLINE:DET:{det}.VAL" in child_group.pvdb
+    assert "{prefix}:PREFIX:{beamline}:BEAMLINE:DET:{det}.RBV" in child_group.pvdb


### PR DESCRIPTION
This is an optimistic proposal for bringing the double-curly-brace string formatting escape hatch to macro expansion. The optimistic change is to exclude `group.prefix` from macro expansion in `channeldata_from_pvspec()` on the theory that macros have already been expanded in the prefix. The new tests show that this works in simple cases. I welcome suggestions for more test cases.

This PR closes #563.