### PR TITLE
FIX: issue 797 - subscription queue loss with eventsoff/eventson

### DIFF
--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -1,10 +1,9 @@
-import copy
 import logging
 import sys
 import time
 import weakref
 from collections import ChainMap, defaultdict, deque, namedtuple
-from collections.abc import Iterable
+from typing import DefaultDict, Deque
 
 import caproto as ca
 from caproto import (CaprotoKeyError, CaprotoNetworkError, CaprotoRuntimeError,
@@ -12,7 +11,8 @@ from caproto import (CaprotoKeyError, CaprotoNetworkError, CaprotoRuntimeError,
                      get_environment_variables)
 
 from .._constants import MAX_UDP_RECV
-from .._dbr import SubscriptionType, _LongStringChannelType
+from .._dbr import DbrTypeBase, _LongStringChannelType
+from .._utils import apply_deadband_filter
 
 # ** Tuning this parameters will affect the servers' performance **
 # ** under high load. **
@@ -690,6 +690,8 @@ class VirtualCircuit:
 
 
 class Context:
+    subscriptions: DefaultDict[SubscriptionSpec, Deque[Subscription]]
+
     def __init__(self, pvdb, interfaces=None):
         if interfaces is None:
             interfaces = ca.get_server_address_list()
@@ -887,135 +889,133 @@ class Context:
             # This queue receives updates that match the db_entry, data_type
             # and mask ("subscription spec") of one or more subscriptions.
             sub_specs, metadata, values, flags, sub = await self.subscription_queue.get()
-            await self._subscription_queue_iteration(sub_specs, metadata,
-                                                     values, flags, sub)
+            if sub is None:
+                # Broadcast to all Subscriptions for the relevant
+                # SubscriptionSpec(s).
+                for sub_spec in sub_specs:
+                    for sub in self.subscriptions[sub_spec]:
+                        await self._subscription_queue_send(
+                            sub_spec,
+                            sub,
+                            metadata=metadata,
+                            values=values,
+                            flags=flags,
+                        )
+            else:
+                # A specific Subscription has been specified, which means this
+                # specific update was prompted by Subscription being new, not
+                # prompted by a new value. The update should only be sent to that
+                # specific Subscription.
+                if len(sub_specs) != 1:
+                    raise RuntimeError("Unexpected sub_specs length")
 
-    async def _subscription_queue_iteration(self, sub_specs, metadata, values,
-                                            flags, sub):
+                sub_spec, = sub_specs
+                await self._subscription_queue_send(
+                    sub_spec,
+                    sub,
+                    metadata=metadata,
+                    values=values,
+                    flags=flags,
+                )
+
+    async def _subscription_queue_send(
+        self,
+        sub_spec: SubscriptionSpec,
+        sub: Subscription,
+        metadata: DbrTypeBase,
+        values,
+        flags: int,
+    ):
         '''Called on every item from the Context subscription queue
 
         This queue receives updates that match the db_entry, data_type and mask
         ("subscription spec") of one or more subscriptions.
         '''
-        subs = []
-        if sub is None:
-            # Broadcast to all Subscriptions for the relevant
-            # SubscriptionSpec(s).
-            for sub_spec in sub_specs:
-                subs.extend(self.subscriptions[sub_spec])
-        else:
-            # A specific Subscription has been specified, which means this
-            # specific update was prompted by Subscription being new, not
-            # prompted by a new value. The update should only be sent to that
-            # specific Subscription.
-            subs = [sub]
-            sub_spec, = sub_specs
         # Pack the data and metadata into an EventAddResponse and send it.  We
         # have to make a new response for each channel because each may have a
         # different requested data_count.
-        for sub in subs:
-            circuit = sub.circuit
-            s_flags = flags
-            chan = sub.channel
+        chan = sub.channel
 
-            # This is a pass-through if arr is None.
-            values = apply_arr_filter(sub_spec.channel_filter.arr, values)
+        # This is a pass-through if arr is None.
+        values = apply_arr_filter(sub_spec.channel_filter.arr, values)
 
-            # If the subscription has a non-zero value respect it, else default
-            # to the full length of the data.
-            data_count = sub.data_count or len(values)
-            if data_count != len(values):
-                values = values[:data_count]
+        # If the subscription has a non-zero value respect it, else default
+        # to the full length of the data.
+        data_count = sub.data_count or len(values)
+        if data_count != len(values):
+            values = values[:data_count]
 
-            command = chan.subscribe(
-                data=values, metadata=metadata, data_type=sub.data_type,
-                data_count=data_count, subscriptionid=sub.subscriptionid,
-                status=1)
+        command = chan.subscribe(
+            data=values,
+            metadata=metadata,
+            data_type=sub.data_type,
+            data_count=data_count,
+            subscriptionid=sub.subscriptionid,
+            status=1,
+        )
 
-            dbnd = sub.channel_filter.dbnd
-            if dbnd is not None:
-                new = values
-                if hasattr(new, 'endian'):
-                    if new.endian != host_endian:
-                        new = copy.copy(new)
-                        new.byteswap()
-                old = self.last_dead_band.get(sub)
-                if old is not None:
-                    old_iterable = isinstance(old, Iterable)
-                    new_iterable = isinstance(new, Iterable)
-                    if ((not old_iterable or (old_iterable and len(old) == 1)) and
-                            (not new_iterable or (new_iterable and len(new) == 1))):
-                        if old_iterable:
-                            old, = old
-                        if new_iterable:
-                            new, = new
-                        # Cool that was fun.
-                        if dbnd.m == 'rel':
-                            out_of_band = dbnd.d < abs((old - new) / old)
-                        else:  # must be 'abs' -- was already validated
-                            out_of_band = dbnd.d < abs(old - new)
-                        # We have verified that that EPICS considers DBE_LOG
-                        # etc. to be an absolute (not relative) threshold.
-                        abs_diff = abs(old - new)
-                        if abs_diff > sub.db_entry.log_atol:
-                            s_flags |= SubscriptionType.DBE_LOG
-                            if abs_diff > sub.db_entry.value_atol:
-                                s_flags |= SubscriptionType.DBE_VALUE
+        dbnd = sub.channel_filter.dbnd
+        if dbnd is not None:
+            deadband_tracking_value = apply_deadband_filter(
+                previous_value=self.last_dead_band.get(sub),
+                new_value=values,
+                sub=sub,
+                flags=flags,
+                host_endian=host_endian
+            )
+            if deadband_tracking_value is None:
+                return
 
-                        if not (out_of_band and (sub.mask & s_flags)):
-                            continue
-                        else:
-                            self.last_dead_band[sub] = new
-                else:
-                    self.last_dead_band[sub] = new
+            self.last_dead_band[sub] = deadband_tracking_value
 
-            # Special-case for edge-triggered modes of the sync Channel
-            # Filter (before, after, first, last). Only send the first
-            # update to each channel.
-            sync = sub.channel_filter.sync
-            if sync is not None:
-                last_update = self.last_sync_edge_update[sub][sync.s].get(sync.m)
-                if last_update and last_update == command:
-                    # This is a redundant update. Do not send.
-                    continue
-                else:
-                    # Stash this and then send it.
-                    self.last_sync_edge_update[sub][sync.s][sync.m] = command
+        # Special-case for edge-triggered modes of the sync Channel
+        # Filter (before, after, first, last). Only send the first
+        # update to each channel.
+        sync = sub.channel_filter.sync
+        if sync is not None:
+            last_update = self.last_sync_edge_update[sub][sync.s].get(sync.m)
+            if last_update and last_update == command:
+                # This is a redundant update. Do not send.
+                return
 
-            # This update will be put at the back of the line of updates to be
-            # sent.
-            #
-            # If len(unexpired_updates[id]) == SUBSCRIPTION_BACKLOG_QUOTA, then
-            # the command at the front of the line will be kicked out.  It is
-            # not literally removed from the queue but whenever it reaches the
-            # front of the line it will dropped on the floor instead of sent.
-            # This effectively prioritizes sending the client "new news"
-            # instead of "old news".
+            # Stash this and then send it.
+            self.last_sync_edge_update[sub][sync.s][sync.m] = command
 
-            # If this circuit has been sent EventsOff by the client, do not
-            # queue any updates until the client sends EventsOn to signal that
-            # it has caught up. But stash the most recent update for each
-            # subscription, which will immediately send when we turn events
-            # back on.
-            if not circuit.events_on.is_set():
-                circuit.most_recent_updates[sub.subscriptionid] = command
-                continue
+        # This update will be put at the back of the line of updates to be
+        # sent.
+        #
+        # If len(unexpired_updates[id]) == SUBSCRIPTION_BACKLOG_QUOTA, then the
+        # command at the front of the line will be kicked out.  It is not
+        # literally removed from the queue but whenever it reaches the front of
+        # the line it will dropped on the floor instead of sent. This
+        # effectively prioritizes sending the client "new news" instead of "old
+        # news".
+        circuit = sub.circuit
 
-            # This is an OrderedBoundedSet, a set with a maxlen, containing
-            # only commands for this particular subscription.
-            circuit.unexpired_updates[sub.subscriptionid].append(command)
+        # If this circuit has been sent EventsOff by the client, do not queue
+        # any updates until the client sends EventsOn to signal that it has
+        # caught up. But stash the most recent update for each subscription,
+        # which will immediately send when we turn events back on.
+        if not circuit.events_on.is_set():
+            circuit.most_recent_updates[sub.subscriptionid] = command
+            return
 
-            # This is a queue with the commands from _all_ subscriptions on
-            # this circuit.
-            try:
-                await circuit.subscription_queue.put(weakref.ref(command))
-            except circuit.QueueFull:
-                # We have hit the overall max for subscription backlog.
-                circuit.log.warning(
-                    "Critically high EventAddResponse load. Dropping all "
-                    "queued responses on this circuit.")
-                circuit.subscription_queue.clear()
-                circuit.unexpired_updates.clear()
+        # This is an OrderedBoundedSet, a set with a maxlen, containing only
+        # commands for this particular subscription.
+        circuit.unexpired_updates[sub.subscriptionid].append(command)
+
+        # This is a queue with the commands from _all_ subscriptions on this
+        # circuit.
+        try:
+            await circuit.subscription_queue.put(weakref.ref(command))
+        except circuit.QueueFull:
+            # We have hit the overall max for subscription backlog.
+            circuit.log.warning(
+                "Critically high EventAddResponse load. Dropping all "
+                "queued responses on this circuit."
+            )
+            circuit.subscription_queue.clear()
+            circuit.unexpired_updates.clear()
 
     async def broadcast_beacon_loop(self):
         self.log.debug('Will send beacons to %r',

--- a/caproto/trio/server.py
+++ b/caproto/trio/server.py
@@ -142,7 +142,7 @@ class VirtualCircuit(_VirtualCircuit):
         self.subscription_queue = self.subscription_chan.send
 
         self.write_event = Event()
-        self.events_on = trio.Event()
+        self.events_on = Event()
 
     async def run(self):
         await self.nursery.start(self.command_queue_loop)


### PR DESCRIPTION
## Context

(Builds on #814 as it refactored subscription code; that must be merged first)

Closes issue #797 

Reproduced with: https://github.com/klauer/issue_797_caproto_subs
Server: `support-ioc.py` (run this first)
Client: `client_issue_797.py` (run this second)

The final result should indicate that each PV saw one subscription total.
caproto master will range from 1 to 19 subscriptions on average.
This PR should bump that up to the expected 20.

## The fix

This is at least a proof-of-concept method to fix #797. I'm not really sure if it's the best way (if there is one).

Subscription values - generated once and held by way of weakref - were getting cleaned up before the queue had a chance to send them.

I think the current implementation attempts to be smart and save effort in the end, but the complexity in doing so introduces potential for confusing errors like this one.

It may indicate that removing `weakref` entirely could be preferable (at risk of ballooning memory due to greedy clients) - but subscriptions are supposed to be lossless anyway, right?

Regardless, I took the path of making a smaller change rather than removing weakref entirely. This PR says "queue up the latest updates when events are off, but if they get garbage collected before events turn back on again, make note of that and redo the subscription - by reading from the database entry directly - when events turn on"

Thoughts? Anyone? ... Bueller?