### PR TITLE
FIX: issue 797 - subscription queue loss with eventsoff/eventson

### DIFF
--- a/caproto/tests/issue_797_server.py
+++ b/caproto/tests/issue_797_server.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+"""
+Based on code provided by @tkurita in issue 797:
+https://github.com/caproto/caproto/issues/797
+"""
+
+from .. import config_caproto_logging
+from ..server import PVGroup
+from ..server import PvpropertyDouble as Double
+from ..server import PvpropertyInteger as Integer
+from ..server import PvpropertyIntegerRO as IntegerRO
+from ..server import SubGroup, ioc_arg_parser, pvproperty, run
+
+PTN_LENGTH = 65536
+MON_LENGTH = 40960
+
+
+class BPMFBGroup(PVGroup):
+    @SubGroup(prefix="MIRROR:")
+    class MIRROR(PVGroup):
+        BPM_P_GAIN_DP_CNST = pvproperty(
+            value=0, dtype=IntegerRO
+        )
+        BPM_P_SHIFT_DP = pvproperty(
+            value=0, dtype=IntegerRO
+        )
+        BPM_P_GAIN_DR_CNST = pvproperty(
+            value=0, dtype=IntegerRO
+        )
+        BPM_P_SHIFT_DR = pvproperty(
+            value=0, dtype=IntegerRO
+        )
+        BPM_I_GAIN_DR_CNST = pvproperty(
+            value=0, dtype=IntegerRO
+        )
+        BPM_I_SHIFT_DR = pvproperty(
+            value=0, dtype=IntegerRO
+        )
+        BPM_PERIOD_IACC_DR_SET = pvproperty(
+            value=0, dtype=IntegerRO
+        )
+        BPM_GAIN_2FS_CNST = pvproperty(
+            value=0, dtype=IntegerRO
+        )
+        BPM_GN_SHIFT_2FS = pvproperty(
+            value=0, dtype=IntegerRO
+        )
+
+    @SubGroup(prefix="RB:")
+    class RB(PVGroup):
+
+        BPM_P_GAIN_DP_FLOAT = pvproperty(value=0, dtype=Double)
+        BPM_P_GAIN_DR_FLOAT = pvproperty(value=0, dtype=Double)
+        BPM_I_GAIN_DR_FLOAT = pvproperty(value=0, dtype=Double)
+        BPM_GAIN_2FS_FLOAT = pvproperty(value=0, dtype=Double)
+
+    @SubGroup(prefix="SET:")
+    class SET(PVGroup):
+        BPM_P_GAIN_DP_FLOAT = pvproperty(value=0, dtype=Double)
+        BPM_P_GAIN_DR_FLOAT = pvproperty(value=0, dtype=Double)
+        BPM_I_GAIN_DR_FLOAT = pvproperty(value=0, dtype=Double)
+        BPM_GAIN_2FS_FLOAT = pvproperty(value=0, dtype=Double)
+        BPM_P_GAIN_DP_FLOAT_CHANGE = pvproperty(
+            value=0, dtype=Double
+        )
+        BPM_P_GAIN_DR_FLOAT_CHANGE = pvproperty(
+            value=0, dtype=Double
+        )
+        BPM_I_GAIN_DR_FLOAT_CHANGE = pvproperty(
+            value=0, dtype=Double
+        )
+        BPM_GAIN_2FS_FLOAT_CHANGE = pvproperty(
+            value=0, dtype=Double
+        )
+
+
+class DelRPatternGroup(PVGroup):
+    GEN_REFERENCE = pvproperty(value=0, dtype=Integer)
+    FB = pvproperty(value=0, dtype=Double)
+    EXT = pvproperty(value=20, dtype=Double)
+    TIMMING_RISE = pvproperty(value=400.0, dtype=Double)
+    REFERENCE_PTN = pvproperty(value=[0] * PTN_LENGTH, dtype=Integer)  # short
+    REFERENCE_PTN_A = pvproperty(
+        value=[0.0] * MON_LENGTH, dtype=Double
+    )
+    WAVE_SPAN = pvproperty(value=2000.0, dtype=Double)
+    WAVE_DELAY = pvproperty(value=0.0, dtype=Double)
+    XAXIS_MON = pvproperty(
+        value=[float(v) for v in range(0, MON_LENGTH)], dtype=Double
+    )
+
+
+class CAVFBGroup(PVGroup):
+    @SubGroup(prefix="MIRROR:")
+    class MIRROR(PVGroup):
+        CAV_P_GAIN_HN1_CNST = pvproperty(
+            value=0, dtype=IntegerRO
+        )
+        CAV_P_GAIN_HN2_CNST = pvproperty(
+            value=0, dtype=IntegerRO
+        )
+        CAV_P_SHIFT = pvproperty(value=0, dtype=IntegerRO)
+        CAV_I_GAIN_HN1_CNST = pvproperty(
+            value=0, dtype=IntegerRO
+        )
+        CAV_I_GAIN_HN2_CNST = pvproperty(
+            value=0, dtype=IntegerRO
+        )
+        CAV_I_SHIFT = pvproperty(value=0, dtype=IntegerRO)
+        CAV_PERIOD_IACC_SET = pvproperty(
+            value=0, dtype=IntegerRO
+        )
+
+    @SubGroup(prefix="RB:")
+    class RB(PVGroup):
+        CAV_P_GAIN_HN1_FLOAT = pvproperty(value=0, dtype=Double)
+        CAV_I_GAIN_HN1_FLOAT = pvproperty(value=0, dtype=Double)
+        CAV_P_GAIN_HN2_FLOAT = pvproperty(value=0, dtype=Double)
+        CAV_I_GAIN_HN2_FLOAT = pvproperty(value=0, dtype=Double)
+
+    @SubGroup(prefix="SET:")
+    class SET(PVGroup):
+        CAV_P_GAIN_HN1_FLOAT = pvproperty(value=0, dtype=Double)
+        CAV_I_GAIN_HN1_FLOAT = pvproperty(value=0, dtype=Double)
+        CAV_P_GAIN_HN2_FLOAT = pvproperty(value=0, dtype=Double)
+        CAV_I_GAIN_HN2_FLOAT = pvproperty(value=0, dtype=Double)
+
+
+class SupportIOC(PVGroup):
+    CAVFBGroup = SubGroup(CAVFBGroup, prefix="CAVFB:")
+    BPMFBGroup = SubGroup(BPMFBGroup, prefix="BPMFB:")
+    DelRPatternGroup = SubGroup(DelRPatternGroup, prefix="DR_PTN:")
+
+
+if __name__ == "__main__":
+    config_caproto_logging(level="INFO")
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix="SUPPORT:",
+        desc="Run an IOC to reproduce issue 797 for the test suite.",
+        # supported_async_libs=("asyncio",),
+    )
+    ioc = SupportIOC(**ioc_options)
+    run_options["log_pv_names"] = True
+    run(ioc.pvdb, **run_options)

--- a/caproto/tests/test_events_off.py
+++ b/caproto/tests/test_events_off.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from caproto.threading.client import (PV, Context, SharedBroadcaster,
+                                      Subscription)
+
+from .conftest import run_example_ioc
+
+issue_797_pv_suffixes = """
+DR_PTN:XAXIS_MON
+DR_PTN:REFERENCE_PTN_A
+DR_PTN:EXT
+DR_PTN:GEN_REFERENCE
+BPMFB:RB:BPM_P_GAIN_DP_FLOAT
+BPMFB:SET:BPM_I_GAIN_DR_FLOAT_CHANGE
+DR_PTN:TIMMING_RISE
+BPMFB:SET:BPM_P_GAIN_DR_FLOAT
+BPMFB:SET:BPM_GAIN_2FS_FLOAT_CHANGE
+DR_PTN:FB
+DR_PTN:WAVE_SPAN
+DR_PTN:WAVE_DELAY
+BPMFB:SET:BPM_P_GAIN_DR_FLOAT_CHANGE
+BPMFB:RB:BPM_I_GAIN_DR_FLOAT
+BPMFB:RB:BPM_GAIN_2FS_FLOAT
+BPMFB:SET:BPM_P_GAIN_DP_FLOAT
+BPMFB:SET:BPM_P_GAIN_DP_FLOAT_CHANGE
+BPMFB:SET:BPM_I_GAIN_DR_FLOAT
+BPMFB:SET:BPM_GAIN_2FS_FLOAT
+BPMFB:RB:BPM_P_GAIN_DR_FLOAT
+""".split()
+
+
+@pytest.fixture
+def issue_797_pvnames(prefix: str) -> list[str]:
+    return ["".join((prefix, suffix)) for suffix in issue_797_pv_suffixes]
+
+
+@pytest.mark.parametrize("async_lib", ["asyncio", "curio", "trio"])
+def test_issue_797(
+    request: pytest.FixtureRequest,
+    prefix: str,
+    async_lib: str,
+    issue_797_pvnames: list[str],
+):
+    run_example_ioc(
+        "caproto.tests.issue_797_server",
+        request=request,
+        args=["--prefix", prefix, "--async-lib", async_lib],
+        pv_to_check=issue_797_pvnames[-1],
+    )
+
+    shared_broadcaster = SharedBroadcaster()
+    ctx = Context(broadcaster=shared_broadcaster)
+    saw_subs = {}
+
+    def user_callback(sub: Subscription, command):
+        nonlocal last_callback
+
+        print(f"{sub.pv}: {command}")
+        saw_subs.setdefault(sub.pv, 0)
+        saw_subs[sub.pv] += 1
+        last_callback = time.monotonic()
+
+    pvs: list[PV] = ctx.get_pvs(*issue_797_pvnames)
+    for pv in pvs:
+        pv.wait_for_connection()
+
+    for pv in pvs:
+        reading = pv.read()
+        print(f'{pv} read back: {reading}')
+
+    last_callback = time.monotonic()
+    for pv in pvs:
+        print(f"Subscribing to {pv}")
+        sub = pv.subscribe(data_type="time")
+        sub.add_callback(user_callback)
+
+    pv = pvs[0]
+    assert pv.circuit_manager is not None
+
+    # Mimic what we saw in the log:
+    pv.circuit_manager.events_off()
+    pv.circuit_manager.events_on()
+    pv.circuit_manager.events_off()
+    pv.circuit_manager.events_on()
+
+    def get_secs_since_last_sub() -> float:
+        return time.monotonic() - last_callback
+
+    # Wait until a second after subscriptions come in
+    while get_secs_since_last_sub() < 1.0:
+        print(
+            "Waiting for subs. Last sub was this many seconds ago: ",
+            get_secs_since_last_sub(),
+            "So far, saw this many PVs:", len(saw_subs)
+        )
+        time.sleep(0.1)
+
+    ctx.disconnect()
+
+    print("Done.\n\n")
+    print(f"Total PVs: {len(pvs)}")
+    print("Saw this many subscription callbacks:")
+
+    for pv, count in saw_subs.items():
+        print(pv.name, count)
+
+    print("Total PVs that had at least one subscription: ", len(saw_subs))
+    print("Total subscriptions: ", sum(count for count in saw_subs.values()))
+    assert len(saw_subs) == len(issue_797_pvnames)


### PR DESCRIPTION
## Context

Closes issue #797 

This initially was the "alternate" solution: uses only `subscriptions_to_resend` and avoids caching data from dropped subscriptions during the period where events are off (and data gets garbage collected) which became my preferred solution to the issue.

## Issue background and reproduction

Reproduced with: https://github.com/klauer/issue_797_caproto_subs
Server: `support-ioc.py` (run this first)
Client: `client_issue_797.py` (run this second)

The final result should indicate that each PV saw one subscription total.
caproto master will range from 1 to 19 subscriptions on average.
This PR should bump that up to the expected 20.

This is now part of the test suite in this PR.

## The fix

Subscription values - generated once and held by way of weakref - were getting cleaned up before the queue had a chance to send them.

The current implementation attempts to be smart and save effort in the end, but the complexity in doing so introduces potential for confusing errors like this one.

This PR says "queue up the latest updates when events are off, but if they get garbage collected before events turn back on again, make note of that and redo the subscription - by reading from the database entry directly - when events turn on"

Though subtle, this importantly also reorders log messages and marking/clearing of the "events on" flag so that the output of a server program can be better correlated to the internal state of the server. 