### PR TITLE
ENH: partially support RVAL for mbbi, mbbo, bi, and bo records

### DIFF
--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -759,6 +759,14 @@ class ChannelEnum(ChannelData):
 
     enum_strings = _read_only_property('enum_strings')
 
+    @property
+    def raw_value(self) -> int:
+        """The raw integer value index of the enum string."""
+        try:
+            return self.enum_strings.index(self.value)
+        except ValueError:
+            return 0
+
     def __getnewargs_ex__(self):
         args, kwargs = super().__getnewargs_ex__()
         kwargs['enum_strings'] = self.enum_strings

--- a/caproto/server/record_body_bi.jinja2
+++ b/caproto/server/record_body_bi.jinja2
@@ -1,2 +1,4 @@
     _link_enum_strings({{ rec.field_to_attr['ZNAM'] }}, index=0)
     _link_enum_strings({{ rec.field_to_attr['ONAM'] }}, index=1)
+    _link_parent_attribute(raw_value, 'raw_value', read_only=True,
+                           use_setattr=True)

--- a/caproto/server/record_body_bo.jinja2
+++ b/caproto/server/record_body_bo.jinja2
@@ -1,2 +1,4 @@
     _link_enum_strings({{ rec.field_to_attr['ZNAM'] }}, index=0)
     _link_enum_strings({{ rec.field_to_attr['ONAM'] }}, index=1)
+    _link_parent_attribute(raw_value, 'raw_value', read_only=True,
+                           use_setattr=True)

--- a/caproto/server/record_body_mbbi.jinja2
+++ b/caproto/server/record_body_mbbi.jinja2
@@ -14,3 +14,5 @@
     _link_enum_strings({{ rec.field_to_attr['TTST'] }}, index=13)
     _link_enum_strings({{ rec.field_to_attr['FTST'] }}, index=14)
     _link_enum_strings({{ rec.field_to_attr['FFST'] }}, index=15)
+    _link_parent_attribute(raw_value, 'raw_value', read_only=True,
+                           use_setattr=True)

--- a/caproto/server/record_body_mbbo.jinja2
+++ b/caproto/server/record_body_mbbo.jinja2
@@ -13,3 +13,5 @@
     _link_enum_strings({{ rec.field_to_attr['TTST'] }}, index=13)
     _link_enum_strings({{ rec.field_to_attr['FTST'] }}, index=14)
     _link_enum_strings({{ rec.field_to_attr['FFST'] }}, index=15)
+    _link_parent_attribute(raw_value, 'raw_value', read_only=True,
+                           use_setattr=True)

--- a/caproto/server/records.py
+++ b/caproto/server/records.py
@@ -8,11 +8,11 @@ Contains PVGroups representing all fields of EPICS base records
 import logging
 import sys
 
-from .server import PVGroup, pvproperty
 from .._constants import MAX_ENUM_STRING_SIZE
 from .._data import ChannelType
 from .._dbr import AlarmSeverity
 from . import menus
+from .server import PVGroup, pvproperty
 
 logger = logging.getLogger(__name__)
 records = {}
@@ -2309,6 +2309,10 @@ class BiFields(RecordFieldGroup):
     # doc='Current Value')
     _link_enum_strings(zero_name, index=0)
     _link_enum_strings(one_name, index=1)
+    _link_parent_attribute(raw_value,
+                           'raw_value',
+                           read_only=True,
+                           use_setattr=True)
 
 
 @register_record
@@ -2430,6 +2434,10 @@ class BoFields(RecordFieldGroup):
     # doc='Current Value')
     _link_enum_strings(zero_name, index=0)
     _link_enum_strings(one_name, index=1)
+    _link_parent_attribute(raw_value,
+                           'raw_value',
+                           read_only=True,
+                           use_setattr=True)
 
 
 @register_record
@@ -3818,6 +3826,10 @@ class MbbiFields(RecordFieldGroup):
     _link_enum_strings(thirteen_string, index=13)
     _link_enum_strings(fourteen_string, index=14)
     _link_enum_strings(fifteen_string, index=15)
+    _link_parent_attribute(raw_value,
+                           'raw_value',
+                           read_only=True,
+                           use_setattr=True)
 
 
 @register_record
@@ -4255,6 +4267,10 @@ class MbboFields(RecordFieldGroup):
     _link_enum_strings(thirteen_string, index=13)
     _link_enum_strings(fourteen_string, index=14)
     _link_enum_strings(fifteen_string, index=15)
+    _link_parent_attribute(raw_value,
+                           'raw_value',
+                           read_only=True,
+                           use_setattr=True)
 
 
 @register_record

--- a/caproto/tests/ioc_any_record.py
+++ b/caproto/tests/ioc_any_record.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from caproto import ChannelType
-from caproto.server import pvproperty, PVGroup, template_arg_parser, run
+from caproto.server import PVGroup, pvproperty, run, template_arg_parser
 from caproto.server.records import records
 
 
@@ -42,6 +42,7 @@ def start_ioc(record_type, *, ioc_options, run_options):
         ', '.join(ioc.A.fields)
     )
     run(ioc.pvdb, **run_options)
+    return ioc
 
 
 if __name__ == '__main__':
@@ -60,5 +61,5 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     ioc_options, run_options = split_args(args)
-    start_ioc(args.record_type, ioc_options=ioc_options,
-              run_options=run_options)
+    ioc = start_ioc(args.record_type, ioc_options=ioc_options,
+                    run_options=run_options)


### PR DESCRIPTION
Closes #724 

Record generation update PR: https://github.com/caproto/reference-dbd/pull/1/files

Supports read-only access of RVAL for mbbi, mbbo, bi, and bo records.

For the future, the field instance needs a hook to see when the pvproperty (i.e., ".VAL") has updated so writes and other things can be supported more easily. I don't think that hook will be too difficult, but it will require some work.