### PR TITLE
FIX/ENH: attempt to support array interface to remove bottleneck processing numpy arrays

### DIFF
--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -735,25 +735,34 @@ class ChannelData:
         return AccessRights.READ | AccessRights.WRITE
 
     def is_compatible_array(self, value) -> bool:
-        try:
-            interface = value.__array_interface__
-        except AttributeError:
+        """
+        Check if the provided value is a compatible array.
+
+        This requires that ``value`` follow the "array interface", as defined by
+        `numpy <https://numpy.org/doc/stable/reference/arrays.interface.html>`_.
+
+        Parameters
+        ----------
+        value : any
+            The value to check.
+
+        Returns
+        -------
+        bool
+            True if ``value`` is compatible, False otherwise.
+        """
+        interface = getattr(value, "__array_interface__", None)
+        if interface is None:
             return False
 
-        try:
-            dimensions = len(interface['shape'])
-            strides = interface['strides']
-            typestr = interface['typestr']
-        except KeyError:
-            return False
-
+        dimensions = len(interface['shape'])
         return (
             # Ensure it's 1 dimensional:
             dimensions == 1 and
             # Not strided - which 1D data shouldn't be anyway...
-            strides is None and
+            interface['strides'] is None and
             # And a compatible array type, defined in the class body:
-            typestr in self._compatible_array_types  # compatible type
+            interface['typestr'] in self._compatible_array_types
         )
 
 

--- a/caproto/_utils.py
+++ b/caproto/_utils.py
@@ -1161,3 +1161,31 @@ def adapt_old_callback_signature(func, weakref_set):
         # Hold a hard reference to w. Its callback removes it from this set.
         weakref_set.add(w)
     return func
+
+
+def is_array_read_only(value) -> bool:
+    """
+    Check if the provided value is flagged as read-only.
+
+    This requires that ``value`` follow the "array interface", as defined by
+    `numpy <https://numpy.org/doc/stable/reference/arrays.interface.html>`_.
+
+    Parameters
+    ----------
+    value : any
+        The value to check.
+
+    Returns
+    -------
+    bool
+        True if ``value`` is marked as read-only, False otherwise.
+    """
+    interface = getattr(value, "__array_interface__", None)
+    if interface is None:
+        return False
+
+    data = interface.get("data", None)
+    if data is None:
+        return False
+    _, is_read_only = data
+    return is_read_only

--- a/caproto/ioc_examples/big_image_noisy_neighbor.py
+++ b/caproto/ioc_examples/big_image_noisy_neighbor.py
@@ -20,9 +20,12 @@ class IOInterruptIOC(PVGroup):
     async def t1(self, instance, async_lib):
         # Loop and grab items from the queue one at a time
         await self.t1.write(time.monotonic())
-        await self.image.write(
-            value=np.random.randint(0, 256, image_shape, dtype=np.uint8).flatten()
-        )
+
+        value = np.random.randint(0, 256, image_shape, dtype=np.uint8).flatten()
+        # caproto will not perform a copy in preprocess_value if you mark
+        # the array as read-only by way of flags:
+        value.flags.writeable = False
+        await self.image.write(value=value)
 
 
 if __name__ == "__main__":

--- a/caproto/ioc_examples/big_image_noisy_neighbor.py
+++ b/caproto/ioc_examples/big_image_noisy_neighbor.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
 import time
-from caproto.server import pvproperty, PVGroup, ioc_arg_parser, run
+
 import numpy as np
+
+from caproto.server import PVGroup, ioc_arg_parser, pvproperty, run
 
 image_shape = (3960, 3960)
 
@@ -10,15 +12,17 @@ image_shape = (3960, 3960)
 class IOInterruptIOC(PVGroup):
     t1 = pvproperty(value=2.0)
     image = pvproperty(
-        value=np.random.randint(0, 256, image_shape).flatten(), dtype=float
+        value=np.random.randint(0, 256, image_shape, dtype=np.uint8).flatten(),
+        dtype=bytes,
     )
 
-    @t1.startup
+    @t1.scan(period=0.1)
     async def t1(self, instance, async_lib):
         # Loop and grab items from the queue one at a time
-        while True:
-            await self.t1.write(time.monotonic())
-            await async_lib.library.sleep(0.1)
+        await self.t1.write(time.monotonic())
+        await self.image.write(
+            value=np.random.randint(0, 256, image_shape, dtype=np.uint8).flatten()
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #705 

Overview
----------
Supports the numpy array interface to remove a significant ``O(n)``  bottleneck when pre-processing numpy arrays for ``ChannelByte`` instances.  

Notes
------
* To avoid an additional copy on immutable data, set ``value.flags.writeable``  to ``False`` when using compatible numpy arrays.  (#731)
* ``ChannelChar`` will eventually be decoded, so `.tobytes()` is unavoidable - but we can at least let numpy take care of this for us instead of using `map(chr, value)`.