### PR TITLE
MNT: Unify asyncio wrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ doc/build
 .cache/
 .coverage
 .coverage.*
+/cov
 pytest_bench.json
 .pytest_cache/
 .idea/

--- a/caproto/_circuit.py
+++ b/caproto/_circuit.py
@@ -7,32 +7,30 @@
 # Requests; a ServerChannel provides convenience methods for composing
 # Responses.
 import logging
+import os
 from collections import deque
 from collections.abc import Iterable
-import os
 
-from ._commands import (AccessRightsResponse, CreateChFailResponse,
-                        ClearChannelRequest, ClearChannelResponse,
-                        ClientNameRequest, CreateChanRequest,
-                        CreateChanResponse, EventAddRequest, EventAddResponse,
-                        EventCancelRequest, EventCancelResponse,
-                        HostNameRequest, ReadNotifyRequest,
-                        ReadRequest, ReadNotifyResponse, ReadResponse,
-                        SearchResponse, ServerDisconnResponse,
+from ._commands import (AccessRightsResponse, ClearChannelRequest,
+                        ClearChannelResponse, ClientNameRequest,
+                        CreateChanRequest, CreateChanResponse,
+                        CreateChFailResponse, EventAddRequest,
+                        EventAddResponse, EventCancelRequest,
+                        EventCancelResponse, HostNameRequest,
+                        ReadNotifyRequest, ReadNotifyResponse, ReadRequest,
+                        ReadResponse, SearchResponse, ServerDisconnResponse,
                         VersionRequest, VersionResponse, WriteNotifyRequest,
                         WriteNotifyResponse, WriteRequest,
-                        read_from_bytestream,)
-from ._state import (ChannelState, CircuitState, get_exception)
-from ._utils import (CLIENT, SERVER, NEED_DATA, DISCONNECTED, CaprotoKeyError,
-                     CaprotoValueError, CaprotoRuntimeError, CaprotoError,
-                     CaprotoTypeError,
-                     parse_channel_filter, parse_record_field,
-                     ChannelFilter, ThreadsafeCounter)
-from ._dbr import (ChannelType, SubscriptionType, field_types, native_type)
+                        read_from_bytestream)
 from ._constants import DEFAULT_PROTOCOL_VERSION
+from ._dbr import ChannelType, SubscriptionType, field_types, native_type
 from ._log import ComposableLogAdapter
+from ._state import ChannelState, CircuitState, get_exception
 from ._status import CAStatus
-
+from ._utils import (CLIENT, DISCONNECTED, NEED_DATA, SERVER, CaprotoError,
+                     CaprotoKeyError, CaprotoRuntimeError, CaprotoTypeError,
+                     CaprotoValueError, ChannelFilter, ThreadsafeCounter,
+                     parse_channel_filter, parse_record_field)
 
 __all__ = ('VirtualCircuit', 'ClientChannel', 'ServerChannel',
            'extract_address')
@@ -188,7 +186,7 @@ class VirtualCircuit:
         total_received = sum(len(byteslike) for byteslike in buffers)
         commands = deque()
         if total_received == 0:
-            self.log.debug('Zero-length recv; sending disconnect notification')
+            self.log.debug('Circuit disconnected')
             commands.append(DISCONNECTED)
             return commands, 0
         self._data += b''.join(buffers)

--- a/caproto/_utils.py
+++ b/caproto/_utils.py
@@ -1090,6 +1090,8 @@ class ShowVersionAction(argparse.Action):
         parser.exit()
 
 
+# TODO: this should be revisited
+# TODO: this LRU cache holds hard references of socket instances.
 @functools.lru_cache(maxsize=128)
 def safe_getsockname(sock):
     """

--- a/caproto/asyncio/client.py
+++ b/caproto/asyncio/client.py
@@ -921,12 +921,14 @@ class VirtualCircuitManager:
                 bytes_received = await transport.recv()
             except ca.CaprotoNetworkError:
                 bytes_received = ''
-                # self.command_queue.put(ca.DISCONNECTED)
 
             self.last_tcp_receipt = time.monotonic()
             commands, _ = self.circuit.recv(bytes_received)
             for c in commands:
                 self.command_queue.put(c)
+
+            if not len(bytes_received):
+                break
 
     async def _connect(self, timeout):
         """Start the connection and spawn tasks."""

--- a/caproto/asyncio/client.py
+++ b/caproto/asyncio/client.py
@@ -28,7 +28,7 @@ from ..client import common
 from ..client.search_results import (DuplicateSearchResponse, SearchResults,
                                      UnknownSearchResponse)
 from .utils import (AsyncioQueue, _CallbackExecutor, _DatagramProtocol,
-                    _StreamProtocol, _TaskHandler, _TransportWrapper,
+                    _StreamProtocol, _TaskHandler, _UdpTransportWrapper,
                     get_running_loop)
 
 ch_logger = logging.getLogger('caproto.ch')
@@ -174,7 +174,7 @@ class SharedBroadcaster:
 
         # TODO: wrapped transport is a server concept for unifying
         # trio/asyncio/curio
-        self.wrapped_transport = _TransportWrapper(transport)
+        self.wrapped_transport = _UdpTransportWrapper(transport)
 
         self.broadcaster.client_address = safe_getsockname(self.udp_sock)
 

--- a/caproto/asyncio/client.py
+++ b/caproto/asyncio/client.py
@@ -920,14 +920,14 @@ class VirtualCircuitManager:
             try:
                 bytes_received = await transport.recv()
             except ca.CaprotoNetworkError:
-                bytes_received = ''
+                bytes_received = b''
 
             self.last_tcp_receipt = time.monotonic()
             commands, _ = self.circuit.recv(bytes_received)
             for c in commands:
                 self.command_queue.put(c)
 
-            if not len(bytes_received):
+            if not bytes_received:
                 break
 
     async def _connect(self, timeout):

--- a/caproto/asyncio/server.py
+++ b/caproto/asyncio/server.py
@@ -111,11 +111,11 @@ class Context(_Context):
                 self.tcp_handler(transport, transport.getpeername())
             )
 
-        await asyncio.start_server(
+        server = await asyncio.start_server(
             _new_client,
             sock=sock,
-            start_serving=True,
         )
+        await server.start_serving()
 
     async def run(self, *, log_pv_names=False):
         'Start the server'

--- a/caproto/asyncio/server.py
+++ b/caproto/asyncio/server.py
@@ -112,8 +112,9 @@ class Context(_Context):
         """Start a TCP server on `sock` and listen for new connections."""
         def _new_client(reader, writer):
             transport = _TransportWrapper(reader, writer)
-            peer_addr = transport.getpeername()
-            self.server_tasks.create(self.tcp_handler(transport, peer_addr))
+            self.server_tasks.create(
+                self.tcp_handler(transport, transport.getpeername())
+            )
 
         await asyncio.start_server(
             _new_client,
@@ -206,7 +207,7 @@ class Context(_Context):
                 sock.close()
             for sock in self.udp_socks.values():
                 sock.close()
-            for _interface, sock in self.beacon_socks.values():
+            for _, sock in self.beacon_socks.values():
                 sock.close()
 
     def _datagram_received(self, pair):

--- a/caproto/asyncio/server.py
+++ b/caproto/asyncio/server.py
@@ -215,7 +215,7 @@ class Context(_Context):
             identifier, data, address = await queue.async_get()
             if isinstance(data, Exception):
                 self.log.exception('Broadcaster failed to receive on %s',
-                                   identifier)
+                                   identifier, exc_info=data)
             else:
                 await self._broadcaster_recv_datagram(data, address)
 

--- a/caproto/asyncio/server.py
+++ b/caproto/asyncio/server.py
@@ -116,11 +116,12 @@ class Context(_Context):
                 self.tcp_handler(transport, transport.getpeername())
             )
 
-        server = await asyncio.start_server(
+        # TODO: when Python 3.7 is the minimum version, the following server
+        # can be an async context manager:
+        await asyncio.start_server(
             _new_client,
             sock=sock,
         )
-        await server.start_serving()
 
     async def run(self, *, log_pv_names=False):
         'Start the server'

--- a/caproto/asyncio/utils.py
+++ b/caproto/asyncio/utils.py
@@ -147,6 +147,14 @@ class _SocketWrapper:
     def close(self):
         return self.sock.close()
 
+    def __repr__(self):
+        try:
+            host, port = self.sock.getpeername()
+        except Exception:
+            return f'<{self.__class__.__name__}>'
+
+        return f'<{self.__class__.__name__} address="{host}:{port}">'
+
 
 class _TransportWrapper(_SocketWrapper):
     """Make an asyncio transport something you can call sendto on."""
@@ -163,6 +171,9 @@ class _ConnectedTransportWrapper(_TransportWrapper):
         super().__init__(transport, loop=loop)
         self.address = address
         self.loop = loop or get_running_loop()
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__} address={self.address}>'
 
 
 class _TaskHandler:

--- a/caproto/pva/asyncio/server.py
+++ b/caproto/pva/asyncio/server.py
@@ -47,8 +47,6 @@ class VirtualCircuit(_VirtualCircuit):
     async def send(self, *messages):
         if self.connected:
             buffers_to_send = self.circuit.send(*messages, extra=self._tags)
-            # lock to make sure a AddEvent does not write bytes
-            # to the socket while we are sending
             await self.client.send(b''.join(buffers_to_send))
 
     async def run(self):

--- a/caproto/pva/asyncio/server.py
+++ b/caproto/pva/asyncio/server.py
@@ -92,11 +92,11 @@ class Context(_Context):
                 self.tcp_handler(transport, transport.getpeername())
             )
 
-        await asyncio.start_server(
+        server = await asyncio.start_server(
             _new_client,
             sock=sock,
-            start_serving=True,
         )
+        await server.start_serving()
 
     @property
     def guid(self) -> str:

--- a/caproto/pva/asyncio/server.py
+++ b/caproto/pva/asyncio/server.py
@@ -96,11 +96,12 @@ class Context(_Context):
                 self.tcp_handler(transport, transport.getpeername())
             )
 
-        server = await asyncio.start_server(
+        # TODO: when Python 3.7 is the minimum version, the following server
+        # can be an async context manager:
+        await asyncio.start_server(
             _new_client,
             sock=sock,
         )
-        await server.start_serving()
 
     @property
     def guid(self) -> str:

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -11,6 +11,7 @@ from caproto import (CaprotoKeyError, CaprotoNetworkError, CaprotoRuntimeError,
                      ChannelType, RemoteProtocolError, apply_arr_filter,
                      get_environment_variables)
 
+from .._constants import MAX_UDP_RECV
 from .._dbr import SubscriptionType, _LongStringChannelType
 
 # ** Tuning this parameters will affect the servers' performance **
@@ -732,7 +733,9 @@ class Context:
     async def _core_broadcaster_loop(self, udp_sock):
         while True:
             try:
-                bytes_received, address = await udp_sock.recvfrom(4096 * 16)
+                bytes_received, address = await udp_sock.recvfrom(
+                    MAX_UDP_RECV
+                )
             except OSError:
                 self.log.exception('UDP server recvfrom error')
                 await self.async_layer.library.sleep(0.1)
@@ -767,7 +770,6 @@ class Context:
             except Exception as ex:
                 self.log.exception('Broadcaster command queue evaluation failed',
                                    exc_info=ex)
-                continue
 
     def __iter__(self):
         # Implemented to support __getitem__ below

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -286,7 +286,7 @@ class VirtualCircuit:
                 if response is not None:
                     await self.send(*response)
                 await self._wake_new_command()
-        except DisconnectedCircuit:
+        except (DisconnectedCircuit, CaprotoNetworkError):
             await self._on_disconnect()
             self.circuit.disconnect()
             await self.context.circuit_disconnected(self)


### PR DESCRIPTION
_Almost_ entirely does away with `asyncio.Protocol`, favoring the higher-level read/write transports - which eschew callbacks and allow for control flow to go through awaitable methods. I think this is in general much easier to follow. With this, we stand to better capture where exceptions are happening and log more appropriate information.

Though tests are passing locally and on Azure, it would be wise to double-check this on each of our platforms. A mistake here has the potential to hamper IOC functionality, after all.

Closes #680 (at least in my own testing)
Closes #696 

Testing:
* Locally working on Python 3.6 to 3.8 with a Win10 20H2 VM, and macOS as usual.
* Tests are passing now (Linux-based Azure)