### PR TITLE
REF: rework PVSpec instantiation, allowing for use outside of PVGroups

### DIFF
--- a/caproto/ioc_examples/decay.py
+++ b/caproto/ioc_examples/decay.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
-from caproto.server import pvproperty, PVGroup, ioc_arg_parser, run
-import numpy as np
 import time
 from textwrap import dedent
+
+import numpy as np
+
+from caproto.server import PVGroup, ioc_arg_parser, pvproperty, run
 
 
 class Decay(PVGroup):
@@ -38,10 +40,10 @@ class Decay(PVGroup):
 
     readback = pvproperty(value=0, dtype=float, read_only=True,
                           name='I',
-                          mock_record='ai')
+                          record='ai')
 
     done = pvproperty(value=0, dtype=float, read_only=True,
-                      mock_record='ai')
+                      record='ai')
 
     setpoint = pvproperty(value=100, dtype=float, name='SP')
     K = pvproperty(value=10, dtype=float)

--- a/caproto/ioc_examples/no_pvproperty.py
+++ b/caproto/ioc_examples/no_pvproperty.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+from caproto.server import PVSpec, ioc_arg_parser, run
+
+
+async def put_handler(instance, value):
+    print(f"You wrote {value} to {instance.pvname}.")
+
+
+pv_a = PVSpec(
+    name="a",
+    value=1,
+    record='bi',
+    doc='An integer',
+    put=put_handler,
+)
+
+pv_b = PVSpec(
+    name="b",
+    value=2.0,
+    record='ai',
+    doc='A float',
+    put=put_handler,
+)
+
+pv_c = PVSpec(
+    name="c",
+    value=[1, 2, 3],
+    record='waveform',
+    doc='An array of integers',
+    put=put_handler,
+)
+
+
+pvdb = {
+    pvspec.name: pvspec.create(group=None)
+    for pvspec in [pv_a, pv_b, pv_c]
+}
+
+if __name__ == '__main__':
+    print("pvdb contents:", pvdb)
+
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix='pvspec:',
+        desc="A simple IOC without using the PVGroup-style class syntax."
+    )
+
+    # It's up to you to add on the prefix and support any other ioc_options:
+    pvdb = {
+        ioc_options['prefix'] + name: data
+        for name, data in pvdb.items()
+    }
+    run(pvdb, **run_options)

--- a/caproto/ioc_examples/records.py
+++ b/caproto/ioc_examples/records.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import caproto
-from caproto.server import pvproperty, PVGroup, ioc_arg_parser, run
+from caproto.server import PVGroup, ioc_arg_parser, pvproperty, run
 
 
 class RecordMockingIOC(PVGroup):
@@ -76,6 +76,9 @@ if __name__ == '__main__':
 
     print('Custom field specifications of A:', RecordMockingIOC.A.fields)
     print('Custom field specifications of B:', RecordMockingIOC.B.fields)
+    print('Custom field specifications of C:', RecordMockingIOC.C.fields)
+    print('Custom field specifications of D:', RecordMockingIOC.D.fields)
+    print('Custom field specifications of E:', RecordMockingIOC.E.fields)
 
     # Run IOC.
     run(ioc.pvdb, **run_options)

--- a/caproto/ioc_examples/too_clever/trigger_with_pc.py
+++ b/caproto/ioc_examples/too_clever/trigger_with_pc.py
@@ -2,7 +2,6 @@
 import contextvars
 import functools
 import random
-import sys
 from textwrap import dedent
 
 import numpy as np
@@ -111,12 +110,6 @@ class TriggeredIOC(PVGroup):
         await self.wait_time.write(sleep_time)
         await instance.async_lib.library.sleep(sleep_time)
         return sleep_time
-
-    fatal = pvproperty(value=0)
-
-    @fatal.putter
-    async def fatal(self, instance, val):
-        sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/caproto/ioc_examples/too_clever/trigger_with_pc.py
+++ b/caproto/ioc_examples/too_clever/trigger_with_pc.py
@@ -115,7 +115,7 @@ class TriggeredIOC(PVGroup):
     fatal = pvproperty(value=0)
 
     @fatal.putter
-    async def fatal(self, val):
+    async def fatal(self, instance, val):
         sys.exit(0)
 
 

--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -770,6 +770,10 @@ class pvproperty:
                                  f'the PV name has a "." in it: {name!r}')
             field_spec = FieldSpec(self, record_type=self.record_type)
 
+        if 'record' not in cls_kwargs and 'record_type' not in cls_kwargs:
+            if self.record_type is not None:
+                cls_kwargs['record'] = self.record_type
+
         self.field_spec = field_spec
         self.pvspec = PVSpec(
             get=get, put=put, startup=startup, shutdown=shutdown, name=name,

--- a/caproto/tests/test_records.py
+++ b/caproto/tests/test_records.py
@@ -1,13 +1,12 @@
 import pytest
-import caproto
+
+from caproto import AlarmSeverity, AlarmStatus, ChannelType
+from caproto.sync.client import read, write
+from caproto.threading.pyepics_compat import get_pv
 
 from .conftest import run_example_ioc
-from caproto.threading.pyepics_compat import get_pv
-from caproto.sync.client import read, write
-from caproto import AlarmSeverity, AlarmStatus, ChannelType
-from .test_threading_client import (
-    context as _context,
-    shared_broadcaster as _sb)
+from .test_threading_client import context as _context
+from .test_threading_client import shared_broadcaster as _sb
 
 context = _context
 shared_broadcaster = _sb
@@ -89,25 +88,3 @@ def test_alarms(request, prefix, sevr_target, sevr_value, context):
         ctrl_vars = PV.get_ctrlvars()
         assert ctrl_vars['status'] == a_status
         assert ctrl_vars['severity'] == a_sevr
-
-
-def test_mock_deprecation():
-    class TestIOC(caproto.server.PVGroup):
-        # Specify both `mock_record` and `record` -> ValueError
-        ai = caproto.server.pvproperty(value=0.0, mock_record='ai',
-                                       record='ai')
-
-    with pytest.raises(ValueError):
-        TestIOC(prefix='a')
-
-    class TestIOC(caproto.server.PVGroup):
-        ai = caproto.server.pvproperty(value=0.0, mock_record='ai')
-
-    ioc = TestIOC(prefix='a')
-    assert ioc.ai.record_type == 'ai'
-
-    class TestIOC(caproto.server.PVGroup):
-        ai = caproto.server.pvproperty(value=0.0, record='ai')
-
-    ioc = TestIOC(prefix='a')
-    assert ioc.ai.record_type == 'ai'


### PR DESCRIPTION
Background
==========
Users have commented that `PVGroup` is _convoluted and confusing_ (@mattgibbs and others).

While I don't disagree about the convoluted nature, I think the cleanliness of the resulting `PVGroup` classes should be reason enough to forgive the implementation details.  

For those that feel that way, the alternative at the moment is to use `ChannelData` directly. This is fairly barebones and doesn't support any of the nice hooks that `pvproperty` brought along with it.

`PVSpec` was initially written with the idea that `pvproperty`/`PVGroup` could be thrown away and the useful bits could be retained. That work had never been completed until now.

This PR
=======
This PR allows you to use `PVSpec` on its own in a sort of "expert" mode, but still having the putter/startup/scan/record hooks that `PVGroup` brings with it.

It removes a significant portion of the convoluted instantiation that confuses users, and I think provides a reasonable middle-ground between "use bare ChannelData and perhaps reinvent the wheel" and "use `PVGroup` that you can't understand/despise/etc"

Example
=======
What does this look like?

Single PV + record example, partial of the one included in the PR:
```python
#!/usr/bin/env python3
from caproto.server import PVSpec, ioc_arg_parser, run


async def put_handler(instance, value):
    print(f"You wrote {value} to {instance.pvname}.")


pv_a = PVSpec(
    name="a",
    value=1,
    record='longin',
    doc='An integer',
    put=put_handler,
)

if __name__ == '__main__':
    ioc_options, run_options = ioc_arg_parser(
        default_prefix='pvspec:',
        desc="A simple IOC without using the PVGroup-style class syntax."
    )

    # It's up to you to add on the prefix and support any other ioc_options:
    pvdb = {
        ioc_options['prefix'] + 'a': pv_a.create()
    }
    run(pvdb, **run_options)
```