### PR TITLE
MNT: show default value for optional macro substitution

### DIFF
--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -1619,8 +1619,10 @@ def template_arg_parser(*, desc, default_prefix, argv=None, macros=None,
             parser.add_argument(f'--{name}', type=str, required=True,
                                 help="Macro substitution required by this IOC")
         else:
-            parser.add_argument(f'--{name}', type=str, default=default_value,
-                                help="Macro substitution, optional")
+            parser.add_argument(
+                f'--{name}', type=str, default=default_value,
+                help=f"Optional macro substitution, default: {default_value!r}"
+            )
 
     def split_args(args):
         """


### PR DESCRIPTION
Show useful default values with optional macro substitutions. Previously showed "Macro substitution, optional" for each. Now shows something along the lines of:

```
  --ev_pv EV_PV         Optional macro substitution, default:
                        'LCLS:HXR:BEAM:EV'
  --pmps_run_pv PMPS_RUN_PV
                        Optional macro substitution, default:
                        'PMPS:HXR:AT2L0:RUN'
  --pmps_tdes_pv PMPS_TDES_PV
                        Optional macro substitution, default:
                        'PMPS:HXR:AT2L0:T_DES'
  --motor_prefix MOTOR_PREFIX
                        Optional macro substitution, default: 'AT2L0:SIM:MMS:'
  --autosave_path AUTOSAVE_PATH
                        Optional macro substitution, default:
                        'autosave_development.json'
```