### PR TITLE
ENH/REF: Support raw timestamps in ChannelData

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.6.1
+    rev: 5.8.0
     hooks:
     -   id: isort
 

--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -4,7 +4,6 @@
 # data as a certain type, and they push updates into queues registered by a
 # higher-level server.
 import copy
-import datetime
 import time
 import weakref
 from collections import defaultdict, namedtuple
@@ -919,11 +918,6 @@ class ChannelData:
 
         if publish:
             await self.publish(SubscriptionType.DBE_PROPERTY)
-
-    @property
-    def datetime(self) -> datetime.datetime:
-        """Current timestamp as a ``datetime`` instance."""
-        return datetime.datetime.fromtimestamp(self.timestamp)
 
     @property
     def timestamp(self) -> float:

--- a/caproto/_dbr.py
+++ b/caproto/_dbr.py
@@ -316,7 +316,7 @@ class TimeStamp(DbrTypeBase):
 
     def as_datetime(self):
         'Timestamp as a datetime'
-        return datetime.datetime.utcfromtimestamp(self.timestamp)
+        return datetime.datetime.fromtimestamp(self.timestamp)
 
     def __iter__(self):
         return iter((self.secondsSinceEpoch, self.nanoSeconds))

--- a/caproto/_dbr.py
+++ b/caproto/_dbr.py
@@ -5,14 +5,16 @@
 # The organizational code, making use of Enum, comes from pypvasync by Kenneth
 # Lauer.
 
+import collections
 import ctypes
 import datetime
-import collections
 import logging
+import numbers
+import time
 from enum import IntEnum, IntFlag
-from ._constants import (EPICS2UNIX_EPOCH, EPICS_EPOCH, MAX_STRING_SIZE,
-                         MAX_UNITS_SIZE, MAX_ENUM_STRING_SIZE, MAX_ENUM_STATES)
 
+from ._constants import (EPICS2UNIX_EPOCH, EPICS_EPOCH, MAX_ENUM_STATES,
+                         MAX_ENUM_STRING_SIZE, MAX_STRING_SIZE, MAX_UNITS_SIZE)
 
 __all__ = ('AccessRights', 'AlarmSeverity', 'AlarmStatus', 'ConnStatus',
            'TimeStamp', 'ChannelType', 'SubscriptionType', 'DbrStringArray',
@@ -275,18 +277,52 @@ class TimeStamp(DbrTypeBase):
 
     @property
     def timestamp(self):
-        'Timestamp as UNIX timestamp (seconds)'
+        """Timestamp as a UNIX timestamp (seconds)."""
         return epics_timestamp_to_unix(self.secondsSinceEpoch,
                                        self.nanoSeconds)
 
     @classmethod
     def from_unix_timestamp(cls, timestamp):
+        """Create a ``TimeStamp`` from a UNIX timestamp."""
         sec, nano = timestamp_to_epics(timestamp)
+        return cls(secondsSinceEpoch=sec, nanoSeconds=nano)
+
+    @classmethod
+    def now(cls):
+        """Get a new ``TimeStamp`` representing 'now' (``time.time()``)"""
+        return cls.from_unix_timestamp(time.time())
+
+    @classmethod
+    def from_flexible_value(cls, timestamp):
+        """
+        Flexible TimeStamp conversion.
+
+        Parameters
+        ----------
+        timestamp : float, int, TimeStamp, or 2-tuple
+            Accepts either a number (UNIX timestamp), a TimeStamp instance, or
+            a tuple of (seconds, nanoseconds).
+
+        Returns
+        -------
+        TimeStamp
+            The EPICS-compatible timestamp.
+        """
+        if isinstance(timestamp, numbers.Real):
+            sec, nano = timestamp_to_epics(timestamp)
+        else:
+            sec, nano = tuple(timestamp)
         return cls(secondsSinceEpoch=sec, nanoSeconds=nano)
 
     def as_datetime(self):
         'Timestamp as a datetime'
         return datetime.datetime.utcfromtimestamp(self.timestamp)
+
+    def __iter__(self):
+        return iter((self.secondsSinceEpoch, self.nanoSeconds))
+
+    def __eq__(self, other):
+        return tuple(self) == tuple(other)
 
 
 class TimeTypeBase(DbrTypeBase):
@@ -1115,7 +1151,7 @@ def epics_timestamp_to_unix(seconds_since_epoch, nano_seconds):
 
 def timestamp_to_epics(ts):
     '''Python timestamp from EPICS TimeStamp structure'''
-    if isinstance(ts, float):
+    if isinstance(ts, numbers.Real):
         ts = datetime.datetime.utcfromtimestamp(ts)
     dt = ts - EPICS_EPOCH
     return int(dt.total_seconds()), int(dt.microseconds * 1e3)

--- a/caproto/ioc_examples/advanced/raw_timestamp.py
+++ b/caproto/ioc_examples/advanced/raw_timestamp.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+from textwrap import dedent
+
+import caproto as ca
+from caproto.server import PVGroup, ioc_arg_parser, pvproperty, run
+
+
+class TimestampIOC(PVGroup):
+    """
+    An IOC that shows how to control writing exact EPICS timestamps, with
+    integral seconds and nanoseconds.
+
+    Note that these raw timestamps use the EPICS epoch, and not the unix one.
+
+    Scalar PVs
+    ----------
+    update (int)
+        A trigger to update ``value``.
+
+    value (int)
+        This is updated after a put to ``update``.
+    """
+    update = pvproperty(
+        value=0,
+        doc='Trigger to update ``value``',
+    )
+    value = pvproperty(
+        value=1,
+        doc='Value with custom timestamp, updated after a put to ``update``',
+        read_only=True,
+    )
+
+    @update.putter
+    async def update(self, instance, value):
+        # I insist my timestamp is correct! This is a **raw** EPICS timestamp
+        # that uses the EPICS epoch and not the unix one.
+        timestamp = ca.TimeStamp.now()
+        timestamp.nanoSeconds = 2 ** 16 - 1
+        await self.value.write(value, timestamp=timestamp)
+
+
+if __name__ == '__main__':
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix='raw:timestamp:',
+        desc=dedent(TimestampIOC.__doc__))
+    ioc = TimestampIOC(**ioc_options)
+    run(ioc.pvdb, **run_options)

--- a/caproto/tests/conftest.py
+++ b/caproto/tests/conftest.py
@@ -252,6 +252,11 @@ ioc_example_to_info = {
         kwargs={},
         marks=[],
     ),
+    "caproto.ioc_examples.advanced.raw_timestamp": dict(
+        group_cls='TimestampIOC',
+        kwargs={},
+        marks=[],
+    ),
 }
 
 

--- a/caproto/tests/test_examples.py
+++ b/caproto/tests/test_examples.py
@@ -174,6 +174,20 @@ def test_pvproperty_string_array(request, ioc_name):
     assert sync.read(array_string_pv).data == [b'array', b'of', b'strings']
 
 
+def test_raw_timestamp(request):
+    info = conftest.run_example_ioc_by_name(
+        "caproto.ioc_examples.advanced.raw_timestamp",
+        request=request
+    )
+    print("Triggering an update of value.")
+    sync.write(f'{info.prefix}update', 1, notify=True)
+    time.sleep(0.5)
+    print("Reading back ``value``...")
+    data = sync.read(f'{info.prefix}value', data_type='time')
+    print(f"data={data} stamp={data.metadata.stamp}")
+    assert data.metadata.stamp.nanoSeconds == 2 ** 16 - 1
+
+
 @conftest.parametrize_iocs(
     "caproto.ioc_examples.enums"
 )

--- a/caproto/tests/test_timestamp.py
+++ b/caproto/tests/test_timestamp.py
@@ -1,0 +1,44 @@
+import time
+
+import caproto as ca
+
+
+def test_timestamp_now():
+    # There's more built into this than it seems:
+    # 1. time.time() -> EPICS timestamp
+    # 2. EPICS timestamp -> POSIX timestamp
+    # 3. And a relaxed check that we're within 1 second of `time.time()`
+    #    on the way out
+    now = ca.TimeStamp.now()
+    assert abs(time.time() - now.timestamp) < 1.
+
+
+def test_timestamp_basic():
+    intval = ca.ChannelInteger(value=5)
+    # Try the datetime interface:
+    assert abs(intval.datetime.timestamp() - intval.timestamp) < 1.
+
+
+def test_timestamp_raw_access():
+    intval = ca.ChannelInteger(value=5)
+    # Try the datetime interface:
+    intval.epics_timestamp.secondsSinceEpoch
+    intval.epics_timestamp.nanoSeconds
+
+
+def test_timestamp_flexible():
+    t0 = time.time()
+    ts = ca.TimeStamp.from_flexible_value(t0)
+    assert abs(ts.timestamp - t0) < 1e-3
+
+
+def test_timestamp_flexible_epics_tuple():
+    ts = ca.TimeStamp.from_flexible_value((1, 2))
+    assert ts.secondsSinceEpoch == 1
+    assert ts.nanoSeconds == 2
+
+
+def test_timestamp_flexible_epics_copy():
+    ts = ca.TimeStamp.from_flexible_value(ca.TimeStamp(2, 3))
+    assert ts.secondsSinceEpoch == 2
+    assert ts.nanoSeconds == 3

--- a/caproto/tests/test_timestamp.py
+++ b/caproto/tests/test_timestamp.py
@@ -16,7 +16,8 @@ def test_timestamp_now():
 def test_timestamp_basic():
     intval = ca.ChannelInteger(value=5)
     # Try the datetime interface:
-    assert abs(intval.datetime.timestamp() - intval.timestamp) < 1.
+    from_dt = intval.epics_timestamp.as_datetime().timestamp()
+    assert abs(from_dt - intval.timestamp) < 1.
 
 
 def test_timestamp_raw_access():


### PR DESCRIPTION
Closes #770 

Hopefully doesn't break anything. `ChannelData._data[*]` is not intended to be modified by the user, and this PR uses that to its advantage.

I don't particularly like the class `TimeStamp`, but it _is_ already accessible to the user. Added a few convenience methods to it accordingly.

Also - more docstrings and improved ones, based on the `timestamp` change.