### PR TITLE
FIX: pyepics compat char_value and enum_strs

### DIFF
--- a/caproto/_dbr.py
+++ b/caproto/_dbr.py
@@ -680,19 +680,6 @@ class DBR_CTRL_ENUM(GraphicControlBase, _EnumWithStrings):
         ('strs', MAX_ENUM_STATES * (MAX_ENUM_STRING_SIZE * char_t)),
     ]
 
-    @property
-    def enum_strings(self):
-        '''Enum byte strings as a tuple'''
-        return tuple(self.strs[i].value
-                     for i in range(self.no_str))
-
-    @enum_strings.setter
-    def enum_strings(self, enum_strings):
-        for i, bytes_ in enumerate(enum_strings):
-            bytes_ = bytes_[:MAX_ENUM_STRING_SIZE - 1]
-            self.strs[i][:] = bytes_.ljust(MAX_ENUM_STRING_SIZE, b'\x00')
-        self.no_str = len(enum_strings)
-
 
 class DBR_CTRL_CHAR(ControlTypeUnits):
     DBR_ID = ChannelType.CTRL_CHAR

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -363,7 +363,10 @@ class SharedBroadcaster:
     def _should_attempt_registration(self):
         'Whether or not a registration attempt should be tried'
         if self.udp_sock is None:
-            return True
+            # This broadcaster does not currently support being revived from
+            # a disconnected state.  Do not attempt registration if the
+            # __init__-defined socket has been removed.
+            return False
 
         if (self.broadcaster.registered or
                 self._registration_retry_time is None):
@@ -1222,10 +1225,6 @@ class Context:
             # clear any state about circuits and search results
             self.log.debug('Clearing circuit managers')
             self.circuit_managers.clear()
-
-            # disconnect the underlying state machine
-            self.broadcaster.remove_listener(self)
-            # (TODO) double remove0
 
             self.log.debug("Stopping SelectorThread of the context")
             self.selector.stop()

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -48,7 +48,7 @@ def _parse_dbr_metadata(dbr_data):
                'lower_alarm_limit': 'lower_alarm_limit',
                'upper_ctrl_limit': 'upper_ctrl_limit',
                'lower_ctrl_limit': 'lower_ctrl_limit',
-               'strs': 'enum_strs',
+               'enum_strings': 'enum_strs',
                # 'secondsSinceEpoch': 'posixseconds',
                # 'nanoSeconds': 'nanoseconds',
                }
@@ -58,8 +58,9 @@ def _parse_dbr_metadata(dbr_data):
             ret[arg] = getattr(dbr_data, attr)
 
     if ret.get('enum_strs', None):
-        ret['enum_strs'] = tuple(k.value.decode(STR_ENC) for
-                                 k in ret['enum_strs'] if k.value)
+        ret['enum_strs'] = tuple(
+            k.decode(STR_ENC) for k in ret['enum_strs']
+        )
 
     if hasattr(dbr_data, 'nanoSeconds'):
         ret['posixseconds'] = dbr_data.secondsSinceEpoch

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -572,6 +572,7 @@ class PV:
         info['raw_value'] = value
         info['value'] = _scalarify(value, command.data_type, command.data_count)
         self._args.update(**info)
+        return info
 
     @ensure_connection
     def force_read_access_rights(self):

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -75,7 +75,7 @@ def _parse_dbr_metadata(dbr_data):
     return ret
 
 
-def _read_response_to_pyepics(full_type, command):
+def _read_response_to_pyepics(full_type, command, enum_strings=None):
     'Parse a ReadResponse command into a pyepics-friendly dict'
     info = _parse_dbr_metadata(command.metadata)
 
@@ -91,6 +91,20 @@ def _read_response_to_pyepics(full_type, command):
         if len(value) == 1:
             value = value[0]
         info['char_value'] = value
+    elif full_type in ca.enum_types:
+        enum_strings = info.get('enum_strs', None) or enum_strings
+        if enum_strings is None:
+            # This None marker will allow get_ctrlvars to be automatically
+            # called later through `_getarg()` magic.
+            char_value = [None] * len(value)
+        else:
+            char_value = [
+                enum_strings[idx] if 0 <= idx < len(enum_strings) else ''
+                for idx in value
+            ]
+        if len(char_value) == 1:
+            char_value = char_value[0]
+        info['char_value'] = char_value
     else:
         info['char_value'] = None
 
@@ -441,7 +455,9 @@ class PV:
                 (count is not None and count > len(cached_value))):
             command = self._caproto_pv.read(data_type=dt, data_count=count,
                                             timeout=timeout)
-            response = _read_response_to_pyepics(self.typefull, command)
+            response = _read_response_to_pyepics(
+                self.typefull, command, enum_strings=self._args['enum_strs']
+            )
             self._args.update(**response)
             md.update(**response)
 
@@ -550,29 +566,30 @@ class PV:
         self._caproto_pv.write(value, wait=wait, callback=run_callback,
                                timeout=timeout, notify=notify)
 
+    def _read_and_update(self, dtype, timeout):
+        """Read the caproto PV with `dtype` and update state _args."""
+        command = self._caproto_pv.read(data_type=dtype, timeout=timeout)
+        info = _read_response_to_pyepics(
+            dtype, command, enum_strings=self._args['enum_strs']
+        )
+        self._args.update(**info)
+        return command, info
+
     @ensure_connection
     def get_ctrlvars(self, timeout=5, warn=True):
         "get control values for variable"
-        dtype = field_types['control'][self.type]
-        command = self._caproto_pv.read(data_type=dtype, timeout=timeout)
-        info = _parse_dbr_metadata(command.metadata)
-        value = command.data
-        info['raw_value'] = value
-        info['value'] = _scalarify(value, command.data_type, command.data_count)
-        self._args.update(**info)
+        _, info = self._read_and_update(
+            field_types['control'][self.type], timeout
+        )
         self.force_read_access_rights()
         return info
 
     @ensure_connection
     def get_timevars(self, timeout=5, warn=True):
         "get time values for variable"
-        dtype = field_types['time'][self.type]
-        command = self._caproto_pv.read(data_type=dtype, timeout=timeout)
-        info = _parse_dbr_metadata(command.metadata)
-        value = command.data
-        info['raw_value'] = value
-        info['value'] = _scalarify(value, command.data_type, command.data_count)
-        self._args.update(**info)
+        _, info = self._read_and_update(
+            field_types['time'][self.type], timeout
+        )
         return info
 
     @ensure_connection
@@ -603,8 +620,9 @@ class PV:
         To have user-defined code run when the PV value changes,
         use add_callback()
         """
-        info = _read_response_to_pyepics(self.typefull, command)
-
+        info = _read_response_to_pyepics(
+            self.typefull, command, enum_strings=self._args['enum_strs']
+        )
         self._args.update(**info)
         self.run_callbacks()
 
@@ -1035,7 +1053,8 @@ def caget_many(pvlist, as_string=False, count=None, as_numpy=True, timeout=5.0,
     def final_get(pv):
         full_type = pv.channel.native_data_type
         info = _read_response_to_pyepics(full_type=full_type,
-                                         command=readings[pv])
+                                         command=readings[pv],
+                                         enum_strings=self._args['enum_strs'])
         return _pyepics_get_value(value=info['raw_value'],
                                   string_value=info['char_value'],
                                   full_type=pv.channel.native_data_type,


### PR DESCRIPTION
Closes #682 

Could use some double-checking and verification, but local testing with `caproto.ioc_examples.enums` proved successful:

```python
In [1]: from caproto.threading.pyepics_compat import PV

In [2]: pv = PV('enum:mbbi')

In [3]: pv.char_value
Out[3]: 'one'

In [4]: pv.enum_strs
Out[4]: ('zero', 'one', '', 'three', 'four')
```