### PR TITLE
FIX: win32 bind and shutdown errors in asyncio client

### DIFF
--- a/caproto/asyncio/client.py
+++ b/caproto/asyncio/client.py
@@ -29,7 +29,7 @@ from ..client.search_results import (DuplicateSearchResponse, SearchResults,
                                      UnknownSearchResponse)
 from .utils import (AsyncioQueue, _CallbackExecutor, _DatagramProtocol,
                     _StreamProtocol, _TaskHandler, _TransportWrapper,
-                    get_running_loop)
+                    get_running_loop, is_proactor_event_loop)
 
 ch_logger = logging.getLogger('caproto.ch')
 search_logger = logging.getLogger('caproto.bcast.search')
@@ -1227,8 +1227,7 @@ class VirtualCircuitManager:
             sock.close()
 
         sock, self.socket = self.socket, None
-
-        if sock is not None:
+        if sock is not None and not is_proactor_event_loop():
             self._tasks.create(shutdown_old_socket(sock))
 
         tags = {'their_address': self.circuit.address}

--- a/caproto/asyncio/client.py
+++ b/caproto/asyncio/client.py
@@ -135,6 +135,12 @@ class SharedBroadcaster:
         await self._tasks.cancel_all(wait=True)
         self.log.debug('Broadcaster: Closing the UDP socket')
         self.udp_sock = None
+        try:
+            if self.protocol is not None:
+                if self.protocol.transport is not None:
+                    self.protocol.transport.close()
+        except OSError:
+            self.log.debug('Broadcaster transport close error')
 
         self.log.debug('Broadcaster disconnect complete')
 
@@ -1225,6 +1231,12 @@ class VirtualCircuitManager:
                 pass
 
             sock.close()
+
+        try:
+            if self.transport is not None:
+                self.transport.close()
+        except OSError:
+            self.log.debug('VirtualCircuitManager transport close error')
 
         sock, self.socket = self.socket, None
         if sock is not None and not is_proactor_event_loop():

--- a/caproto/asyncio/client.py
+++ b/caproto/asyncio/client.py
@@ -140,7 +140,7 @@ class SharedBroadcaster:
                 if self.protocol.transport is not None:
                     self.protocol.transport.close()
         except OSError:
-            self.log.debug('Broadcaster transport close error')
+            self.log.exception('Broadcaster transport close error')
 
         self.log.debug('Broadcaster disconnect complete')
 

--- a/caproto/asyncio/utils.py
+++ b/caproto/asyncio/utils.py
@@ -178,17 +178,6 @@ class _CallbackExecutor:
         self.callbacks.put((callback, args, kwargs))
 
 
-ProactorEventLoop = getattr(asyncio, 'ProactorEventLoop', None)
-
-
-def is_proactor_event_loop() -> bool:
-    """Is the currently running event loop a ProactorEventLoop?"""
-    if ProactorEventLoop is None:
-        return False
-
-    return isinstance(get_running_loop(), ProactorEventLoop)
-
-
 if sys.version_info < (3, 7):
     # python <= 3.6 compatibility
     def get_running_loop():

--- a/caproto/asyncio/utils.py
+++ b/caproto/asyncio/utils.py
@@ -178,6 +178,17 @@ class _CallbackExecutor:
         self.callbacks.put((callback, args, kwargs))
 
 
+ProactorEventLoop = getattr(asyncio, 'ProactorEventLoop', None)
+
+
+def is_proactor_event_loop() -> bool:
+    """Is the currently running event loop a ProactorEventLoop?"""
+    if ProactorEventLoop is None:
+        return False
+
+    return isinstance(get_running_loop(), ProactorEventLoop)
+
+
 if sys.version_info < (3, 7):
     # python <= 3.6 compatibility
     def get_running_loop():


### PR DESCRIPTION
Windows-related fixes. More users are trying the asyncio client on Windows and running into strange issues. Hopefully this will fix at least some of them.

Fixes
------
(1) There appears to have been a race for using the socket versus binding it, so `bind()` was moved up to avoid the following exception:
```
[E 11:09:50.604        utils:   61] <caproto.asyncio.utils._DatagramProtocol object at 0x000001F5E4BE8CD0> receive error
    Traceback (most recent call last):
      File "C:\tools\miniconda3\envs\caproto\lib\asyncio\proactor_events.py", line 566, in _loop_reading
        self._read_fut = self._loop._proactor.recvfrom(self._sock,
      File "C:\tools\miniconda3\envs\caproto\lib\asyncio\windows_events.py", line 494, in recvfrom
        ov.WSARecvFrom(conn.fileno(), nbytes, flags)
    OSError: [WinError 10022] An invalid argument was supplied
```

(2) 
The proactor event loop handles shutdown and closing of sockets:

https://github.com/python/cpython/blob/7370be30017f81d2f41f1b4b2abf31dd9a3f8fb1/Lib/asyncio/proactor_events.py#L153-L168

So master currently duplicates that effort, causing asyncio's `finally` block to raise the following:
```
Exception in callback _ProactorBasePipeTransport._call_connection_lost(None)
handle: <Handle _ProactorBasePipeTransport._call_connection_lost(None)>
Traceback (most recent call last):
  File "C:\tools\miniconda3\envs\caproto\lib\asyncio\events.py", line 81, in _run
    self._context.run(self._callback, *self._args)
  File "C:\tools\miniconda3\envs\caproto\lib\asyncio\proactor_events.py", line 162, in _call_connection_lost
    self._sock.shutdown(socket.SHUT_RDWR)
OSError: [WinError 10038] An operation was attempted on something that is not a socket
```

I initially checked to see if this was the currently running event loop type, but then backed this up (in ac3d142) after running into (3) below, which I believe fixes it for both supported event loops.

(3) Event loop closed messages are avoided by trying to close the transport. This may be sufficient to get around (2) for all platforms, but I have not tested these separately.

```
Exception ignored in: <function _ProactorBasePipeTransport.__del__ at 0x000001E2DA11B310>
Traceback (most recent call last):
  File "C:\tools\miniconda3\envs\caproto\lib\asyncio\proactor_events.py", line 116, in __del__
    self.close()
  File "C:\tools\miniconda3\envs\caproto\lib\asyncio\proactor_events.py", line 108, in close
    self._loop.call_soon(self._call_connection_lost, None)
  File "C:\tools\miniconda3\envs\caproto\lib\asyncio\base_events.py", line 719, in call_soon
    self._check_closed()
  File "C:\tools\miniconda3\envs\caproto\lib\asyncio\base_events.py", line 508, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
```


Note
-----
* https://docs.python.org/3.6/library/asyncio-eventloop.html#asyncio.AbstractEventLoop.create_datagram_endpoint
`create_datagram_endpoint` is _not_ supported until 3.8 on Windows, though it does _exist_. It may be worth making note of this in the documentation that people should be using 3.8+.
* `ProactorEventLoop` isn't importable on non-Windows platforms ~which made making a utility function for it sensible (in my opinion)~
 
Related issues
-------
#680 (may or may not close it)
Closes #708 

Test script
-----------

```python
import asyncio
import sys

import caproto
from caproto.asyncio.client import Context


async def main(*pvnames):
    async with Context() as ctx:
        for pvname in pvnames:
            pv = await ctx.get_pvs(pvname)
            data = await pv[0].read()
            print(pvname, data)


if __name__ == "__main__":
    # caproto.config_caproto_logging(level='DEBUG')
    asyncio.run(main(*sys.argv[1:]))
```

Using `softIoc` from conda-forge's epics-base on Windows.