### PR TITLE
fabricate channels for FileNumber and Compression in spoof-beamline

### DIFF
--- a/caproto/ioc_examples/pathological/spoof_beamline.py
+++ b/caproto/ioc_examples/pathological/spoof_beamline.py
@@ -72,6 +72,10 @@ def fabricate_channel(key):
     elif ('file' in key.lower() and 'number' not in key.lower() and
           'mode' not in key.lower()):
         return ChannelChar(value='a' * 250)
+    elif ('filenumber' in key.lower()):
+        return ChannelInteger(value=0)
+    elif 'Compression' in key:
+        return ChannelEnum(value=0, enum_strings=['None', 'N-bit', 'szip', 'zlib', 'blosc'])
     return ChannelDouble(value=0.0)
 
 


### PR DESCRIPTION
This PR proposes two additional fabricated channels for spoof-beamline: FileNumber and Compression.