### PR TITLE
CI: add codecov uploading back

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -46,3 +46,6 @@ jobs:
       with:
         name: Unit Test Results (Python ${{ matrix.python-version }})
         path: junit/test-results.xml
+
+    - name: Upload code coverage
+      uses: codecov/codecov-action@v1


### PR DESCRIPTION
We dodged the codecov breach because we removed travis in a7e4f6e81be776002c6fa1a2eb0f32b72fc638de and did not add the uploading back to GH actions.

This restores the uploading.