### PR TITLE
Reconnect PV when connection is interrupted

### DIFF
--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -812,7 +812,7 @@ class SharedBroadcaster:
                                 "automatically begin attempting to reconnect "
                                 "to a responsive server.",
                                 *address, circuit_manager)
-                            circuit_manager.disconnect()
+                            circuit_manager._disconnected()
                     checking.pop(address)
                 # else:
                 #     # We are still waiting to give the server time to respond


### PR DESCRIPTION
This fixes a problem (#798) where a PV would never reconnect after the connection to the IOC was temporarily interrupted.