### PR TITLE
CI: move azure pipelines to Ubuntu 22.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,7 +106,7 @@ jobs:
 - job: 'Publish'
   dependsOn: 'Test'
   pool:
-    vmImage: 'Ubuntu 16.04'
+    vmImage: 'ubuntu-22.04'
 
   steps:
   - task: UsePythonVersion@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,15 +4,15 @@ jobs:
 
 - job: 'Test'
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-22.04'
   strategy:
     matrix:
-      Python 3.8:
-        python.version: '3.8'
       Python 3.9:
         python.version: '3.9'
       Python 3.10:
         python.version: '3.10'
+      Python 3.11:
+        python.version: '3.11'
 
   steps:
   - task: UsePythonVersion@0


### PR DESCRIPTION
18.04 was removed in December 2022 per https://learn.microsoft.com/en-us/azure/devops/release-notes/2022/sprint-208-update

If this upgrade isn't easy, I'm going to just nuke Azure Pipelines entirely from this repository because it's failing our test suite unnecessarily