### PR TITLE
FIX: Win32 server beacon fix on proactor event loop

### DIFF
--- a/caproto/asyncio/client.py
+++ b/caproto/asyncio/client.py
@@ -29,7 +29,7 @@ from ..client.search_results import (DuplicateSearchResponse, SearchResults,
                                      UnknownSearchResponse)
 from .utils import (AsyncioQueue, _CallbackExecutor, _DatagramProtocol,
                     _StreamProtocol, _TaskHandler, _TransportWrapper,
-                    get_running_loop)
+                    get_running_loop, is_proactor_event_loop)
 
 ch_logger = logging.getLogger('caproto.ch')
 search_logger = logging.getLogger('caproto.bcast.search')
@@ -1227,8 +1227,7 @@ class VirtualCircuitManager:
             sock.close()
 
         sock, self.socket = self.socket, None
-
-        if sock is not None:
+        if sock is not None and not is_proactor_event_loop():
             self._tasks.create(shutdown_old_socket(sock))
 
         tags = {'their_address': self.circuit.address}

--- a/caproto/asyncio/client.py
+++ b/caproto/asyncio/client.py
@@ -135,6 +135,12 @@ class SharedBroadcaster:
         await self._tasks.cancel_all(wait=True)
         self.log.debug('Broadcaster: Closing the UDP socket')
         self.udp_sock = None
+        try:
+            if self.protocol is not None:
+                if self.protocol.transport is not None:
+                    self.protocol.transport.close()
+        except OSError:
+            self.log.debug('Broadcaster transport close error')
 
         self.log.debug('Broadcaster disconnect complete')
 
@@ -1225,6 +1231,12 @@ class VirtualCircuitManager:
                 pass
 
             sock.close()
+
+        try:
+            if self.transport is not None:
+                self.transport.close()
+        except OSError:
+            self.log.debug('VirtualCircuitManager transport close error')
 
         sock, self.socket = self.socket, None
         if sock is not None and not is_proactor_event_loop():

--- a/caproto/asyncio/utils.py
+++ b/caproto/asyncio/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import inspect
+import socket
 import sys
 import threading
 
@@ -176,6 +177,19 @@ class _CallbackExecutor:
 
     def submit(self, callback, *args, **kwargs):
         self.callbacks.put((callback, args, kwargs))
+
+
+def _create_udp_socket():
+    """Create a UDP socket for usage with a datagram endpoint."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+    # Python says this is unsafe, but we need it to have
+    # multiple servers live on the same host.
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    if sys.platform not in ('win32', ) and hasattr(socket, 'SO_REUSEPORT'):
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+    sock.setblocking(False)
+    return sock
 
 
 if sys.version_info < (3, 7):

--- a/caproto/asyncio/utils.py
+++ b/caproto/asyncio/utils.py
@@ -178,17 +178,6 @@ class _CallbackExecutor:
         self.callbacks.put((callback, args, kwargs))
 
 
-ProactorEventLoop = getattr(asyncio, 'ProactorEventLoop', None)
-
-
-def is_proactor_event_loop() -> bool:
-    """Is the currently running event loop a ProactorEventLoop?"""
-    if ProactorEventLoop is None:
-        return False
-
-    return isinstance(get_running_loop(), ProactorEventLoop)
-
-
 if sys.version_info < (3, 7):
     # python <= 3.6 compatibility
     def get_running_loop():

--- a/caproto/asyncio/utils.py
+++ b/caproto/asyncio/utils.py
@@ -178,6 +178,17 @@ class _CallbackExecutor:
         self.callbacks.put((callback, args, kwargs))
 
 
+ProactorEventLoop = getattr(asyncio, 'ProactorEventLoop', None)
+
+
+def is_proactor_event_loop() -> bool:
+    """Is the currently running event loop a ProactorEventLoop?"""
+    if ProactorEventLoop is None:
+        return False
+
+    return isinstance(get_running_loop(), ProactorEventLoop)
+
+
 if sys.version_info < (3, 7):
     # python <= 3.6 compatibility
     def get_running_loop():


### PR DESCRIPTION
May fix some beacon errors with running IOCs on Windows with the proactor event loop:

```
[E 12:47:49.911        utils:   59] <caproto.asyncio.utils._DatagramProtocol object at 0x0000011599F66820> receive error
    Traceback (most recent call last):
      File "C:\tools\miniconda3\envs\caproto\lib\asyncio\proactor_events.py", line 563, in _loop_reading
        self._read_fut = self._loop._proactor.recv(self._sock,
      File "C:\tools\miniconda3\envs\caproto\lib\asyncio\windows_events.py", line 449, in recv
        ov.WSARecv(conn.fileno(), nbytes, flags)
    OSError: [WinError 10022] An invalid argument was supplied
[I 12:47:49.913       server:  206] Server startup complete.
```

Not fully tested, but anecdotally fixed the above

(Based on #707 , which should be merged first)