### PR TITLE
REF: allow for both 'scan' and 'startup' hooks in server

### DIFF
--- a/caproto/ioc_examples/scan_rate.py
+++ b/caproto/ioc_examples/scan_rate.py
@@ -30,6 +30,12 @@ class ScanRateIOC(PVGroup):
     # close to this value, but not exact. To compare these, you can also try:
     #    $ camonitor -tsi periodic:scanned
 
+    # As of caproto v0.7.2, you may also include a "startup" method along
+    # with a "scan" method:
+    @scanned.startup
+    async def scanned(self, instance, async_lib):
+        print(f"{instance.name} startup called.")
+
 
 if __name__ == '__main__':
     ioc_options, run_options = ioc_arg_parser(

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -1033,7 +1033,7 @@ class Context:
     def _find_hook_methods(self, *attrs):
         """Return a dictionary of (not-None) methods given attribute names."""
         return {
-            name: getattr(instance, attr)
+            f"{name}.{attr}": getattr(instance, attr)
             for attr in attrs
             for name, instance in self.pvdb_with_fields.items()
             if getattr(instance, attr, None) is not None

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -1030,21 +1030,24 @@ class Context:
         '''Notification from circuit that its connection has closed'''
         self.circuits.discard(circuit)
 
+    def _find_hook_methods(self, *attrs):
+        """Return a dictionary of (not-None) methods given attribute names."""
+        return {
+            name: getattr(instance, attr)
+            for attr in attrs
+            for name, instance in self.pvdb_with_fields.items()
+            if getattr(instance, attr, None) is not None
+        }
+
     @property
     def startup_methods(self):
         'Notify all ChannelData instances of the server startup'
-        return {name: instance.server_startup
-                for name, instance in self.pvdb_with_fields.items()
-                if hasattr(instance, 'server_startup') and
-                instance.server_startup is not None}
+        return self._find_hook_methods("server_startup", "server_scan")
 
     @property
     def shutdown_methods(self):
         'Notify all ChannelData instances of the server shutdown'
-        return {name: instance.server_shutdown
-                for name, instance in self.pvdb.items()
-                if hasattr(instance, 'server_shutdown') and
-                instance.server_shutdown is not None}
+        return self._find_hook_methods("server_shutdown")
 
     async def _bind_tcp_sockets_with_consistent_port_number(self, make_socket):
         # Find a random port number that is free on all self.interfaces,

--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -134,7 +134,7 @@ class PvpropertyData:
         if pvspec.scan is not None:
             # enable the scan hook for this instance only:
             self.server_scan = self._server_scan
-            # bind the startup method to the group (used in server_scan)
+            # bind the scan method to the group (used in server_scan)
             self.scan = MethodType(pvspec.scan, group)
         if pvspec.shutdown is not None:
             # enable the shutdown hook for this instance only:


### PR DESCRIPTION
Supersedes #692 
Closes #691 (by allowing both, rather than raising)

Tested locally and now working.