### PR TITLE
DOC: preliminary v0.8.0 release notes

### DIFF
--- a/doc/source/release-notes.rst
+++ b/doc/source/release-notes.rst
@@ -2,6 +2,59 @@
 Release History
 ***************
 
+v0.8.0 (2021-03-??)
+===================
+
+Fixed
+-----
+
+- pyepics compatibility layer ``char_value`` and ``enum_strs`` handling with
+  ``PV`` instances and ``caget_many`` should now behave better.  (#732)
+- Windows compatibility has been improved, especially with respect to
+  the more recent ProactorEventLoop (#720, #707)
+- The environment variable ``CAPROTO_DEFAULT_TIMEOUT`` is no longer erroneously
+  interpreted as a string.  All clients should now mostly respect this value.
+  (#727)
+- Previously only either ``scan`` or ``startup`` hooks were allowed
+  per-``pvproperty``.  Both may be used simultaneously now. (#729)
+- Threading client ``SharedBroadcaster`` should no longer attempt
+  re-registration after it is disconnected.  (#732)
+- RecordFieldGroup subclasses may now customize common fields without
+  intefering with other classes. (#736)
+
+
+Added
+-----
+
+- An example indicating how to analyze IOCs response times for channel creation
+  was added in #725.
+- A ``value_write_hook`` is now supported when updating a value in records.
+  This means that if the user updates ``.VAL``, other fields will have the
+  chance to update their state. (#734)
+- Added preliminary support of the ``raw_value`` (``.RVAL``) field for bi, bo,
+  mbbi, and mbbo records.  (#734)
+
+
+Changed
+-------
+
+- The ``mock_record=`` keyword argument for ``pvproperty``, deprecated in
+  v0.5.0, has been removed.  Please change any remaining references to
+  ``record=`` when upgrading to v0.8.0.
+- Efforts have been made to allow ``PVSpec`` to be used in a standalone
+  fashion - i.e., without ``pvproperty``.  See the ``no_pvproperty`` IOC
+  example for further details.
+- asyncio-based transports have mostly been removed in favor of using a
+  higher-level API provided by asyncio. This should allow for more precise
+  and informative exception tracebacks.  This is now used for all asyncio
+  servers and clients supported by caproto. (#720, )
+- The method for generating record field ``PVGroup`` classes has been changed
+  to better split auto-generated code with user-customizable field-handling
+  code. (#734)
+- Improved hook method signature checker to include source code filename,
+  line number, and suggested signature.  (#736)
+
+
 v0.7.1 (2020-01-13)
 ===================
 

--- a/doc/source/release-notes.rst
+++ b/doc/source/release-notes.rst
@@ -21,6 +21,10 @@ Fixed
   re-registration after it is disconnected.  (#732)
 - RecordFieldGroup subclasses may now customize common fields without
   intefering with other classes. (#736)
+- Supports the numpy array interface to remove a significant ``O(n)``
+  bottleneck when pre-processing numpy arrays for ``ChannelByte`` instances.
+  To avoid an additional copy on immutable data, set ``value.flags.writeable``
+  to ``False`` when using compatible numpy arrays.  (#731)
 
 
 Added

--- a/doc/source/release-notes.rst
+++ b/doc/source/release-notes.rst
@@ -25,7 +25,8 @@ Fixed
   bottleneck when pre-processing numpy arrays for ``ChannelByte`` instances.
   To avoid an additional copy on immutable data, set ``value.flags.writeable``
   to ``False`` when using compatible numpy arrays.  (#731)
-
+- ``safe_getsockname`` was stashing references to sockets and not allowing
+  them to be garbage collected. (#739)
 
 Added
 -----
@@ -51,7 +52,7 @@ Changed
   ``record=`` when upgrading to v0.8.0.
 - Efforts have been made to allow ``PVSpec`` to be used in a standalone
   fashion - i.e., without ``pvproperty``.  See the ``no_pvproperty`` IOC
-  example for further details.
+  example (``ioc_examples/advanced``) for further details.
 - asyncio-based transports have mostly been removed in favor of using a
   higher-level API provided by asyncio. This should allow for more precise
   and informative exception tracebacks.  This is now used for all asyncio
@@ -61,8 +62,11 @@ Changed
   code. (#734)
 - Improved hook method signature checker to include source code filename,
   line number, and suggested signature.  (#736)
-- Reworked IOC documentation and corresponding examples.  Some have been
-  moved around a bit.
+- Reworked IOC documentation and corresponding examples.
+- Old and bad form example ``all_in_one`` moved to testing area.
+- Old and bad form example ``inline_style`` moved to testing area.
+- Example using ChannelData ``type_varieties`` moved to "advanced"
+
 
 v0.7.1 (2020-01-13)
 ===================

--- a/doc/source/release-notes.rst
+++ b/doc/source/release-notes.rst
@@ -37,7 +37,11 @@ Added
   chance to update their state. (#734)
 - Added preliminary support of the ``raw_value`` (``.RVAL``) field for bi, bo,
   mbbi, and mbbo records.  (#734)
-
+- Added ``sleep`` to AsyncLibraryLayer. (#739)
+- Added ``startup_hook`` to ``caproto.server.run()`` (with support in asyncio,
+  curio, trio).  By convention, consider using ``__ainit__`` for this hook.
+  (#739)
+- Added ``monitor`` helper to the asyncio client. (#739)
 
 Changed
 -------
@@ -51,13 +55,14 @@ Changed
 - asyncio-based transports have mostly been removed in favor of using a
   higher-level API provided by asyncio. This should allow for more precise
   and informative exception tracebacks.  This is now used for all asyncio
-  servers and clients supported by caproto. (#720, )
+  servers and clients supported by caproto. (#720)
 - The method for generating record field ``PVGroup`` classes has been changed
   to better split auto-generated code with user-customizable field-handling
   code. (#734)
 - Improved hook method signature checker to include source code filename,
   line number, and suggested signature.  (#736)
-
+- Reworked IOC documentation and corresponding examples.  Some have been
+  moved around a bit.
 
 v0.7.1 (2020-01-13)
 ===================

--- a/doc/source/release-notes.rst
+++ b/doc/source/release-notes.rst
@@ -65,8 +65,9 @@ v0.7.1 (2020-01-13)
 Fixed
 -----
 
-- For ``pvproperty``, avoid multiple passes of macro expansion, such that
-  ``{{`` is sufficient to escape an opening curly bracket.
+- For ``pvproperty``, avoid multiple passes of macro expansion, so
+  {% raw %}``{{``{% endraw %} is now sufficient to escape curly brackets in PV
+  names.
 - The server implementation will now catch when `socket.recv` raises `OSError`.
 - Broken entrypoints have been fixed for the pathological examples,
   ``defaultdict_server`` and ``spoof_beamline``.


### PR DESCRIPTION
Included unmerged PRs which I've marked in the v0.8.0 milestone. Those will be merged prior to this PR, before a tag and release.
