### PR TITLE
Use RotatingFileManager when restoring autosave

### DIFF
--- a/caproto/server/autosave.py
+++ b/caproto/server/autosave.py
@@ -214,6 +214,7 @@ class AutosaveHelper(PVGroup):
         if file_manager is None:
             file_manager = RotatingFileManager(self.filename)
         self.file_manager = file_manager
+        self.filename = self.file_manager.filename
 
     @autosave_hook.startup
     async def autosave_hook(self, instance, async_lib):


### PR DESCRIPTION
If a `RotatingFileManager` is provided when setting up an `AutosaveHelper` it attempts to use the default filename, `autosave.json`, instead of the filename provided by the `RotatingFileManager` when restoring the autosaved values. This pull request changes that behaviour so the AutoSaveHelper instead loads the filename as specified within its `RotatingFileManager`.