### PR TITLE
FIX/MNT: cleanups and attempts at addressing windows instability

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,7 @@ jobs:
       env:
         CAPROTO_SKIP_MOTORSIM_TESTS: 1
       run: |
-        coverage run --parallel-mode run_tests.py --timeout=100 -v --junitxml=junit/test-results.xml
+        coverage run --parallel-mode run_tests.py --timeout=100 --junitxml=junit/test-results.xml
 
     - name: Coverage report
       run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "caproto/tests/reference-dbd"]
 	path = caproto/tests/reference-dbd
-	url = git://github.com/caproto/reference-dbd.git
+	url = https://github.com/caproto/reference-dbd.git

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ jobs:
 
 - job: 'Test'
   pool:
-    vmImage: 'Ubuntu 16.04'
+    vmImage: 'ubuntu-18.04'
   strategy:
     matrix:
       Python 3.7:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,8 @@ jobs:
         python.version: '3.8'
       Python 3.9:
         python.version: '3.9'
+      Python 3.10:
+        python.version: '3.10'
 
   steps:
   - task: UsePythonVersion@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,8 +7,6 @@ jobs:
     vmImage: 'Ubuntu 16.04'
   strategy:
     matrix:
-      Python 3.6:
-        python.version: '3.6'
       Python 3.7:
         python.version: '3.7'
       Python 3.8:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,7 +83,7 @@ jobs:
 
   - bash: |
       source $HOME/azure_env.sh
-      coverage run --parallel-mode run_tests.py --timeout=100 -v --junitxml=junit/test-results.xml
+      coverage run --parallel-mode run_tests.py --timeout=100 --junitxml=junit/test-results.xml
     displayName: 'pytest'
 
   - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,8 +7,6 @@ jobs:
     vmImage: 'ubuntu-18.04'
   strategy:
     matrix:
-      Python 3.7:
-        python.version: '3.7'
       Python 3.8:
         python.version: '3.8'
       Python 3.9:

--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -386,7 +386,7 @@ class ChannelData:
             'string_encoding': self.string_encoding,
             'reported_record_type': self.reported_record_type,
             'max_length': self._max_length,
-            **self._data
+            **copy.deepcopy(self._data)
         }
         return ((), kwargs)
 

--- a/caproto/_utils.py
+++ b/caproto/_utils.py
@@ -337,7 +337,7 @@ def get_manually_specified_client_addresses(
         *, protocol=Protocol.ChannelAccess):
     '''Get a list of addresses, as configured by EPICS_CA_ADDR_LIST'''
     return _split_address_list(
-        get_environment_variables()[f'EPICS_{protocol}_ADDR_LIST'])
+        get_environment_variables()[f'EPICS_{protocol.value}_ADDR_LIST'])
 
 
 def get_address_list(*, protocol=Protocol.ChannelAccess):
@@ -351,7 +351,7 @@ def get_address_list(*, protocol=Protocol.ChannelAccess):
 
     env = get_environment_variables()
     addresses = get_manually_specified_client_addresses(protocol=protocol)
-    auto_addr_list = env[f'EPICS_{protocol}_AUTO_ADDR_LIST']
+    auto_addr_list = env[f'EPICS_{protocol.value}_AUTO_ADDR_LIST']
 
     if addresses and auto_addr_list.lower() != 'yes':
         # Custom address list specified, and EPICS_CA_AUTO_ADDR_LIST=NO

--- a/caproto/_utils.py
+++ b/caproto/_utils.py
@@ -55,7 +55,6 @@ __all__ = (  # noqa F822
     'ensure_bytes',
     'random_ports',
     'bcast_socket',
-    'buffer_list_slice',
     'parse_record_field',
     'parse_channel_filter',
     'batch_requests',
@@ -631,26 +630,6 @@ if 'pypy' in sys.implementation.name:
 else:
     def _cast_buffers_to_byte(buffers):
         return tuple(memoryview(b).cast('b') for b in buffers)
-
-
-def buffer_list_slice(*buffers, offset):
-    'Helper function for slicing a list of buffers'
-    if offset < 0:
-        raise CaprotoValueError('Negative offset')
-
-    buffers = _cast_buffers_to_byte(buffers)
-
-    start = 0
-    for bufidx, buf in enumerate(buffers):
-        end = start + len(buf)
-        if offset < end:
-            offset -= start
-            return (buf[offset:], ) + buffers[bufidx + 1:]
-
-        start = end
-
-    raise CaprotoValueError('Offset beyond end of buffers '
-                            '(total length={} offset={})'.format(end, offset))
 
 
 RecordAndField = namedtuple('RecordAndField',

--- a/caproto/_windows_compat.py
+++ b/caproto/_windows_compat.py
@@ -1,9 +1,5 @@
 import os
 import sys
-import socket
-import selectors
-import functools
-
 
 __all__ = ()
 
@@ -12,47 +8,11 @@ if sys.platform != 'win32':
     raise ImportError('Do not import this outside of win32')
 
 
-def _sendmsg(self, buffers, ancdata=None, flags=None, address=None):
-    # No support for sendmsg on win32
-    # Additionally, sending individual buffers leads to failures, so here we
-    # combine all of them (TODO performance)
-    to_send = b''.join(buffers)
-    self.sendall(to_send)
-    return len(to_send)
-
-
-# EVIL_WIN32_TODO: i know this is evil
-if not hasattr(socket.socket, 'sendmsg'):
-    socket.socket.sendmsg = _sendmsg
-
-
 try:
-    import curio
+    import curio  # noqa: F401
 except ImportError:
     ...
 else:
-    # Monkey patch curio.run to use a Windows-compatible selector
-    # See note here: https://github.com/dabeaz/curio/issues/75
-    def windows_selector():
-        dummy_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-
-        # Windows fails with OSError when select([], [], []) is called - that
-        # is, with three empty lists. So, add a socket that will never get used
-        # here:
-        selector = selectors.DefaultSelector()
-        selector.register(dummy_socket, selectors.EVENT_READ)
-        return selector
-
-    @functools.wraps(curio.run)
-    def curio_run(*args, selector=None, **kwargs):
-        if selector is None:
-            selector = windows_selector()
-        return curio._pre_caproto_run(*args, selector=selector, **kwargs)
-
-    if not hasattr(curio, '_pre_caproto_run'):
-        curio._pre_caproto_run = curio.run
-        curio.run = curio_run
-
-    if not hasattr(os, 'set_blocking'):
+    if not hasattr(os, "set_blocking"):
         # EVIL_WIN32_TODO_HACK: curio set_blocking monkeypatch
         os.set_blocking = lambda file_no, blocking: None

--- a/caproto/asyncio/client.py
+++ b/caproto/asyncio/client.py
@@ -1068,7 +1068,7 @@ class VirtualCircuitManager:
         # TODO: can we trust asyncio to get this all out the door 😱
         # and not use our blocking wrapper?
         for buff in buffers_to_send:
-            self.transport.writer.write(buff.tobytes())
+            self.transport.writer.write(bytes(buff))
 
         await self.transport.writer.drain()
 

--- a/caproto/asyncio/client.py
+++ b/caproto/asyncio/client.py
@@ -993,11 +993,6 @@ class VirtualCircuitManager:
         self.transport = _TransportWrapper(reader, writer)
         self._tasks.create(self._transport_receive_loop(self.transport))
 
-        # this is done by default from 3.6+
-        self.transport.sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-        # This is required because of `sock_sendall`
-        self.transport.sock.setblocking(False)
-
         self.circuit.our_address = self.transport.getsockname()
 
         # This dict is passed to the loggers.

--- a/caproto/asyncio/client.py
+++ b/caproto/asyncio/client.py
@@ -1067,7 +1067,10 @@ class VirtualCircuitManager:
         buffers_to_send = self.circuit.send(*commands, extra=extra)
         # TODO: can we trust asyncio to get this all out the door 😱
         # and not use our blocking wrapper?
-        await self.transport.send(b''.join(buffers_to_send))
+        for buff in buffers_to_send:
+            self.transport.writer.write(buff)
+
+        await self.transport.writer.drain()
 
     async def events_off(self):
         """

--- a/caproto/asyncio/client.py
+++ b/caproto/asyncio/client.py
@@ -1068,7 +1068,8 @@ class VirtualCircuitManager:
         # TODO: can we trust asyncio to get this all out the door 😱
         # and not use our blocking wrapper?
         for buff in buffers_to_send:
-            self.transport.writer.write(buff)
+            if len(buff) > 0:
+                self.transport.writer.write(buff)
 
         await self.transport.writer.drain()
 

--- a/caproto/asyncio/client.py
+++ b/caproto/asyncio/client.py
@@ -215,6 +215,17 @@ class SharedBroadcaster:
         queues = collections.defaultdict(list)
         while True:
             _, bytes_received, address = await self.receive_queue.async_get()
+            if isinstance(bytes_received, ConnectionResetError):
+                # Win32: "On a UDP-datagram socket this error indicates a
+                # previous send operation resulted in an ICMP Port Unreachable
+                # message."
+                #
+                # https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom
+                self.log.debug(
+                    "Broadcaster received ConnectionResetError",
+                    exc_info=bytes_received
+                )
+                continue
             if isinstance(bytes_received, Exception):
                 self.log.exception('Broadcaster receive exception',
                                    exc_info=bytes_received)

--- a/caproto/asyncio/client.py
+++ b/caproto/asyncio/client.py
@@ -1068,8 +1068,7 @@ class VirtualCircuitManager:
         # TODO: can we trust asyncio to get this all out the door 😱
         # and not use our blocking wrapper?
         for buff in buffers_to_send:
-            if len(buff) > 0:
-                self.transport.writer.write(buff)
+            self.transport.writer.write(buff.tobytes())
 
         await self.transport.writer.drain()
 

--- a/caproto/asyncio/server.py
+++ b/caproto/asyncio/server.py
@@ -78,6 +78,17 @@ class VirtualCircuit(_VirtualCircuit):
         self.tasks.create(self.command_queue_loop())
         self._sub_task = self.tasks.create(self.subscription_queue_loop())
 
+    async def command_queue_loop(self):
+        loop = asyncio.get_running_loop()
+        try:
+            return await super().command_queue_loop()
+        except RuntimeError:
+            if loop.is_closed():
+                # Intended to catch: RuntimeError: Event loop is closed
+                return
+            # And raise for everything else
+            raise
+
     async def _start_write_task(self, handle_write):
         self.tasks.create(handle_write())
 

--- a/caproto/asyncio/server.py
+++ b/caproto/asyncio/server.py
@@ -261,8 +261,7 @@ async def start_server(pvdb, *, interfaces=None, log_pv_names=False,
                        startup_hook=None):
     '''Start an asyncio server with a given PV database'''
     ctx = Context(pvdb, interfaces)
-    ret = await ctx.run(log_pv_names=log_pv_names, startup_hook=startup_hook)
-    return ret
+    return await ctx.run(log_pv_names=log_pv_names, startup_hook=startup_hook)
 
 
 def run(pvdb, *, interfaces=None, log_pv_names=False, startup_hook=None):
@@ -285,14 +284,14 @@ def run(pvdb, *, interfaces=None, log_pv_names=False, startup_hook=None):
     startup_hook : coroutine, optional
         Hook to call at startup with the ``async_lib`` shim.
     """
-    loop = asyncio.get_event_loop()
-    task = loop.create_task(
-        start_server(pvdb, interfaces=interfaces, log_pv_names=log_pv_names,
-                     startup_hook=startup_hook))
     try:
-        loop.run_until_complete(task)
+        asyncio.run(
+            start_server(
+                pvdb,
+                interfaces=interfaces,
+                log_pv_names=log_pv_names,
+                startup_hook=startup_hook,
+            )
+        )
     except KeyboardInterrupt:
         ...
-    finally:
-        task.cancel()
-        loop.run_until_complete(task)

--- a/caproto/asyncio/utils.py
+++ b/caproto/asyncio/utils.py
@@ -67,22 +67,20 @@ class _TransportWrapper:
 
     Parameters
     ----------
-    sock : socket.socket
-        The socket.
+    reader : ??
+
+    writer : ??
 
     loop : asyncio.AbstractEventLoop, optional
         The event loop.
     """
 
-    sock: socket.socket
     loop: asyncio.AbstractEventLoop
     transport: asyncio.BaseTransport
 
     def __init__(self, reader, writer, loop=None):
         self.reader = reader
         self.writer = writer
-        self.loop = loop or get_running_loop()
-        self.sock = self.writer.get_extra_info('socket')
         self.lock = asyncio.Lock()
 
     def getsockname(self):

--- a/caproto/asyncio/utils.py
+++ b/caproto/asyncio/utils.py
@@ -258,18 +258,6 @@ def _create_udp_socket():
     return sock
 
 
-if sys.version_info < (3, 7):
-    # python <= 3.6 compatibility
-    def get_running_loop():
-        return asyncio.get_event_loop()
-
-    def run(coro, debug=False):
-        return get_running_loop().run_until_complete(coro)
-
-    def create_task(coro):
-        return get_running_loop().create_task(coro)
-
-else:
-    get_running_loop = asyncio.get_running_loop
-    run = asyncio.run
-    create_task = asyncio.create_task
+get_running_loop = asyncio.get_running_loop
+run = asyncio.run
+create_task = asyncio.create_task

--- a/caproto/asyncio/utils.py
+++ b/caproto/asyncio/utils.py
@@ -41,8 +41,9 @@ class AsyncioQueue:
             self._queue.put(value), self._loop)
 
 
-class _DatagramProtocol(asyncio.Protocol):
+class _DatagramProtocol(asyncio.DatagramProtocol):
     def __init__(self, parent, identifier, queue):
+        super().__init__()
         self.transport = None
         self.parent = parent
         self.identifier = identifier

--- a/caproto/asyncio/utils.py
+++ b/caproto/asyncio/utils.py
@@ -67,21 +67,20 @@ class _TransportWrapper:
 
     Parameters
     ----------
-    reader : ??
+    reader : asyncio.StreamReader
 
-    writer : ??
-
-    loop : asyncio.AbstractEventLoop, optional
-        The event loop.
+    writer : asyncio.StreamWriter
     """
 
     loop: asyncio.AbstractEventLoop
+    reader: asyncio.StreamReader
+    writer: asyncio.StreamWriter
     transport: asyncio.BaseTransport
 
-    def __init__(self, reader, writer, loop=None):
+    def __init__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
         self.reader = reader
         self.writer = writer
-        self.lock = asyncio.Lock()
+        self.send_lock = asyncio.Lock()
 
     def getsockname(self):
         return self.writer.get_extra_info('sockname')
@@ -92,7 +91,7 @@ class _TransportWrapper:
     async def send(self, bytes_to_send):
         """Sends data over a connected socket."""
         try:
-            async with self.lock:
+            async with self.send_lock:
                 self.writer.write(bytes_to_send)
                 await self.writer.drain()
         except OSError as exc:

--- a/caproto/curio/server.py
+++ b/caproto/curio/server.py
@@ -10,13 +10,11 @@ from .._utils import safe_getsockname
 from ..server import AsyncLibraryLayer
 from ..server.common import Context as _Context
 from ..server.common import VirtualCircuit as _VirtualCircuit
+from .utils import curio_run
 
-if hasattr(curio, 'KernelExit'):
-    class ServerExit(curio.KernelExit):
-        ...
-else:
-    class ServerExit(SystemExit):
-        ...
+
+class ServerExit(SystemExit):
+    ...
 
 
 class Event(curio.Event):
@@ -269,13 +267,14 @@ def run(pvdb, *, interfaces=None, log_pv_names=False, startup_hook=None):
         Hook to call at startup with the ``async_lib`` shim.
     """
     try:
-        return curio.run(
+        return curio_run(
             functools.partial(
                 start_server,
                 pvdb,
                 interfaces=interfaces,
                 log_pv_names=log_pv_names,
                 startup_hook=startup_hook,
-            ))
+            )
+        )
     except KeyboardInterrupt:
         return

--- a/caproto/curio/server.py
+++ b/caproto/curio/server.py
@@ -84,7 +84,8 @@ class VirtualCircuit(_VirtualCircuit):
     async def _send_buffers(self, *buffers):
         """Send ``buffers`` over the wire."""
         async with self._send_lock:
-            await self.client.send(b"".join(buffers))
+            for buffer in buffers:
+                await self.client.sendall(bytes(buffer))
 
     async def run(self):
         await self.pending_tasks.spawn(self.command_queue_loop())

--- a/caproto/curio/utils.py
+++ b/caproto/curio/utils.py
@@ -14,7 +14,7 @@ def curio_run(*args, selector=None, **kwargs):
     See note here: https://github.com/dabeaz/curio/issues/75
     """
     if sys.platform != "win32":
-        return curio.run
+        return curio.run(*args, selector=selector, **kwargs)
 
     if selector is None:
         dummy_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

--- a/caproto/curio/utils.py
+++ b/caproto/curio/utils.py
@@ -1,0 +1,28 @@
+import functools
+import selectors
+import socket
+import sys
+
+import curio
+
+
+@functools.wraps(curio.run)
+def curio_run(*args, selector=None, **kwargs):
+    """
+    Compatibility wrapper for curio.run on Windows.
+
+    See note here: https://github.com/dabeaz/curio/issues/75
+    """
+    if sys.platform != "win32":
+        return curio.run
+
+    if selector is None:
+        dummy_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+        # Windows fails with OSError when select([], [], []) is called - that
+        # is, with three empty lists. So, add a socket that will never get used
+        # here:
+        selector = selectors.DefaultSelector()
+        selector.register(dummy_socket, selectors.EVENT_READ)
+
+    return curio.run(*args, selector=selector, **kwargs)

--- a/caproto/examples/thread_client_simple.py
+++ b/caproto/examples/thread_client_simple.py
@@ -1,6 +1,6 @@
 import time
 
-from caproto.threading.client import SharedBroadcaster, Context
+from caproto.threading.client import Context, SharedBroadcaster
 
 
 def main(pvname1='int', pvname2='str'):
@@ -15,7 +15,7 @@ def main(pvname1='int', pvname2='str'):
     # Some user function to call when subscriptions receive data.
     called = []
 
-    def user_callback(command):
+    def user_callback(sub, command):
         print("Subscription has received data: {}".format(command))
         called.append(command)
 

--- a/caproto/ioc_examples/big_image_noisy_neighbor.py
+++ b/caproto/ioc_examples/big_image_noisy_neighbor.py
@@ -35,5 +35,4 @@ if __name__ == "__main__":
     )
 
     ioc = IOInterruptIOC(**ioc_options)
-    print(ioc.image)
     run(ioc.pvdb, **run_options)

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -1095,14 +1095,14 @@ class Context:
             while True:
                 try:
                     await circuit.recv()
+                except DisconnectedCircuit:
+                    await self.circuit_disconnected(circuit)
+                    break
                 except Exception:
                     self.log.exception(
                         "Client disconnected in unexpected way"
                     )
                     await circuit._on_disconnect()
-                    await self.circuit_disconnected(circuit)
-                    break
-                except DisconnectedCircuit:
                     await self.circuit_disconnected(circuit)
                     break
         except KeyboardInterrupt as ex:

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -151,8 +151,8 @@ class VirtualCircuit:
             buffers_to_send = self.circuit.send(*commands)
             # send bytes over the wire using some caproto utilities
             try:
-                async with self._raw_lock:
-                    await ca.async_send_all(buffers_to_send, self.client.sendmsg)
+                bytes_to_send = b"".join(buffers_to_send)
+                await self.client.sendall(bytes_to_send)
             except (OSError, CaprotoNetworkError) as ex:
                 raise DisconnectedCircuit(
                     f"Circuit disconnected: {ex}"

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -1095,6 +1095,13 @@ class Context:
             while True:
                 try:
                     await circuit.recv()
+                except Exception:
+                    self.log.exception(
+                        "Client disconnected in unexpected way"
+                    )
+                    await circuit._on_disconnect()
+                    await self.circuit_disconnected(circuit)
+                    break
                 except DisconnectedCircuit:
                     await self.circuit_disconnected(circuit)
                     break

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -143,16 +143,18 @@ class VirtualCircuit:
                 await sub_spec.db_entry.unsubscribe(queue, sub_spec)
         self.subscriptions.clear()
 
+    async def _send_buffers(self, *commands):
+        """To be implemented in a subclass"""
+        raise NotImplementedError()
+
     async def send(self, *commands):
         """
         Process a command and tranport it over the TCP socket for this circuit.
         """
         if self.connected:
             buffers_to_send = self.circuit.send(*commands)
-            # send bytes over the wire using some caproto utilities
             try:
-                bytes_to_send = b"".join(buffers_to_send)
-                await self.client.sendall(bytes_to_send)
+                await self._send_buffers(*buffers_to_send)
             except (OSError, CaprotoNetworkError) as ex:
                 raise DisconnectedCircuit(
                     f"Circuit disconnected: {ex}"

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -98,6 +98,8 @@ host_endian = ('>' if sys.byteorder == 'big' else '<')
 
 
 class VirtualCircuit:
+    circuit: ca.VirtualCircuit
+
     def __init__(self, circuit, client, context):
         self.connected = True
         self.circuit = circuit  # a caproto.VirtualCircuit

--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -22,9 +22,9 @@ from caproto._log import _set_handler_with_logger, set_handler
 from .. import (AccessRights, AlarmSeverity, AlarmStatus,
                 CaprotoAttributeError, CaprotoRuntimeError, CaprotoTypeError,
                 CaprotoValueError, ChannelAlarm, ChannelByte, ChannelChar,
-                ChannelDouble, ChannelEnum, ChannelFloat, ChannelInteger,
-                ChannelShort, ChannelString, ChannelType, __version__,
-                get_server_address_list)
+                ChannelData, ChannelDouble, ChannelEnum, ChannelFloat,
+                ChannelInteger, ChannelShort, ChannelString, ChannelType,
+                __version__, get_server_address_list)
 from .._backend import backend
 
 module_logger = logging.getLogger(__name__)
@@ -85,7 +85,7 @@ class AsyncLibraryLayer:
     library = None
 
 
-class PvpropertyData:
+class PvpropertyData(ChannelData):
     """
     A top-level class for mixing in with `ChannelData` subclasses.
 
@@ -201,6 +201,19 @@ class PvpropertyData:
         else:
             self.field_inst = None
             self.fields = {}
+
+    def __getstate__(self):
+        state = super().__getstate__()
+        state["group"] = None
+        return state
+
+    def __getnewargs_ex__(self):
+        args, kwargs = super().__getnewargs_ex__()
+        kwargs["pvname"] = self.pvname
+        kwargs["group"] = None
+        kwargs["pvspec"] = self.pvspec
+        kwargs["record"] = self.record_type
+        return (args, kwargs)
 
     async def read(self, data_type):
         """

--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -9,6 +9,7 @@ For an example server implementation, see caproto.curio.server
 import argparse
 import copy
 import enum
+import functools
 import inspect
 import logging
 import sys
@@ -1676,25 +1677,7 @@ class PVGroup(metaclass=PVGroupMeta):
             else:
                 self.states = {}
 
-        pv_group = self
-
-        class StateUpdateContext:
-            def __init__(self, state, value):
-                self.pv_group = pv_group
-                self.state = state
-                self.value = value
-
-            async def __aenter__(self):
-                for attr in pv_group.attr_pvdb.values():
-                    attr.pre_state_change(self.state, self.value)
-                pv_group.states[self.state] = self.value
-                return self
-
-            async def __aexit__(self, exc_type, exc_value, traceback):
-                for attr in pv_group.attr_pvdb.values():
-                    attr.post_state_change(self.state, self.value)
-
-        self.update_state = StateUpdateContext
+        self.update_state = functools.partial(_StateUpdateContext, self)
 
         # Create logger name from parent or from module class
         self.name = (self.__class__.__name__
@@ -1715,9 +1698,9 @@ class PVGroup(metaclass=PVGroupMeta):
 
         # Prime the snapshots to the current state.
         for key, val in self.states.items():
-            for attr in pv_group.attr_pvdb.values():
-                attr.pre_state_change(key, val)
-                attr.post_state_change(key, val)
+            for prop in self.attr_pvdb.values():
+                prop.pre_state_change(key, val)
+                prop.post_state_change(key, val)
 
     def _create_pvdb(self):
         'Create the PV database for all subgroups and pvproperties'
@@ -1780,6 +1763,23 @@ class PVGroup(metaclass=PVGroupMeta):
         'Generic write called for channels without `put` defined'
         self.log.debug('group_write: %s = %s', instance.pvspec.attr, value)
         return value
+
+
+class _StateUpdateContext:
+    def __init__(self, pv_group: PVGroup, state, value):
+        self.pv_group = pv_group
+        self.state = state
+        self.value = value
+
+    async def __aenter__(self):
+        for prop in self.pv_group.attr_pvdb.values():
+            prop.pre_state_change(self.state, self.value)
+        self.pv_group.states[self.state] = self.value
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        for prop in self.pv_group.attr_pvdb.values():
+            prop.post_state_change(self.state, self.value)
 
 
 def template_arg_parser(*, desc, default_prefix, argv=None, macros=None,

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -127,12 +127,8 @@ def search(pv_name, udp_sock, timeout, *, max_retries=2):
                 # message."
                 #
                 # https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom
-                #
-                # Despite the above, this does not *appear* to be fatal;
-                # sometimes the second try will work.
                 logger.debug('Connection reset, retrying: %s', ex)
                 check_timeout()
-                time.sleep(0.1)
                 continue
             except socket.timeout:
                 check_timeout()

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -39,7 +39,7 @@ def send(circuit, command, pv_name=None):
     else:
         tags = None
     buffers_to_send = circuit.send(command, extra=tags)
-    sockets[circuit].sendmsg(buffers_to_send)
+    sockets[circuit].sendall(b"".join(buffers_to_send))
 
 
 def recv(circuit):

--- a/caproto/sync/repeater.py
+++ b/caproto/sync/repeater.py
@@ -93,8 +93,14 @@ def _run_repeater(server_sock, bind_addr):
         try:
             msg, addr = server_sock.recvfrom(MAX_UDP_RECV)
         except ConnectionResetError as ex:
-            logger.debug("Repeater ConnectionResetError during recvfrom: %s", ex)
-            time.sleep(0.1)
+            # Win32: "On a UDP-datagram socket this error indicates
+            # a previous send operation resulted in an ICMP Port
+            # Unreachable message."
+            #
+            # https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom
+            logger.debug(
+                "UDP socket reported previous send failed during recvfrom: %s", ex
+            )
             continue
 
         host, port = addr

--- a/caproto/sync/repeater.py
+++ b/caproto/sync/repeater.py
@@ -90,7 +90,13 @@ def _run_repeater(server_sock, bind_addr):
 
     logger.info("Repeater is listening on %s:%d", bind_host, bind_port)
     while True:
-        msg, addr = server_sock.recvfrom(MAX_UDP_RECV)
+        try:
+            msg, addr = server_sock.recvfrom(MAX_UDP_RECV)
+        except ConnectionResetError as ex:
+            logger.debug("Repeater ConnectionResetError during recvfrom: %s", ex)
+            time.sleep(0.1)
+            continue
+
         host, port = addr
 
         if port in clients and clients[port] != host:

--- a/caproto/tests/conftest.py
+++ b/caproto/tests/conftest.py
@@ -567,112 +567,61 @@ def default_teardown_module(module):
     stop_repeater()
 
 
-@pytest.fixture(scope='function')
-def pvdb_from_server_example():
-    alarm = ca.ChannelAlarm(
-        status=ca.AlarmStatus.READ,
-        severity=ca.AlarmSeverity.MINOR_ALARM,
-        alarm_string='alarm string',
-    )
-
-    pvdb = {
-        'pi': ca.ChannelDouble(value=3.14,
-                               lower_disp_limit=3.13,
-                               upper_disp_limit=3.15,
-                               lower_alarm_limit=3.12,
-                               upper_alarm_limit=3.16,
-                               lower_warning_limit=3.11,
-                               upper_warning_limit=3.17,
-                               lower_ctrl_limit=3.10,
-                               upper_ctrl_limit=3.18,
-                               precision=5,
-                               units='doodles',
-                               alarm=alarm,
-                               ),
-        'enum': ca.ChannelEnum(value='b',
-                               enum_strings=['a', 'b', 'c', 'd'],
-                               ),
-        'enum2': ca.ChannelEnum(value='bb',
-                                enum_strings=['aa', 'bb', 'cc', 'dd'],
-                                ),
-        'int': ca.ChannelInteger(value=96,
-                                 units='doodles',
-                                 ),
-        'char': ca.ChannelByte(value=b'3',
-                               units='poodles',
-                               lower_disp_limit=33,
-                               upper_disp_limit=35,
-                               lower_alarm_limit=32,
-                               upper_alarm_limit=36,
-                               lower_warning_limit=31,
-                               upper_warning_limit=37,
-                               lower_ctrl_limit=30,
-                               upper_ctrl_limit=38,
-                               ),
-        'bytearray': ca.ChannelByte(value=b'1234567890' * 2),
-        'chararray': ca.ChannelChar(value=b'1234567890' * 2),
-        'str': ca.ChannelString(value='hello',
-                                string_encoding='latin-1',
-                                alarm=alarm),
-        'str2': ca.ChannelString(value='hello',
-                                 string_encoding='latin-1',
-                                 alarm=alarm),
-        'stra': ca.ChannelString(value=['hello', 'how is it', 'going'],
-                                 string_encoding='latin-1'),
-    }
-
-    return pvdb
-
-
-@pytest.fixture(scope='function')
-def sample_server_pvdb(prefix: str) -> Dict[str, ca.ChannelData]:
+@pytest.fixture(scope="function")
+def pvdb_from_server_example(prefix: str) -> Dict[str, ca.ChannelData]:
     str_alarm_status = ca.ChannelAlarm(
         status=ca.AlarmStatus.READ,
         severity=ca.AlarmSeverity.MINOR_ALARM,
-        alarm_string='alarm string',
+        alarm_string="alarm string",
     )
 
     caget_pvdb = {
-        'pi': ca.ChannelDouble(value=3.14,
-                               lower_disp_limit=3.13,
-                               upper_disp_limit=3.15,
-                               lower_alarm_limit=3.12,
-                               upper_alarm_limit=3.16,
-                               lower_warning_limit=3.11,
-                               upper_warning_limit=3.17,
-                               lower_ctrl_limit=3.10,
-                               upper_ctrl_limit=3.18,
-                               precision=5,
-                               units='doodles',
-                               ),
-        'enum': ca.ChannelEnum(value='b',
-                               enum_strings=['a', 'b', 'c', 'd'],
-                               ),
-        'int': ca.ChannelInteger(value=33,
-                                 units='poodles',
-                                 lower_disp_limit=33,
-                                 upper_disp_limit=35,
-                                 lower_alarm_limit=32,
-                                 upper_alarm_limit=36,
-                                 lower_warning_limit=31,
-                                 upper_warning_limit=37,
-                                 lower_ctrl_limit=30,
-                                 upper_ctrl_limit=38,
-                                 ),
-        'char': ca.ChannelByte(value=b'3',
-                               units='poodles',
-                               lower_disp_limit=33,
-                               upper_disp_limit=35,
-                               lower_alarm_limit=32,
-                               upper_alarm_limit=36,
-                               lower_warning_limit=31,
-                               upper_warning_limit=37,
-                               lower_ctrl_limit=30,
-                               upper_ctrl_limit=38,
-                               ),
-        'str': ca.ChannelString(value='hello',
-                                alarm=str_alarm_status,
-                                reported_record_type='caproto'),
+        "pi": ca.ChannelDouble(
+            value=3.14,
+            lower_disp_limit=3.13,
+            upper_disp_limit=3.15,
+            lower_alarm_limit=3.12,
+            upper_alarm_limit=3.16,
+            lower_warning_limit=3.11,
+            upper_warning_limit=3.17,
+            lower_ctrl_limit=3.10,
+            upper_ctrl_limit=3.18,
+            precision=5,
+            units="doodles",
+        ),
+        "enum": ca.ChannelEnum(
+            value="b",
+            enum_strings=["a", "b", "c", "d"],
+        ),
+        "int": ca.ChannelInteger(
+            value=33,
+            units="poodles",
+            lower_disp_limit=33,
+            upper_disp_limit=35,
+            lower_alarm_limit=32,
+            upper_alarm_limit=36,
+            lower_warning_limit=31,
+            upper_warning_limit=37,
+            lower_ctrl_limit=30,
+            upper_ctrl_limit=38,
+        ),
+        "char": ca.ChannelByte(
+            value=b"3",
+            units="poodles",
+            lower_disp_limit=33,
+            upper_disp_limit=35,
+            lower_alarm_limit=32,
+            upper_alarm_limit=36,
+            lower_warning_limit=31,
+            upper_warning_limit=37,
+            lower_ctrl_limit=30,
+            upper_ctrl_limit=38,
+        ),
+        "str": ca.ChannelString(
+            value="hello",
+            alarm=str_alarm_status,
+            reported_record_type="caproto"
+        ),
     }
 
     # tack on a unique prefix
@@ -748,6 +697,9 @@ def trio_runner(pvdb, client, *, threaded_client=False):
     async def run_server_and_client():
         async with trio.open_nursery() as test_nursery:
             server_context = await test_nursery.start(trio_server_main)
+            if server_context is None:
+                raise RuntimeError("Failed to start server")
+
             # Give this a couple tries, akin to poll_readiness.
             for _ in range(15):
                 try:
@@ -759,6 +711,7 @@ def trio_runner(pvdb, client, *, threaded_client=False):
                     continue
                 else:
                     break
+
             server_context.stop()
             # don't leave the server running:
             test_nursery.cancel_scope.cancel()

--- a/caproto/tests/conftest.py
+++ b/caproto/tests/conftest.py
@@ -802,7 +802,7 @@ def server(request):
             for _ in range(15):
                 try:
                     if threaded_client:
-                        await loop.run_in_executor(client)
+                        await loop.run_in_executor(None, client)
                     else:
                         await client()
                 except TimeoutError:

--- a/caproto/tests/conftest.py
+++ b/caproto/tests/conftest.py
@@ -504,7 +504,42 @@ def _run_type_varieties_ioc(prefix, request):
                            type='caproto')
 
 
+def _run_states_ioc(prefix, request):
+    name = 'Caproto states IOC example'
+    pvs = dict(
+        (pv, f"{prefix}{pv}")
+        for pv in (
+            "value", "enable_state", "disable_state"
+        )
+    )
+    process = run_example_ioc(
+        "caproto.ioc_examples.states",
+        request=request,
+        pv_to_check=pvs["value"],
+        args=("--prefix", prefix),
+    )
+    return SimpleNamespace(
+        process=process, prefix=prefix, name=name, pvs=pvs, type="caproto"
+    )
+
+
+def _run_records_ioc(prefix, request):
+    name = 'Caproto records IOC example'
+    pvs = dict((pv, f"{prefix}{pv}") for pv in "ABCDE")
+    process = run_example_ioc(
+        "caproto.ioc_examples.records",
+        request=request,
+        pv_to_check=pvs["C"],
+        args=("--prefix", prefix),
+    )
+    return SimpleNamespace(
+        process=process, prefix=prefix, name=name, pvs=pvs, type="caproto"
+    )
+
+
 type_varieties_ioc = pytest.fixture(scope='function')(_run_type_varieties_ioc)
+records_ioc = pytest.fixture(scope='function')(_run_records_ioc)
+states_ioc = pytest.fixture(scope='function')(_run_states_ioc)
 epics_base_ioc = pytest.fixture(scope='function')(_run_epics_base_ioc)
 
 

--- a/caproto/tests/conftest.py
+++ b/caproto/tests/conftest.py
@@ -412,7 +412,7 @@ def prefix():
     return new_prefix()
 
 
-def _epics_base_ioc(prefix, request):
+def _run_epics_base_ioc(prefix, request):
     if not ca.benchmarking.has_softioc():
         pytest.skip('no softIoc')
     name = 'Waveform and standard record IOC'
@@ -478,7 +478,7 @@ def _epics_base_ioc(prefix, request):
                            type='epics-base')
 
 
-def _caproto_ioc(prefix, request):
+def _run_type_varieties_ioc(prefix, request):
     name = 'Caproto type varieties example'
     pvs = dict(int=prefix + 'int',
                int2=prefix + 'int2',
@@ -492,6 +492,7 @@ def _caproto_ioc(prefix, request):
                empty_bytes=prefix + 'empty_bytes',
                empty_char=prefix + 'empty_char',
                empty_float=prefix + 'empty_float',
+               fib=prefix + 'fib',
                )
     process = run_example_ioc(
         'caproto.ioc_examples.advanced.type_varieties',
@@ -503,8 +504,8 @@ def _caproto_ioc(prefix, request):
                            type='caproto')
 
 
-caproto_ioc = pytest.fixture(scope='function')(_caproto_ioc)
-epics_base_ioc = pytest.fixture(scope='function')(_epics_base_ioc)
+type_varieties_ioc = pytest.fixture(scope='function')(_run_type_varieties_ioc)
+epics_base_ioc = pytest.fixture(scope='function')(_run_epics_base_ioc)
 
 
 @pytest.fixture(params=['caproto', 'epics-base'], scope='function')
@@ -512,9 +513,9 @@ def ioc_factory(prefix, request):
     'A fixture that runs more than one IOC: caproto, epics'
     # Get a new prefix for each IOC type:
     if request.param == 'caproto':
-        return functools.partial(_caproto_ioc, prefix, request)
+        return functools.partial(_run_type_varieties_ioc, prefix, request)
     elif request.param == 'epics-base':
-        return functools.partial(_epics_base_ioc, prefix, request)
+        return functools.partial(_run_epics_base_ioc, prefix, request)
 
 
 @pytest.fixture(params=['caproto', 'epics-base'], scope='function')
@@ -522,11 +523,9 @@ def ioc(prefix, request):
     'A fixture that runs more than one IOC: caproto, epics'
     # Get a new prefix for each IOC type:
     if request.param == 'caproto':
-        ioc_ = _caproto_ioc(prefix, request)
-    elif request.param == 'epics-base':
-        ioc_ = _epics_base_ioc(prefix, request)
-
-    return ioc_
+        return _run_type_varieties_ioc(prefix, request)
+    if request.param == 'epics-base':
+        return _run_epics_base_ioc(prefix, request)
 
 
 def start_repeater():

--- a/caproto/tests/test_catvs.py
+++ b/caproto/tests/test_catvs.py
@@ -143,6 +143,7 @@ def test_catvs(catvs_ioc_runner: Callable, test_class: type, test_name: str):
         port = ctx.ca_server_port if "udp" in test_name.lower() else ctx.port
         hacked_setup(test_inst, port)
         test_func = getattr(test_inst, test_name)
+        print(f"Running {test_func.__name__}")
         test_func()
 
     catvs_ioc_runner(client_test, threaded_client=True)

--- a/caproto/tests/test_channel_filters.py
+++ b/caproto/tests/test_channel_filters.py
@@ -43,8 +43,11 @@ def test_array_filter(request, prefix, context, filter, expected, type_varieties
     pv.wait_for_connection()
     event = threading.Event()
 
-    def cb(sub, reading):
-        assert list(reading.data) == expected
+    subscription_reading = None
+
+    def cb(_, reading):
+        nonlocal subscription_reading
+        subscription_reading = reading
         event.set()
 
     # Test read.
@@ -56,6 +59,8 @@ def test_array_filter(request, prefix, context, filter, expected, type_varieties
     sub.add_callback(cb)
     # Wait for callback to process.
     event.wait(timeout=2)
+    assert subscription_reading is not None
+    assert list(subscription_reading.data) == expected
 
 
 def test_ts_filter(request, prefix, context, type_varieties_ioc):

--- a/caproto/tests/test_channel_filters.py
+++ b/caproto/tests/test_channel_filters.py
@@ -96,7 +96,7 @@ MANY = object()
 
 
 # TO DO --- These really should not be flaky!
-# @pytest.mark.xfail
+@pytest.mark.xfail
 @pytest.mark.parametrize('filter, initial, on, off',
                          [('{"before": "my_stately_state"}', 1, 1, 1),
                           ('{"after": "my_stately_state"}', 1, 1, 1),

--- a/caproto/tests/test_channel_filters.py
+++ b/caproto/tests/test_channel_filters.py
@@ -4,7 +4,6 @@ import time
 import pytest
 
 from ..threading.client import Context
-from .conftest import run_example_ioc
 
 
 @pytest.fixture(scope='function')
@@ -106,13 +105,7 @@ MANY = object()
                           ('{"while": "my_stately_state"}', 1, MANY, 1),
                           ('{"unless": "my_stately_state"}', MANY, 1, MANY),
                           ])
-def test_sync_filter(request, prefix, context, filter, initial, on, off):
-    value_name = f'{prefix}value'
-    enable_state_name = f'{prefix}enable_state'
-    disable_state_name = f'{prefix}disable_state'
-    run_example_ioc('caproto.ioc_examples.states', request=request,
-                    args=['--prefix', prefix],
-                    pv_to_check=value_name)
+def test_sync_filter(request, prefix, context, filter, initial, on, off, states_ioc):
     responses = []
 
     def cache(_, response):
@@ -127,7 +120,10 @@ def test_sync_filter(request, prefix, context, filter, initial, on, off):
                 'Expected an exact number of responses'
 
     value, disable_state, enable_state = context.get_pvs(
-        value_name + '.' + filter, disable_state_name, enable_state_name)
+        states_ioc.pvs["value"] + "." + filter,
+        states_ioc.pvs["disable_state"],
+        states_ioc.pvs["enable_state"],
+    )
 
     for pv in (value, disable_state, enable_state):
         pv.wait_for_connection()

--- a/caproto/tests/test_channel_filters.py
+++ b/caproto/tests/test_channel_filters.py
@@ -49,12 +49,12 @@ def test_array_filter(request, prefix, context, filter, expected):
     pv.wait_for_connection()
     event = threading.Event()
 
-    def cb(reading):
+    def cb(sub, reading):
         assert list(reading.data) == expected
         event.set()
     # Test read.
     reading = pv.read()
-    cb(reading)
+    cb(None, reading)
     # Test subscribe.
     sub = pv.subscribe()
     event.clear()
@@ -85,12 +85,12 @@ def test_ts_filter(request, prefix, context):
 
     event = threading.Event()
 
-    def cb(reading):
+    def cb(_, reading):
         assert reading.metadata.timestamp != proc_time
         event.set()
     # Test read.
     reading = ts_pv.read(data_type='time')
-    cb(reading)
+    cb(None, reading)
     # Test subscribe.
     sub = pv.subscribe(data_type='time')
     event.clear()
@@ -121,7 +121,7 @@ def test_sync_filter(request, prefix, context, filter, initial, on, off):
                     pv_to_check=value_name)
     responses = []
 
-    def cache(response):
+    def cache(_, response):
         print('* response:', response.data)
         responses.append(response)
 
@@ -174,7 +174,7 @@ def test_dbnd_filter(request, caproto_ioc, context, filter, expected):
 
     responses = []
 
-    def cache(response):
+    def cache(_, response):
         responses.append(response)
 
     pv, = context.get_pvs(caproto_ioc.pvs['float'] + '.' + filter)

--- a/caproto/tests/test_channel_filters.py
+++ b/caproto/tests/test_channel_filters.py
@@ -36,14 +36,8 @@ def context(request):
                           ('{"arr": {"s": 2, "e": 3}}', [2, 3]),
                           ('{"arr": {"s": 2, "e": 6, "i": 2}}', [2, 5, 13])
                           ])
-def test_array_filter(request, prefix, context, filter, expected):
-    pv_name = f'{prefix}fib'
-    run_example_ioc(
-        'caproto.ioc_examples.advanced.type_varieties',
-        request=request,
-        args=['--prefix', prefix],
-        pv_to_check=pv_name
-    )
+def test_array_filter(request, prefix, context, filter, expected, type_varieties_ioc):
+    pv_name = type_varieties_ioc.pvs["fib"]
 
     pv, = context.get_pvs(pv_name + '.' + filter)
     pv.wait_for_connection()
@@ -52,6 +46,7 @@ def test_array_filter(request, prefix, context, filter, expected):
     def cb(sub, reading):
         assert list(reading.data) == expected
         event.set()
+
     # Test read.
     reading = pv.read()
     cb(None, reading)
@@ -63,14 +58,8 @@ def test_array_filter(request, prefix, context, filter, expected):
     event.wait(timeout=2)
 
 
-def test_ts_filter(request, prefix, context):
-    pv_name = f'{prefix}fib'
-    run_example_ioc(
-        'caproto.ioc_examples.advanced.type_varieties',
-        request=request,
-        args=['--prefix', prefix],
-        pv_to_check=pv_name
-    )
+def test_ts_filter(request, prefix, context, type_varieties_ioc):
+    pv_name = type_varieties_ioc.pvs["fib"]
 
     # Access one element.
     pv, = context.get_pvs(pv_name)
@@ -170,14 +159,14 @@ def test_sync_filter(request, prefix, context, filter, initial, on, off):
                           ('{"dbnd": {"abs": 1}}', [3.14]),
                           # TODO Cover more interesting cases.
                           ])
-def test_dbnd_filter(request, caproto_ioc, context, filter, expected):
+def test_dbnd_filter(request, type_varieties_ioc, context, filter, expected):
 
     responses = []
 
     def cache(_, response):
         responses.append(response)
 
-    pv, = context.get_pvs(caproto_ioc.pvs['float'] + '.' + filter)
+    pv, = context.get_pvs(type_varieties_ioc.pvs['float'] + '.' + filter)
     pv.wait_for_connection()
 
     sub = pv.subscribe()

--- a/caproto/tests/test_channel_filters.py
+++ b/caproto/tests/test_channel_filters.py
@@ -96,7 +96,7 @@ MANY = object()
 
 
 # TO DO --- These really should not be flaky!
-@pytest.mark.xfail
+# @pytest.mark.xfail
 @pytest.mark.parametrize('filter, initial, on, off',
                          [('{"before": "my_stately_state"}', 1, 1, 1),
                           ('{"after": "my_stately_state"}', 1, 1, 1),

--- a/caproto/tests/test_data_copy.py
+++ b/caproto/tests/test_data_copy.py
@@ -1,0 +1,200 @@
+import copy
+
+import pytest
+
+from .. import (ChannelByte, ChannelChar, ChannelData, ChannelDouble,
+                ChannelEnum, ChannelFloat, ChannelInteger, ChannelShort,
+                ChannelString)
+from ..server.server import (PVGroup, PvpropertyBoolEnum, PvpropertyBoolEnumRO,
+                             PvpropertyByte, PvpropertyByteRO, PvpropertyChar,
+                             PvpropertyCharRO, PvpropertyDouble,
+                             PvpropertyDoubleRO, PvpropertyEnum,
+                             PvpropertyEnumRO, PvpropertyFloat,
+                             PvpropertyFloatRO, PvpropertyInteger,
+                             PvpropertyIntegerRO, PvpropertyShort,
+                             PvpropertyShortRO, PvpropertyString,
+                             PvpropertyStringRO, PVSpec)
+
+
+async def _fake_putter(data, value):
+    ...
+
+
+pvspec = PVSpec(put=_fake_putter)
+group = PVGroup(prefix="abc")
+
+
+sample_data = [
+    pytest.param(
+        ChannelInteger(value=5),
+        id="ChannelInteger",
+    ),
+    pytest.param(
+        ChannelByte(value=5),
+        id="ChannelByte",
+    ),
+    pytest.param(
+        ChannelChar(value=5),
+        id="ChannelChar",
+    ),
+    pytest.param(
+        ChannelDouble(value=5.0),
+        id="ChannelDouble",
+    ),
+    pytest.param(
+        ChannelEnum(value=0, enum_strings=["a", "b", "c"]),
+        id="ChannelEnum",
+    ),
+    pytest.param(
+        ChannelFloat(value=5.0),
+        id="ChannelFloat",
+    ),
+    pytest.param(
+        ChannelShort(value=2),
+        id="ChannelShort",
+    ),
+    pytest.param(
+        ChannelString(value="string", long_string_max_length=82),
+        id="ChannelString",
+    ),
+    pytest.param(
+        ChannelInteger(value=5),
+        id="ChannelInteger",
+    ),
+    pytest.param(
+        ChannelByte(value=5),
+        id="ChannelByte",
+    ),
+    pytest.param(
+        ChannelChar(value=5),
+        id="ChannelChar",
+    ),
+    pytest.param(
+        ChannelDouble(value=5.0),
+        id="ChannelDouble",
+    ),
+    pytest.param(
+        ChannelEnum(value=0, enum_strings=["a", "b", "c"]),
+        id="ChannelEnum",
+    ),
+    pytest.param(
+        ChannelFloat(value=5.0),
+        id="ChannelFloat",
+    ),
+    pytest.param(
+        ChannelShort(value=2),
+        id="ChannelShort",
+    ),
+    pytest.param(
+        ChannelString(value="string", long_string_max_length=82),
+        id="ChannelString",
+    ),
+    pytest.param(
+        PvpropertyChar(value=5, group=group, pvspec=pvspec, pvname="pvname"),
+        id="PvpropertyChar",
+    ),
+    pytest.param(
+        PvpropertyByte(value=5, group=group, pvspec=pvspec, pvname="pvname"),
+        id="PvpropertyByte",
+    ),
+    pytest.param(
+        PvpropertyShort(value=5, group=group, pvspec=pvspec, pvname="pvname"),
+        id="PvpropertyShort",
+    ),
+    pytest.param(
+        PvpropertyInteger(value=5, group=group, pvspec=pvspec, pvname="pvname"),
+        id="PvpropertyInteger",
+    ),
+    pytest.param(
+        PvpropertyFloat(value=5, group=group, pvspec=pvspec, pvname="pvname"),
+        id="PvpropertyFloat",
+    ),
+    pytest.param(
+        PvpropertyDouble(value=5, group=group, pvspec=pvspec, pvname="pvname"),
+        id="PvpropertyDouble",
+    ),
+    pytest.param(
+        PvpropertyString(value=5, group=group, pvspec=pvspec, pvname="pvname"),
+        id="PvpropertyString",
+    ),
+    pytest.param(
+        PvpropertyEnum(value=5, group=group, pvspec=pvspec, pvname="pvname"),
+        id="PvpropertyEnum",
+    ),
+    pytest.param(
+        PvpropertyBoolEnum(value=5, group=group, pvspec=pvspec, pvname="pvname"),
+        id="PvpropertyBoolEnum",
+    ),
+    pytest.param(
+        PvpropertyCharRO(value=5, group=group, pvspec=pvspec, pvname="pvname"),
+        id="PvpropertyCharRO",
+    ),
+    pytest.param(
+        PvpropertyByteRO(value=5, group=group, pvspec=pvspec, pvname="pvname"),
+        id="PvpropertyByteRO",
+    ),
+    pytest.param(
+        PvpropertyShortRO(value=5, group=group, pvspec=pvspec, pvname="pvname"),
+        id="PvpropertyShortRO",
+    ),
+    pytest.param(
+        PvpropertyIntegerRO(value=5, group=group, pvspec=pvspec, pvname="pvname"),
+        id="PvpropertyIntegerRO",
+    ),
+    pytest.param(
+        PvpropertyFloatRO(value=5, group=group, pvspec=pvspec, pvname="pvname"),
+        id="PvpropertyFloatRO",
+    ),
+    pytest.param(
+        PvpropertyDoubleRO(value=5, group=group, pvspec=pvspec, pvname="pvname"),
+        id="PvpropertyDoubleRO",
+    ),
+    pytest.param(
+        PvpropertyStringRO(value=5, group=group, pvspec=pvspec, pvname="pvname"),
+        id="PvpropertyStringRO",
+    ),
+    pytest.param(
+        PvpropertyEnumRO(value=5, group=group, pvspec=pvspec, pvname="pvname"),
+        id="PvpropertyEnumRO",
+    ),
+    pytest.param(
+        PvpropertyBoolEnumRO(value=5, group=group, pvspec=pvspec, pvname="pvname"),
+        id="PvpropertyBoolEnumRO",
+    ),
+]
+
+
+def compare_data(data: ChannelData, copied: ChannelData):
+    for key in data._data:
+        assert copied._data[key] == data._data[key]
+    assert copied.value == data.value
+    assert copied.timestamp == data.timestamp
+    assert copied._data["timestamp"] is not data._data["timestamp"]
+
+    if hasattr(data, "pvname"):
+        assert copied.pvname == data.pvname
+        assert copied.pvspec == data.pvspec
+        assert copied.group is None
+
+    _, kwargs = data.__getnewargs_ex__()
+    attr_map = {
+        "timestamp": "epics_timestamp",
+        "record": "record_type",
+    }
+    for attr, expected in kwargs.items():
+        copied_attr_value = getattr(copied, attr_map.get(attr, attr))
+
+        assert copied_attr_value == expected
+
+
+@pytest.mark.parametrize("data", sample_data)
+def test_copy(data: ChannelData):
+    copied = copy.deepcopy(data)
+    compare_data(data, copied)
+
+
+@pytest.mark.parametrize("data", sample_data)
+def test_getnewargs(data: ChannelData):
+    args, kwargs = data.__getnewargs_ex__()
+    copied = type(data)(*args, **kwargs)
+    compare_data(data, copied)

--- a/caproto/tests/test_examples.py
+++ b/caproto/tests/test_examples.py
@@ -1,6 +1,5 @@
 import time
 
-import curio
 import pytest
 
 import caproto as ca
@@ -23,17 +22,16 @@ def test_asyncio_client_example(ioc):
     ca.asyncio.utils.run(coro, debug=True)
 
 
-def test_thread_client_example(curio_server):
+def test_thread_client_example(sample_server_pvdb):
     from caproto.examples.thread_client_simple import main as example_main
-    server_runner, prefix, caget_pvdb = curio_server
 
-    @conftest.threaded_in_curio_wrapper
+    pvname1, = [pv for pv in sample_server_pvdb if pv.endswith("int")]
+    pvname2, = [pv for pv in sample_server_pvdb if pv.endswith("str")]
+
     def client():
-        example_main(pvname1=prefix + 'int',
-                     pvname2=prefix + 'str')
+        example_main(pvname1=pvname1, pvname2=pvname2)
 
-    with curio.Kernel() as kernel:
-        kernel.run(server_runner, client)
+    conftest.asyncio_runner(sample_server_pvdb, client, threaded_client=True)
 
 
 @pytest.mark.flaky(reruns=2, reruns_delay=2)

--- a/caproto/tests/test_examples.py
+++ b/caproto/tests/test_examples.py
@@ -99,6 +99,7 @@ def test_areadetector_generate():
     "caproto.ioc_examples.too_clever.caproto_to_ophyd"
 )
 def test_typhos_example(request, ioc_name):
+    pytest.importorskip("ophyd")
     info = conftest.run_example_ioc_by_name(ioc_name, request=request)
     from caproto.ioc_examples.too_clever import caproto_to_typhos
     caproto_to_typhos.pydm = None

--- a/caproto/tests/test_examples.py
+++ b/caproto/tests/test_examples.py
@@ -22,16 +22,16 @@ def test_asyncio_client_example(ioc):
     ca.asyncio.utils.run(coro, debug=True)
 
 
-def test_thread_client_example(sample_server_pvdb):
+def test_thread_client_example(pvdb_from_server_example):
     from caproto.examples.thread_client_simple import main as example_main
 
-    pvname1, = [pv for pv in sample_server_pvdb if pv.endswith("int")]
-    pvname2, = [pv for pv in sample_server_pvdb if pv.endswith("str")]
+    pvname1, = [pv for pv in pvdb_from_server_example if pv.endswith("int")]
+    pvname2, = [pv for pv in pvdb_from_server_example if pv.endswith("str")]
 
     def client():
         example_main(pvname1=pvname1, pvname2=pvname2)
 
-    conftest.asyncio_runner(sample_server_pvdb, client, threaded_client=True)
+    conftest.asyncio_runner(pvdb_from_server_example, client, threaded_client=True)
 
 
 @pytest.mark.flaky(reruns=2, reruns_delay=2)

--- a/caproto/tests/test_records.py
+++ b/caproto/tests/test_records.py
@@ -4,7 +4,6 @@ from caproto import AlarmSeverity, AlarmStatus, ChannelType
 from caproto.sync.client import read, write
 from caproto.threading.pyepics_compat import get_pv
 
-from .conftest import run_example_ioc
 from .test_threading_client import context as _context
 from .test_threading_client import shared_broadcaster as _sb
 
@@ -23,12 +22,8 @@ field_map = {
 }
 
 
-def test_limit_fields_and_description(request, prefix, context):
-    pv = f'{prefix}C'
-    run_example_ioc('caproto.ioc_examples.records',
-                    request=request,
-                    args=['--prefix', prefix],
-                    pv_to_check=pv)
+def test_limit_fields_and_description(request, prefix, context, records_ioc):
+    pv = records_ioc.pvs["C"]
     PV = get_pv(pv, context=context)
 
     def check_fields():
@@ -53,12 +48,8 @@ def test_limit_fields_and_description(request, prefix, context):
 
 @pytest.mark.parametrize('sevr_target', ['LLSV', 'LSV', 'HSV', 'HHSV'])
 @pytest.mark.parametrize('sevr_value', AlarmSeverity)
-def test_alarms(request, prefix, sevr_target, sevr_value, context):
-    pv = f'{prefix}C'
-    run_example_ioc('caproto.ioc_examples.records',
-                    request=request,
-                    args=['--prefix', prefix],
-                    pv_to_check=pv)
+def test_alarms(request, prefix, sevr_target, sevr_value, context, records_ioc):
+    pv = records_ioc.pvs["C"]
     PV = get_pv(pv, context=context)
     get_pv(f'{pv}.{sevr_target}', context=context).put(
         sevr_value, wait=True)

--- a/caproto/tests/test_server.py
+++ b/caproto/tests/test_server.py
@@ -262,8 +262,8 @@ def test_with_caput(backends, prefix, pvdb_from_server_example, server, pv,
     print('done')
 
 
-def test_limits_enforced(request, caproto_ioc):
-    pv = caproto_ioc.pvs['float']
+def test_limits_enforced(request, type_varieties_ioc):
+    pv = type_varieties_ioc.pvs['float']
     write(pv, 3.101, notify=True)  # within limit
     write(pv, 3.179, notify=True)  # within limit
     with pytest.raises(ErrorResponseReceived):
@@ -272,20 +272,20 @@ def test_limits_enforced(request, caproto_ioc):
         write(pv, 3.181, notify=True)  # beyond limit
 
 
-def test_empties_with_caproto_client(request, caproto_ioc):
-    assert read(caproto_ioc.pvs['empty_string']).data == [b'']
-    assert list(read(caproto_ioc.pvs['empty_bytes']).data) == []
-    assert list(read(caproto_ioc.pvs['empty_char']).data) == []
-    assert list(read(caproto_ioc.pvs['empty_float']).data) == []
+def test_empties_with_caproto_client(request, type_varieties_ioc):
+    assert read(type_varieties_ioc.pvs['empty_string']).data == [b'']
+    assert list(read(type_varieties_ioc.pvs['empty_bytes']).data) == []
+    assert list(read(type_varieties_ioc.pvs['empty_char']).data) == []
+    assert list(read(type_varieties_ioc.pvs['empty_float']).data) == []
 
 
 @pytest.mark.skipif(not has_caget(), reason='No caget binary')
-def test_empties_with_caget(request, caproto_ioc):
+def test_empties_with_caget(request, type_varieties_ioc):
     async def test():
-        info = await run_caget('asyncio', caproto_ioc.pvs['empty_string'])
+        info = await run_caget('asyncio', type_varieties_ioc.pvs['empty_string'])
         assert info['value'] == ''
 
-        info = await run_caget('asyncio', caproto_ioc.pvs['empty_bytes'])
+        info = await run_caget('asyncio', type_varieties_ioc.pvs['empty_bytes'])
         # NOTE: this zero is not a value, it's actually the length:
         # $ caget  type_varieties:empty_bytes
         # type_varieties:empty_bytes     0
@@ -295,20 +295,20 @@ def test_empties_with_caget(request, caproto_ioc):
         # type_varieties:empty_bytes     1 0
         assert info['value'] == '0'
 
-        info = await run_caget('asyncio', caproto_ioc.pvs['empty_char'])
+        info = await run_caget('asyncio', type_varieties_ioc.pvs['empty_char'])
         assert info['value'] == '0'
 
-        info = await run_caget('asyncio', caproto_ioc.pvs['empty_float'])
+        info = await run_caget('asyncio', type_varieties_ioc.pvs['empty_float'])
         # NOTE: 2 below is length, with 2 elements of 0
         assert info['value'] == ['2', '0', '0']
         # TODO: somehow caget gets the max_length instead of the current
         # length.  caproto-get does not have this issue.
 
-    asyncio.get_event_loop().run_until_complete(test())
+    asyncio.run(test())
 
 
-def test_char_write(request, caproto_ioc):
-    pv = caproto_ioc.pvs['chararray']
+def test_char_write(request, type_varieties_ioc):
+    pv = type_varieties_ioc.pvs['chararray']
     write(pv, b'testtesttest', notify=True)
     response = read(pv)
     assert ''.join(chr(c) for c in response.data) == 'testtesttest'

--- a/caproto/tests/test_server.py
+++ b/caproto/tests/test_server.py
@@ -44,8 +44,6 @@ caget_checks += [('char', ChannelType.CHAR),
 @pytest.mark.parametrize('pv, dbr_type', caget_checks)
 def test_with_caget(backends, prefix, pvdb_from_server_example, server, pv,
                     dbr_type):
-    caget_pvdb = {prefix + pv_: value
-                  for pv_, value in pvdb_from_server_example.items()}
     pv = prefix + pv
     ctrl_keys = ('upper_disp_limit', 'lower_alarm_limit',
                  'upper_alarm_limit', 'lower_warning_limit',
@@ -61,7 +59,7 @@ def test_with_caget(backends, prefix, pvdb_from_server_example, server, pv,
         print('* client caget test: pv={} dbr_type={}'.format(pv, dbr_type))
         print(f'(client args: {client_args})')
 
-        db_entry = caget_pvdb[pv]
+        db_entry = pvdb_from_server_example[pv]
         # native type as in the ChannelData database
         db_native = ca.native_type(db_entry.data_type)
         # native type of the request
@@ -163,7 +161,7 @@ def test_with_caget(backends, prefix, pvdb_from_server_example, server, pv,
         test_completed = True
 
     try:
-        server(pvdb=caget_pvdb, client=client)
+        server(pvdb=pvdb_from_server_example, client=client)
     except OSError:
         if sys.platform == 'win32' and test_completed:
             # WIN32_TODO: windows asyncio stuff is still buggy...
@@ -191,9 +189,6 @@ caput_checks = [('int', '1', 1),
 def test_with_caput(backends, prefix, pvdb_from_server_example, server, pv,
                     put_value, check_value):
 
-    caget_pvdb = {prefix + pv_: value
-                  for pv_, value in pvdb_from_server_example.items()
-                  }
     pv = prefix + pv
     test_completed = False
 
@@ -205,7 +200,7 @@ def test_with_caput(backends, prefix, pvdb_from_server_example, server, pv,
               ''.format(pv, put_value, check_value))
         print('(client args: {})'.format(client_args))
 
-        db_entry = caget_pvdb[pv]
+        db_entry = pvdb_from_server_example[pv]
         db_old = db_entry.value
         data = await run_caput(server.backend, pv, put_value,
                                as_string=isinstance(db_entry, (ca.ChannelByte,
@@ -256,7 +251,7 @@ def test_with_caput(backends, prefix, pvdb_from_server_example, server, pv,
         test_completed = True
 
     try:
-        server(pvdb=caget_pvdb, client=client)
+        server(pvdb=pvdb_from_server_example, client=client)
     except OSError:
         if sys.platform == 'win32' and test_completed:
             # WIN32_TODO: windows asyncio stuff is still buggy...

--- a/caproto/tests/test_utils.py
+++ b/caproto/tests/test_utils.py
@@ -54,27 +54,6 @@ _incr_sends = [
 ]
 
 
-@pytest.mark.parametrize('buffers, offset, expected', _incr_sends)
-def test_buffer_list_slice(buffers, offset, expected):
-    assert ca.buffer_list_slice(*buffers, offset=offset) == expected
-
-
-@pytest.mark.parametrize('buffers, offset, expected', _incr_sends)
-def test_incremental_send(buffers, offset, expected):
-    full_bytes = b''.join(bytes(b) for b in buffers)
-
-    gen = ca.incremental_buffer_list_slice(*buffers)
-    gen.send(None)
-
-    for i in range(len(full_bytes)):
-        try:
-            buffers = gen.send(1)
-        except StopIteration:
-            assert i == (len(full_bytes) - 1), 'StopIteration unexpected'
-            break
-        assert full_bytes[i + 1:] == b''.join(bytes(b) for b in buffers)
-
-
 records_to_check = [
     ['x.NAME', ('x.NAME', 'x', 'NAME', None)],
     ['x.', ('x', 'x', None, None)],

--- a/caproto/tests/test_utils.py
+++ b/caproto/tests/test_utils.py
@@ -283,3 +283,15 @@ def test_server_addresses(monkeypatch, protocol, env_addr, expected):
 
     patch_env(monkeypatch, env)
     assert set(ca.get_server_address_list(protocol=protocol)) == set(expected)
+
+
+def test_timeout_fixture():
+    import asyncio
+
+    from . import conftest
+
+    async def client():
+        await asyncio.sleep(100)
+
+    with pytest.raises(RuntimeError):
+        conftest.asyncio_runner({}, client, timeout=2.0)

--- a/caproto/tests/test_utils.py
+++ b/caproto/tests/test_utils.py
@@ -250,8 +250,8 @@ def test_client_addresses(monkeypatch, protocol, default_port, env_auto,
     # Easier to test without netifaces
     monkeypatch.setattr(ca._utils, 'netifaces', None)
 
-    env[f'EPICS_{protocol}_ADDR_LIST'] = env_addr
-    env[f'EPICS_{protocol}_AUTO_ADDR_LIST'] = env_auto
+    env[f'EPICS_{protocol.value}_ADDR_LIST'] = env_addr
+    env[f'EPICS_{protocol.value}_AUTO_ADDR_LIST'] = env_auto
     if protocol == 'CA':
         env['EPICS_CA_SERVER_PORT'] = int(default_port)
     elif protocol == 'PVA':

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -395,7 +395,7 @@ class SharedBroadcaster:
 
         try:
             self.udp_sock.sendto(bytes_to_send, addr)
-        except OSError as ex:
+        except (OSError, AttributeError) as ex:
             host, specified_port = addr
             self.log.exception('%s while sending %d bytes to %s:%d',
                                ex, len(bytes_to_send), host, specified_port)
@@ -453,8 +453,11 @@ class SharedBroadcaster:
             self.broadcaster.log.debug(
                 '%d commands %dB',
                 len(commands), len(bytes_to_send), extra=tags)
+            sock = self.udp_sock
+            if sock is None:
+                return
             try:
-                self.udp_sock.sendto(bytes_to_send, host_tuple)
+                sock.sendto(bytes_to_send, host_tuple)
             except OSError as ex:
                 host, specified_port = host_tuple
                 raise CaprotoNetworkError(

--- a/caproto/trio/server.py
+++ b/caproto/trio/server.py
@@ -114,8 +114,11 @@ class TrioSocketStreamCompat:
         return self._sock.getsockname()
 
     async def send_all(self, data):
-        async with self._send_lock:
-            return await self._stream.send_all(data)
+        try:
+            async with self._send_lock:
+                return await self._stream.send_all(data)
+        except trio.BrokenResourceError:
+            raise DisconnectedCircuit("Disconnected while sending to client")
 
 
 class VirtualCircuit(_VirtualCircuit):

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W
+SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -74,7 +74,7 @@ release = caproto.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/doc/source/release-notes.rst
+++ b/doc/source/release-notes.rst
@@ -25,7 +25,11 @@ Fixed
   an ICMP Port Unreachable message."  This is not fatal in caproto's case and
   can safely be ignored (or worked around, in the case of asyncio).
   https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom
-  - Fixed pickle/copy for ChannelData subclasses
+- Fixed pickle/copy for ChannelData subclasses
+- Fixed synchronous repeater bind address to INADDR_ANY ("0.0.0.0").  Binding
+  to a specific interface meant that on Windows the repeater could not use
+  its client-is-alive detection mechanism by binding to the client port as
+  the bind would always succeed.
 
 Development
 -----------

--- a/doc/source/release-notes.rst
+++ b/doc/source/release-notes.rst
@@ -2,8 +2,11 @@
 Release History
 ***************
 
-v0.8.2 (2021-??-??)
+v0.9.0 (2022-??-??)
 ===================
+
+- Python 3.6 and Python 3.7 support has been dropped.
+- Python 3.8 through Python 3.10 are now targeted for support.
 
 Changed
 -------
@@ -13,6 +16,33 @@ Changed
   are now deprecated and will be reverted to pre-pvAccess (no protocol argument
   allowed) signatures in a future release.
 
+Fixed
+-----
+
+- Fixes for all Windows clients, servers, and the repeater relating to PV
+  searches. ``recvfrom`` was occasionally raising ``ConnectionResetError``,
+  which on Windows only means that: "... a previous send operation resulted in
+  an ICMP Port Unreachable message."  This is not fatal in caproto's case and
+  can safely be ignored (or worked around, in the case of asyncio).
+  https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom
+  - Fixed pickle/copy for ChannelData subclasses
+
+Development
+-----------
+
+- Adjusted continuous integration jobs to reflect new supported versions.
+- Improved test suite reliability on continuous integration.
+- Removed buffer-slicing tools and tests in a refactor to avoid ``sendmsg`` on
+  all platforms and async libraries.
+- Removed some old windows compatibility patches in
+  ``caproto._windows_compat``, and avoided monkey-patching for curio by moving
+  its Windows-facing ``curio.run`` modification to
+  ``caproto.curio.utils.curio_run``.
+- Test suite has some built-in timeout-handling functionality on a
+  per-async-library basis, avoiding exiting the entire test suite on Windows
+  (due to limitations of ``pytest-timeout``).
+- Trio socket handling has been updated to follow better practices for recent
+  trio versions.
 
 v0.8.1 (2021-06-03)
 ===================

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,3 +1,4 @@
+curio
 doctr
 doctr-versions-menu
 graphviz
@@ -6,3 +7,4 @@ matplotlib
 numpydoc
 sphinx>=3.2.1
 sphinx_rtd_theme>=0.5.0
+trio

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(name='caproto',
           # rebuild record fields:
           '': ['*.rst', '*.jinja2'],
       },
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       classifiers=classifiers,
       extras_require=extras_require
       )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import versioneer
 # NOTE: This file must remain Python 2 compatible for the foreseeable future,
 # to ensure that we error out properly for people with outdated setuptools
 # and/or pip.
-if sys.version_info < (3, 6):
+if sys.version_info < (3, 7):
     error = """
 Caproto does not support Python 2.x, 3.0, 3.1, 3.2, 3.3, 3.4, or 3.5.
 Python 3.6 and above is required. Check your Python version like so:
@@ -29,7 +29,6 @@ classifiers = [
     'Intended Audience :: Science/Research',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
@@ -81,7 +80,7 @@ setup(name='caproto',
           # rebuild record fields:
           '': ['*.rst', '*.jinja2'],
       },
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       classifiers=classifiers,
       extras_require=extras_require
       )

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,10 @@ import versioneer
 # NOTE: This file must remain Python 2 compatible for the foreseeable future,
 # to ensure that we error out properly for people with outdated setuptools
 # and/or pip.
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 8):
     error = """
 Caproto does not support Python 2.x, 3.0, 3.1, 3.2, 3.3, 3.4, or 3.5.
-Python 3.6 and above is required. Check your Python version like so:
+Python 3.8 and above is required. Check your Python version like so:
 
 python --version
 
@@ -29,7 +29,6 @@ classifiers = [
     'Intended Audience :: Science/Research',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,10 @@ classifiers = [
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
     'Topic :: Scientific/Engineering :: Visualization',
     'License :: OSI Approved :: BSD License'
 ]


### PR DESCRIPTION
Issues
-------
Supersedes #787 
Likely addresses #789 

Notes
-----

- Python 3.6 and Python 3.7 support has been dropped.
- Python 3.8 through Python 3.10 are now targeted for support.

Fixed
-----

- Fixes for all Windows clients, servers, and the repeater relating to PV
  searches. ``recvfrom`` was occasionally raising ``ConnectionResetError``,
  which on Windows only means that: "... a previous send operation resulted in
  an ICMP Port Unreachable message."  This is not fatal in caproto's case and
  can safely be ignored (or worked around, in the case of [asyncio](https://github.com/python/cpython/issues/88906)).
  https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom
- Fixed pickle/copy for ChannelData subclasses
- Fixed synchronous repeater bind address to INADDR_ANY ("0.0.0.0").  Binding
  to a specific interface meant that on Windows the repeater could not use
  its client-is-alive detection mechanism by binding to the client port as
  the bind would always succeed.

Development
-----------

- Adjusted continuous integration jobs to reflect new supported versions.
- Improved test suite reliability on continuous integration.
- Removed buffer-slicing tools and tests in a refactor to avoid ``sendmsg`` on
  all platforms and async libraries.
- Removed some old windows compatibility patches in
  ``caproto._windows_compat``, and avoided monkey-patching for curio by moving
  its Windows-facing ``curio.run`` modification to
  ``caproto.curio.utils.curio_run``.
- Test suite has some built-in timeout-handling functionality on a
  per-async-library basis, avoiding exiting the entire test suite on Windows
  (due to limitations of ``pytest-timeout``).
- Trio socket handling has been updated to follow better practices for recent
  trio versions.
