### PR TITLE
FIX: pvproperty broken when decorating methods with docstring.

### DIFF
--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -1048,7 +1048,7 @@ class pvproperty:
         if get.__doc__:
             if self.__doc__ is None:
                 self.__doc__ = get.__doc__
-            if 'doc' not in self.spec_kw:
+            if 'doc' not in spec_kw:
                 spec_kw['doc'] = get.__doc__
 
         self.pvspec = PVSpec(get, put, startup, shutdown, **spec_kw)


### PR DESCRIPTION
Just a one-liner. There's a small typo on `pvproperty.__call__` that prevents this scenario from working.

Resolves #777