### PR TITLE
Updated method get_data_class() in PVSpec so that type maps are correct for read only

### DIFF
--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -542,7 +542,7 @@ class PVSpec(namedtuple('PVSpec',
         """
         if group is None:
             type_map = pvspec_type_map
-            type_map_read_only = pvspec_type_map
+            type_map_read_only = pvspec_type_map_read_only
         else:
             type_map = group.type_map
             type_map_read_only = group.type_map_read_only


### PR DESCRIPTION
Fix for issue described in: https://github.com/caproto/caproto/issues/783 .