### PR TITLE
Update required python version in docs

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -4,7 +4,7 @@ Install Caproto
 
 You can install caproto using pip or from source.
 
-First verify that you have Python 3.6+.
+First verify that you have Python 3.8+.
 
 .. code-block:: bash
 


### PR DESCRIPTION
Version 3.8+ is required, according to https://github.com/caproto/caproto/commit/fcf35af6a4de6d730c3155a6619f8cb5565bb6f5