### PR TITLE
CI: add basic GitHub actions for Windows and macOS testing

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,4 +1,4 @@
-name: Python package
+name: caproto-actions
 
 on: [push, pull_request]
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -22,3 +22,25 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8
         pip install -r requirements-test.txt
+    - name: Lint with flake8
+      run: |
+        flake8 caproto
+    - name: Test with pytest
+      env:
+        CAPROTO_SKIP_MOTORSIM_TESTS: 1
+      run: |
+        coverage run --parallel-mode run_tests.py --timeout=100 -v --junitxml=junit/test-results.xml
+    - name: Coverage report
+      run: |
+        coverage combine --append
+        coverage report -m
+    - name: Leak report
+      run: |
+        python caproto/tests/view_leaks.py junit/test-results.xml
+
+    - name: Upload Unit Test Results
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: Unit Test Results (Python ${{ matrix.python-version }})
+        path: junit/test-results.xml

--- a/caproto/asyncio/client.py
+++ b/caproto/asyncio/client.py
@@ -1301,15 +1301,15 @@ class VirtualCircuitManager:
 
     async def disconnect(self):
         await self._disconnected()
+
+        self.log.debug("Shutting down ThreadPoolExecutor for user callbacks",
+                       extra={'their_address': self.circuit.address})
+        await self.user_callback_executor.shutdown()
+
         if self.transport is None:
             return
 
         self.log.debug('Circuit manager disconnected by user')
-
-        tags = {'their_address': self.circuit.address}
-        self.log.debug("Shutting down ThreadPoolExecutor for user callbacks",
-                       extra=tags)
-        await self.user_callback_executor.shutdown()
 
 
 def ensure_connected(func):

--- a/caproto/asyncio/client.py
+++ b/caproto/asyncio/client.py
@@ -1300,7 +1300,7 @@ class VirtualCircuitManager:
             self.log.debug('Not attempting reconnection', extra=tags)
 
     async def disconnect(self):
-        await self._disconnected()
+        await self._disconnected(reconnect=False)
 
         self.log.debug("Shutting down ThreadPoolExecutor for user callbacks",
                        extra={'their_address': self.circuit.address})

--- a/caproto/curio/server.py
+++ b/caproto/curio/server.py
@@ -6,6 +6,7 @@ from curio import socket
 
 import caproto as ca
 
+from .._utils import safe_getsockname
 from ..server import AsyncLibraryLayer
 from ..server.common import Context as _Context
 from ..server.common import VirtualCircuit as _VirtualCircuit
@@ -130,13 +131,15 @@ class Context(_Context):
     async def broadcaster_udp_server_loop(self):
         for interface in self.interfaces:
             udp_sock = ca.bcast_socket(socket)
-            self.broadcaster.server_addresses.append(udp_sock.getsockname())
             try:
                 udp_sock.bind((interface, self.ca_server_port))
             except Exception:
                 self.log.exception('UDP bind failure on interface %r:%d',
                                    interface, self.ca_server_port)
                 raise
+            self.broadcaster.server_addresses.append(
+                safe_getsockname(udp_sock)
+            )
             self.log.debug('UDP socket bound on %s:%d', interface,
                            self.ca_server_port)
             self.udp_socks[interface] = udp_sock

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -118,6 +118,19 @@ def search(pv_name, udp_sock, timeout, *, max_retries=2):
         while True:
             try:
                 bytes_received, address = udp_sock.recvfrom(ca.MAX_UDP_RECV)
+            except ConnectionResetError as ex:
+                # Win32: "On a UDP-datagram socket this error indicates a
+                # previous send operation resulted in an ICMP Port Unreachable
+                # message."
+                #
+                # https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom
+                #
+                # Despite the above, this does not *appear* to be fatal;
+                # sometimes the second try will work.
+                logger.debug('Connection reset, retrying: %s', ex)
+                check_timeout()
+                time.sleep(0.1)
+                continue
             except socket.timeout:
                 check_timeout()
                 continue

--- a/caproto/tests/test_doc_utils.py
+++ b/caproto/tests/test_doc_utils.py
@@ -4,7 +4,6 @@ import caproto.docs.utils
 import caproto.ioc_examples.chirp
 import caproto.ioc_examples.custom_write
 import caproto.ioc_examples.decay
-import caproto.ioc_examples.io_interrupt
 import caproto.ioc_examples.macros
 import caproto.ioc_examples.mini_beamline
 import caproto.ioc_examples.pathological.reading_counter
@@ -32,7 +31,6 @@ from . import ioc_all_in_one, ioc_inline_style
         caproto.ioc_examples.thermo_sim.Thermo,
         caproto.ioc_examples.custom_write.CustomWrite,
         ioc_inline_style.InlineStyleIOC,
-        caproto.ioc_examples.io_interrupt.IOInterruptIOC,
         caproto.ioc_examples.macros.MacroifiedNames,
         caproto.ioc_examples.mini_beamline.MiniBeamline,
         caproto.ioc_examples.random_walk.RandomWalkIOC,

--- a/caproto/tests/view_leaks.py
+++ b/caproto/tests/view_leaks.py
@@ -8,7 +8,9 @@ Usage:
 """
 
 import ast
+import os
 import sys
+import traceback
 import xml.etree.ElementTree as ET
 
 DEFAULT_KEYS = ['total_threads', 'dangling_threads', 'total_sockets',
@@ -60,7 +62,6 @@ def parse_properties(fn):
         try:
             name, properties = get_properties(test_case)
         except Exception:
-            print('Failed: {test_case}')
             continue
 
         all_properties[name] = properties
@@ -77,12 +78,18 @@ def parse_properties(fn):
 
 
 if __name__ == '__main__':
-    properties = parse_properties(sys.argv[1])
+    fn = sys.argv[1]
+    if not os.path.exists(fn):
+        print(f"ERROR: File does not exist: {fn}")
+        sys.exit(0)
 
     try:
+        properties = parse_properties(fn)
         import pandas as pd
-    except ImportError:
-        ...
-    else:
-        df = pd.DataFrame(properties).transpose()
-        print(df)
+    except Exception:
+        print("Error occurred while looking for leaks :(")
+        traceback.print_exc()
+        sys.exit(0)
+
+    df = pd.DataFrame(properties).transpose()
+    print(df)

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1538,15 +1538,16 @@ class VirtualCircuitManager:
         else:
             self.log.debug('Not attempting reconnection', extra=tags)
 
-        self.log.debug("Shutting down ThreadPoolExecutor for user callbacks", extra=tags)
-        self.user_callback_executor.shutdown()
-
     def disconnect(self):
         self._disconnected()
         if self.socket is None:
             return
 
         self.log.debug('Circuit manager disconnected by user')
+        tags = {'their_address': self.circuit.address}
+        self.log.debug("Shutting down ThreadPoolExecutor for user callbacks",
+                       extra=tags)
+        self.user_callback_executor.shutdown()
 
     def __del__(self):
         try:

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1539,7 +1539,7 @@ class VirtualCircuitManager:
             self.log.debug('Not attempting reconnection', extra=tags)
 
     def disconnect(self):
-        self._disconnected()
+        self._disconnected(reconnect=False)
 
         self.log.debug("Shutting down ThreadPoolExecutor for user callbacks",
                        extra={'their_address': self.circuit.address})

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1540,14 +1540,15 @@ class VirtualCircuitManager:
 
     def disconnect(self):
         self._disconnected()
+
+        self.log.debug("Shutting down ThreadPoolExecutor for user callbacks",
+                       extra={'their_address': self.circuit.address})
+        self.user_callback_executor.shutdown()
+
         if self.socket is None:
             return
 
         self.log.debug('Circuit manager disconnected by user')
-        tags = {'their_address': self.circuit.address}
-        self.log.debug("Shutting down ThreadPoolExecutor for user callbacks",
-                       extra=tags)
-        self.user_callback_executor.shutdown()
 
     def __del__(self):
         try:

--- a/caproto/trio/server.py
+++ b/caproto/trio/server.py
@@ -184,14 +184,15 @@ class Context(_Context):
     async def broadcaster_udp_server_loop(self, task_status):
         for interface in self.interfaces:
             udp_sock = ca.bcast_socket(socket)
-            self.broadcaster.server_addresses.append(
-                safe_getsockname(udp_sock))
             try:
                 await udp_sock.bind((interface, self.ca_server_port))
             except Exception:
                 self.log.exception('UDP bind failure on interface %r',
                                    interface)
                 raise
+            self.broadcaster.server_addresses.append(
+                safe_getsockname(udp_sock)
+            )
             self.log.debug('UDP socket bound on %s:%d', interface,
                            self.ca_server_port)
             self.udp_socks[interface] = udp_sock


### PR DESCRIPTION
Notably these do not rely on `conda` and do **not** test with their respective platform's `softIoc` executable like the azure pipelines tests do for Linux. So if they pass, at least caproto itself is internally consistent, but untested with respect to epics-base servers.

Also includes some fixes found along the way:

Closes #747 
Closes #746 
Closes #745 
Closes #748

Long-standing awful test "test_multithreaded_many_write" has been improved here, too. (As much as I like the concept behind that test suite, it's pretty poorly written...)

(Apologies for starting Actions as a push to master; I'm new to it and not sure if there was a way around it. Regardless, this PR should give a good initial first test suite runner)