### PR TITLE
Lakeshore example with put completion and settle_time

### DIFF
--- a/caproto/ioc_examples/lakeshore.py
+++ b/caproto/ioc_examples/lakeshore.py
@@ -82,7 +82,7 @@ class PIDController(PID):
         self._feedback = None
         self._output = None
         self._run = True
-        self.history = {'output':[], 'feedback':[], 'setpoint':[], 'timestamp':[]}
+        self.history = {"output": [], "feedback": [], "setpoint": [], "timestamp": []}
         threading.Thread(target=self._executor).start()
 
     @property
@@ -100,10 +100,10 @@ class PIDController(PID):
         while self._run:
             self._feedback = self._get_feedback()
             self._output = self.__call__(self._get_feedback())
-            self.history['output'].append(self._output)
-            self.history['feedback'].append(self._feedback)
-            self.history['setpoint'].append(self.setpoint)
-            self.history['timestamp'].append(time.time())
+            self.history["output"].append(self._output)
+            self.history["feedback"].append(self._feedback)
+            self.history["setpoint"].append(self.setpoint)
+            self.history["timestamp"].append(time.time())
             self._set_output(self._output)
             time.sleep(0.1)
 
@@ -143,6 +143,7 @@ class PIDController(PID):
     plt.amplhow(block=False)
 """
 
+
 class Lakeshore336Sim(PVGroup):
     """
     Simulated Lakeshore IOC.
@@ -162,12 +163,7 @@ class Lakeshore336Sim(PVGroup):
             setpoint=150,
         )
 
-    Kp = pvproperty(
-        value=0,
-        dtype=float,
-        name='Kp',
-        doc="PID parameter Kp"
-    )
+    Kp = pvproperty(value=0, dtype=float, name="Kp", doc="PID parameter Kp")
 
     @Kp.getter
     async def Kp(self, instance):
@@ -178,12 +174,7 @@ class Lakeshore336Sim(PVGroup):
         self._temperature_controller.Kp = value
         return value
 
-    Ki = pvproperty(
-        value=0,
-        dtype=float,
-        name='Ki',
-        doc="PID parameter Ki"
-    )
+    Ki = pvproperty(value=0, dtype=float, name="Ki", doc="PID parameter Ki")
 
     @Ki.getter
     async def Ki(self, instance):
@@ -194,12 +185,7 @@ class Lakeshore336Sim(PVGroup):
         self._temperature_controller.Ki = value
         return value
 
-    Kd = pvproperty(
-        value=0,
-        dtype=float,
-        name='Kd',
-        doc="PID parameter Kd"
-    )
+    Kd = pvproperty(value=0, dtype=float, name="Kd", doc="PID parameter Kd")
 
     @Kd.getter
     async def Kd(self, instance):
@@ -211,10 +197,7 @@ class Lakeshore336Sim(PVGroup):
         return value
 
     setpoint = pvproperty(
-        value=100,
-        dtype=float,
-        name='setpoint',
-        doc="temperature setpoint"
+        value=100, dtype=float, name="setpoint", doc="temperature setpoint"
     )
 
     @setpoint.getter
@@ -227,33 +210,24 @@ class Lakeshore336Sim(PVGroup):
         return value
 
     feedback = pvproperty(
-        value=100,
-        dtype=float,
-        name='feedback',
-        doc="temperature feedback"
+        value=100, dtype=float, name="feedback", doc="temperature feedback"
     )
 
     @feedback.getter
     async def feedback(self, instance):
         return self._temperature_controller.feedback
 
-    output = pvproperty(
-        value=100,
-        dtype=float,
-        name='output',
-        doc="output value"
-    )
+    output = pvproperty(value=100, dtype=float, name="output", doc="output value")
 
     @output.getter
     async def output(self, instance):
         return self._temperature_controller.output
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     ioc_options, run_options = ioc_arg_parser(
-        default_prefix='Lakeshore336Sim:',
-        desc="Lakeshore336Sim IOC")
+        default_prefix="Lakeshore336Sim:", desc="Lakeshore336Sim IOC"
+    )
     ioc = Lakeshore336Sim(**ioc_options)
-    print('PVs:', list(ioc.pvdb))
+    print("PVs:", list(ioc.pvdb))
     run(ioc.pvdb, **run_options)
-

--- a/caproto/ioc_examples/lakeshore.py
+++ b/caproto/ioc_examples/lakeshore.py
@@ -18,6 +18,7 @@ import functools
 import threading
 import time
 
+from collections import deque
 from simple_pid import PID
 from caproto.server import PVGroup, ioc_arg_parser, pvproperty, run
 from ophyd import EpicsSignal, EpicsSignalRO, PVPositionerPC
@@ -156,7 +157,10 @@ class PIDController(PID):
         self._output = None
         self._run = True
         self._ramping = False
-        self.history = {"output": [], "feedback": [], "setpoint": [], "timestamp": []}
+        self.history = {"output": deque(maxlen=600),
+                        "feedback": deque(maxlen=600),
+                        "setpoint": deque(maxlen=600),
+                        "timestamp": deque(maxlen=600)}
         threading.Thread(target=self._executor).start()
 
     @property

--- a/caproto/ioc_examples/lakeshore.py
+++ b/caproto/ioc_examples/lakeshore.py
@@ -10,6 +10,8 @@ after the setpoint ramp is complete.
 This also includes a simulated material that can be heated/cooled and a
 PID controller that can be connected to arbitrary systems. The PIDController
 has a ramp feature so that the setpoint ramps to the target value gradually.
+
+This example has two non-standard dependencies: ophyd, and simple_pid
 """
 
 import asyncio

--- a/caproto/ioc_examples/lakeshore.py
+++ b/caproto/ioc_examples/lakeshore.py
@@ -22,7 +22,7 @@ import time
 
 from collections import deque
 from simple_pid import PID
-from caproto.server import PVGroup, ioc_arg_parser, pvproperty
+from caproto.server import PVGroup, ioc_arg_parser, pvproperty, run
 from ophyd import EpicsSignal, EpicsSignalRO, PVPositionerPC
 from ophyd import Component as Cpt
 

--- a/caproto/ioc_examples/lakeshore.py
+++ b/caproto/ioc_examples/lakeshore.py
@@ -309,7 +309,7 @@ class LakeshoreIOC(PVGroup):
 
     async def wait_for_completion(self):
         """
-        Wait until the device is changing the setpoint.
+        Wait until the device is done changing the setpoint.
         """
         while True:
             if not self._temperature_controller.ramping:

--- a/caproto/ioc_examples/lakeshore.py
+++ b/caproto/ioc_examples/lakeshore.py
@@ -105,6 +105,7 @@ class PIDController(PID):
     @setpoint.setter
     def setpoint(self, value):
         self._setpoint_target = value
+        self._ramping = True
         if self.ramp_rate is None:
             self._setpoint = value
 
@@ -253,13 +254,9 @@ class Lakeshore336Sim(PVGroup):
 
     async def wait_for_completion(self):
         while True:
-            old_ramping = self._temperature_controller.ramping
-            await asyncio.sleep(0.1)
-            ramping = self._temperature_controller.ramping
-            if old_ramping and not ramping:
+            if not self._temperature_controller.ramping:
                 return
-            else:
-                old_ramping = ramping
+            await asyncio.sleep(0.1)
 
     @setpoint.getter
     async def setpoint(self, instance):

--- a/caproto/ioc_examples/lakeshore.py
+++ b/caproto/ioc_examples/lakeshore.py
@@ -6,7 +6,7 @@ import time
 
 from simple_pid import PID
 from caproto.server import PVGroup, ioc_arg_parser, pvproperty, run
-from ophyd import EpicsSignal, EpicsSignalRO, Device, PVPositionerPC
+from ophyd import EpicsSignal, EpicsSignalRO, PVPositionerPC
 from ophyd import Component as Cpt
 
 

--- a/caproto/ioc_examples/lakeshore.py
+++ b/caproto/ioc_examples/lakeshore.py
@@ -1,6 +1,6 @@
+import functools
 import time
 import threading
-
 from caproto.server import PVGroup, ioc_arg_parser, pvproperty, run
 from simple_pid import PID
 
@@ -258,6 +258,8 @@ class Lakeshore336Sim(PVGroup):
             ramping = self._temperature_controller.ramping
             if old_ramping and not ramping:
                 return
+            else:
+                old_ramping = ramping
 
     @setpoint.getter
     async def setpoint(self, instance):

--- a/caproto/ioc_examples/lakeshore.py
+++ b/caproto/ioc_examples/lakeshore.py
@@ -1,3 +1,12 @@
+"""
+An IOC with a simulated temperature controller.
+This demonstrates how to do put_completion with a caproto ioc and ophyd device.
+
+Another interesting part of this example is the use of settle_time. Settle_time allows us to wait an additional amount after the put_completion. It is used here to wait for the stabilization of the material temperature after the setpoint ramp is complete.
+
+This also includes a simulated material that can be heated/cooled and a PID controller that can be connected to arbitrary systems. The PIDController has a ramp feature so that the setpoint ramps to the target value gradually.
+"""
+
 import asyncio
 import contextvars
 import functools

--- a/caproto/ioc_examples/lakeshore.py
+++ b/caproto/ioc_examples/lakeshore.py
@@ -1,0 +1,203 @@
+import time
+import threading
+
+from caproto.server import PVGroup, ioc_arg_parser, pvproperty, run
+from simple_pid import PID
+
+
+class ThermalMaterial:
+    """
+    A material that you can heat and cool.
+
+    Parameters
+    ----------
+    thermal_mass: float, optional
+        How the material's energy relates to its temperature.
+    start_temp: float, optional
+        Starting temperature of the material.
+    ambient_temp: float, optional
+        The temperature of the environment.
+    heater_power: float, optional
+        The rate at which the heater is adding energy to the sample.
+    cooling_constant: float, optional
+        How readily the sample releases energy to the environment.
+    """
+
+    def __init__(
+        self,
+        thermal_mass=100,
+        start_temp=100,
+        ambient_temp=0,
+        heater_power=0,
+        cooling_constant=1,
+    ):
+        self.energy = start_temp * thermal_mass
+        self.thermal_mass = thermal_mass
+        self.ambient_temp = ambient_temp
+        self._heater_power = heater_power
+        self.cooling_constant = cooling_constant
+        self.time = time.time()
+        self._run = True
+        threading.Thread(target=self._simulate).start()
+
+    @property
+    def temperature(self):
+        return self.energy / self.thermal_mass
+
+    @property
+    def heater_power(self):
+        return self._heater_power
+
+    @heater_power.setter
+    def heater_power(self, value):
+        self._heater_power = value
+
+    def set_heater_power(self, value):
+        self._heater_power = value
+
+    def stop(self):
+        self._run = False
+
+    def _cooling(self):
+        return -1 * self.cooling_constant * (self.temperature - self.ambient_temp)
+
+    def _heating(self):
+        return self.heater_power
+
+    def _simulate(self):
+        while self._run:
+            now = time.time()
+            time_delta = now - self.time
+            self.time = now
+            self.energy += self._cooling() * time_delta
+            self.energy += self._heating() * time_delta
+            time.sleep(0.1)
+
+
+class PIDController(PID):
+    def __init__(self, get_feedback, set_output, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._get_feedback = get_feedback
+        self._set_output = set_output
+        self._feedback = None
+        self._output = None
+        self._run = True
+        self.history = {'output':[], 'feedback':[], 'setpoint':[], 'timestamp':[]}
+        threading.Thread(target=self._executor).start()
+
+    @property
+    def output(self):
+        return self._output
+
+    @property
+    def feedback(self):
+        return self._feedback
+
+    def stop(self):
+        self.run = False
+
+    def _executor(self):
+        while self._run:
+            self._feedback = self._get_feedback()
+            self._output = self.__call__(self._get_feedback())
+            self.history['output'].append(self._output)
+            self.history['feedback'].append(self._feedback)
+            self.history['setpoint'].append(self.setpoint)
+            self.history['timestamp'].append(time.time())
+            self._set_output(self._output)
+            time.sleep(0.1)
+
+
+class Lakeshore336Sim(PVGroup):
+    """
+    Simulated Lakeshore IOC.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    Kp = pvproperty(
+        value=0,
+        dtype=float,
+        name='Kp',
+        doc="PID parameter Kp"
+    )
+
+    Ki = pvproperty(
+        value=0,
+        dtype=float,
+        name='Ki',
+        doc="PID parameter Ki"
+    )
+
+    Kd = pvproperty(
+        value=0,
+        dtype=float,
+        name='Kd',
+        doc="PID parameter Kd"
+    )
+
+    setpoint = pvproperty(
+        value=100,
+        dtype=float,
+        name='setpoint',
+        doc="temperature setpoint"
+    )
+
+    feedback = pvproperty(
+        value=100,
+        dtype=float,
+        name='feedback',
+        doc="temperature feedback"
+    )
+
+    output = pvproperty(
+        value=100,
+        dtype=float,
+        name='output',
+        doc="output value"
+    )
+
+
+if __name__ == '__main__':
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix='Lakeshore336Sim:',
+        desc="Lakeshore336Sim IOC")
+    ioc = Lakeshore336Sim(**ioc_options)
+    print('PVs:', list(ioc.pvdb))
+    run(ioc.pvdb, **run_options)
+
+"""
+    # Example Code
+
+    import matplotlib.pyplot as plt
+    from matplotlib.animation import FuncAnimation
+
+    sample = ThermalMaterial()
+    setpoint = 150
+
+    temperature_controller = PIDController(
+        lambda: sample.temperature,
+        sample.set_heater_power,
+        Kp=1,
+        Ki=0.1,
+        Kd=0.05,
+        setpoint=setpoint,
+    )
+
+    def update(i):
+        x_values = temperature_controller.history['timestamp']
+        plt.cla()
+        plt.plot(x_values, temperature_controller.history['feedback'])
+        plt.plot(x_values, temperature_controller.history['output'])
+        plt.plot(x_values, temperature_controller.history['setpoint'])
+        plt.xlabel('time')
+        plt.ylabel('temperature')
+        plt.title('Temperature Controller')
+        plt.gcf().autofmt_xdate()
+        plt.tight_layout()
+
+    ani = FuncAnimation(plt.gcf(), update, 1000)
+    plt.tight_layout()
+    plt.amplhow(block=False)
+"""

--- a/caproto/ioc_examples/lakeshore.py
+++ b/caproto/ioc_examples/lakeshore.py
@@ -129,15 +129,12 @@ class PIDController(PID):
 
             # Ramping logic.
             remaining = (self._setpoint_target - self.setpoint)
+            self._ramping = bool(remaining)
             if isinstance(self.ramp_rate, (int, float)):
                 if remaining > 0:
                     self._setpoint += min(self.ramp_rate*iteration_time, abs(remaining))
-                    self._ramping = True
                 elif remaining < 0:
                     self._setpoint -= min(self.ramp_rate*iteration_time, abs(remaining))
-                    self._ramping = True
-                elif remaining == 0:
-                    self._ramping = False
             elif self.ramp_rate is None and remaining != 0:
                 self._setpoint = self._setpoint_target
 

--- a/caproto/ioc_examples/lakeshore.py
+++ b/caproto/ioc_examples/lakeshore.py
@@ -27,9 +27,6 @@ from ophyd import EpicsSignal, EpicsSignalRO, PVPositionerPC
 from ophyd import Component as Cpt
 
 
-pvproperty_with_rbv = get_pv_pair_wrapper(setpoint_suffix="", readback_suffix="_rbv")
-
-
 class ThermalMaterial:
     """
     A material that you can heat and cool.
@@ -279,9 +276,10 @@ class LakeshoreIOC(PVGroup):
             await self.feedback_rbv.write(self._temperature_controller.feedback)
             await self.ramp_rate_rbv.write(self._temperature_controller.ramp_rate)
             await self.output_rbv.write(self._temperature_controller.output)
+            await asyncio.sleep(.1)
 
     Kp = pvproperty(value=0, dtype=float, name="Kp", doc="PID parameter Kp")
-    Kp_rbv = pvproperty(dtype=float, name="Kp_rbv", doc="PID parameter Kp readback")
+    Kp_rbv = pvproperty(value=0, dtype=float, name="Kp_rbv", doc="PID parameter Kp readback")
 
     @Kp.putter
     async def Kp(self, instance, value):

--- a/caproto/ioc_examples/lakeshore.py
+++ b/caproto/ioc_examples/lakeshore.py
@@ -22,7 +22,7 @@ import time
 
 from collections import deque
 from simple_pid import PID
-from caproto.server import PVGroup, ioc_arg_parser, pvproperty, run, get_pv_pair_wrapper
+from caproto.server import PVGroup, ioc_arg_parser, pvproperty
 from ophyd import EpicsSignal, EpicsSignalRO, PVPositionerPC
 from ophyd import Component as Cpt
 

--- a/caproto/ioc_examples/lakeshore.py
+++ b/caproto/ioc_examples/lakeshore.py
@@ -154,8 +154,8 @@ class Lakeshore336Sim(PVGroup):
         self._sample = ThermalMaterial()
 
         self._temperature_controller = PIDController(
-            lambda: sample.temperature,
-            sample.set_heater_power,
+            lambda: self._sample.temperature,
+            self._sample.set_heater_power,
             Kp=1,
             Ki=0.1,
             Kd=0.05,
@@ -169,12 +169,30 @@ class Lakeshore336Sim(PVGroup):
         doc="PID parameter Kp"
     )
 
+    @Kp.getter
+    async def Kp(self, instance):
+        return self._temperature_controller.Kp
+
+    @Kp.putter
+    async def Kp(self, instance, value):
+        self._temperature_controller.Kp = value
+        return value
+
     Ki = pvproperty(
         value=0,
         dtype=float,
         name='Ki',
         doc="PID parameter Ki"
     )
+
+    @Ki.getter
+    async def Ki(self, instance):
+        return self._temperature_controller.Ki
+
+    @Ki.putter
+    async def Ki(self, instance, value):
+        self._temperature_controller.Ki = value
+        return value
 
     Kd = pvproperty(
         value=0,
@@ -183,12 +201,30 @@ class Lakeshore336Sim(PVGroup):
         doc="PID parameter Kd"
     )
 
+    @Kd.getter
+    async def Kd(self, instance):
+        return self._temperature_controller.Kd
+
+    @Kd.putter
+    async def Kd(self, instance, value):
+        self._temperature_controller.Kd = value
+        return value
+
     setpoint = pvproperty(
         value=100,
         dtype=float,
         name='setpoint',
         doc="temperature setpoint"
     )
+
+    @setpoint.getter
+    async def setpoint(self, instance):
+        return self._temperature_controller.setpoint
+
+    @setpoint.putter
+    async def setpoint(self, instance, value):
+        self._temperature_controller.setpoint = value
+        return value
 
     feedback = pvproperty(
         value=100,
@@ -197,12 +233,20 @@ class Lakeshore336Sim(PVGroup):
         doc="temperature feedback"
     )
 
+    @feedback.getter
+    async def feedback(self, instance):
+        return self._temperature_controller.feedback
+
     output = pvproperty(
         value=100,
         dtype=float,
         name='output',
         doc="output value"
     )
+
+    @output.getter
+    async def output(self, instance):
+        return self._temperature_controller.output
 
 
 if __name__ == '__main__':

--- a/caproto/ioc_examples/lakeshore.py
+++ b/caproto/ioc_examples/lakeshore.py
@@ -279,7 +279,7 @@ class LakeshoreIOC(PVGroup):
             await asyncio.sleep(.1)
 
     Kp = pvproperty(value=0, dtype=float, name="Kp", doc="PID parameter Kp")
-    Kp_rbv = pvproperty(value=0, dtype=float, name="Kp_rbv", doc="PID parameter Kp readback")
+    Kp_rbv = pvproperty(dtype=float, name="Kp_rbv", doc="PID parameter Kp readback")
 
     @Kp.putter
     async def Kp(self, instance, value):

--- a/caproto/ioc_examples/lakeshore.py
+++ b/caproto/ioc_examples/lakeshore.py
@@ -2,9 +2,14 @@
 An IOC with a simulated temperature controller.
 This demonstrates how to do put_completion with a caproto ioc and ophyd device.
 
-Another interesting part of this example is the use of settle_time. Settle_time allows us to wait an additional amount after the put_completion. It is used here to wait for the stabilization of the material temperature after the setpoint ramp is complete.
+Another interesting part of this example is the use of settle_time.
+Settle_time allows us to wait an additional amount after the put_completion.
+It is used here to wait for the stabilization of the material temperature
+after the setpoint ramp is complete.
 
-This also includes a simulated material that can be heated/cooled and a PID controller that can be connected to arbitrary systems. The PIDController has a ramp feature so that the setpoint ramps to the target value gradually.
+This also includes a simulated material that can be heated/cooled and a
+PID controller that can be connected to arbitrary systems. The PIDController
+has a ramp feature so that the setpoint ramps to the target value gradually.
 """
 
 import asyncio
@@ -106,7 +111,8 @@ class PIDController(PID):
     -------
     import matplotlib.pyplot as plt
     from matplotlib.animation import FuncAnimation
-    from caproto.ioc_examples.lakeshore import PIDController, ThermalMaterial
+    from caproto.ioc_examples.lakeshore import (PIDController,
+    ThermalMaterial)
 
     sample = ThermalMaterial()
     setpoint = 150

--- a/caproto/ioc_examples/lakeshore.py
+++ b/caproto/ioc_examples/lakeshore.py
@@ -108,6 +108,41 @@ class PIDController(PID):
             time.sleep(0.1)
 
 
+"""
+    # Temperature Controller Example Code
+
+    import matplotlib.pyplot as plt
+    from matplotlib.animation import FuncAnimation
+
+    sample = ThermalMaterial()
+    setpoint = 150
+
+    temperature_controller = PIDController(
+        lambda: sample.temperature,
+        sample.set_heater_power,
+        Kp=1,
+        Ki=0.1,
+        Kd=0.05,
+        setpoint=setpoint,
+    )
+
+    def update(i):
+        x_values = temperature_controller.history['timestamp']
+        plt.cla()
+        plt.plot(x_values, temperature_controller.history['feedback'])
+        plt.plot(x_values, temperature_controller.history['output'])
+        plt.plot(x_values, temperature_controller.history['setpoint'])
+        plt.xlabel('time')
+        plt.ylabel('temperature')
+        plt.title('Temperature Controller')
+        plt.gcf().autofmt_xdate()
+        plt.tight_layout()
+
+    ani = FuncAnimation(plt.gcf(), update, 1000)
+    plt.tight_layout()
+    plt.amplhow(block=False)
+"""
+
 class Lakeshore336Sim(PVGroup):
     """
     Simulated Lakeshore IOC.
@@ -115,6 +150,17 @@ class Lakeshore336Sim(PVGroup):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        self._sample = ThermalMaterial()
+
+        self._temperature_controller = PIDController(
+            lambda: sample.temperature,
+            sample.set_heater_power,
+            Kp=1,
+            Ki=0.1,
+            Kd=0.05,
+            setpoint=150,
+        )
 
     Kp = pvproperty(
         value=0,
@@ -167,37 +213,3 @@ if __name__ == '__main__':
     print('PVs:', list(ioc.pvdb))
     run(ioc.pvdb, **run_options)
 
-"""
-    # Example Code
-
-    import matplotlib.pyplot as plt
-    from matplotlib.animation import FuncAnimation
-
-    sample = ThermalMaterial()
-    setpoint = 150
-
-    temperature_controller = PIDController(
-        lambda: sample.temperature,
-        sample.set_heater_power,
-        Kp=1,
-        Ki=0.1,
-        Kd=0.05,
-        setpoint=setpoint,
-    )
-
-    def update(i):
-        x_values = temperature_controller.history['timestamp']
-        plt.cla()
-        plt.plot(x_values, temperature_controller.history['feedback'])
-        plt.plot(x_values, temperature_controller.history['output'])
-        plt.plot(x_values, temperature_controller.history['setpoint'])
-        plt.xlabel('time')
-        plt.ylabel('temperature')
-        plt.title('Temperature Controller')
-        plt.gcf().autofmt_xdate()
-        plt.tight_layout()
-
-    ani = FuncAnimation(plt.gcf(), update, 1000)
-    plt.tight_layout()
-    plt.amplhow(block=False)
-"""

--- a/caproto/ioc_examples/lakeshore.py
+++ b/caproto/ioc_examples/lakeshore.py
@@ -80,7 +80,7 @@ class ThermalMaterial:
 
 
 class PIDController(PID):
-    def __init__(self, get_feedback, set_output, ramp_rate=None,
+    def __init__(self, get_feedback, set_output, ramp_rate=1,
                  setpoint=150,
                  *args, **kwargs):
         self._setpoint = setpoint
@@ -307,7 +307,7 @@ from ophyd import Component as Cpt
 
 class Lakeshore(Device):
     feedback = Cpt(EpicsSignalRO, ':feedback')
-    setpoint = Cpt(EpicsSignal, ':setpoint')
+    setpoint = Cpt(EpicsSignal, ':setpoint', put_complete=True)
     ramp_rate = Cpt(EpicsSignal, 'ramp_rate')
 
 


### PR DESCRIPTION
An IOC with a simulated temperature controller and thermal material.
This demonstrates how to do put_completion with a caproto ioc and ophyd device.

Another interesting part of this example is the use of settle_time.  Settle_time allows us to wait an additional amount after the put_completion.  It is used here to wait for the stabilization of the material temperature after the setpoint ramp is complete.

This also includes a simulated material that can be heated/cooled and a PID controller that can be connected to arbitrary systems.  The PIDController has a ramp feature so that the setpoint ramps to the target value gradually.

Here is a plot of the pid controller working:
![image](https://user-images.githubusercontent.com/11858848/224826315-80aed61b-2409-499c-8ac4-e0dad6203063.png)


