### PR TITLE
Reuse existing context if none is specified

### DIFF
--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -1032,7 +1032,7 @@ def caget_many(pvlist, as_string=False, count=None, as_numpy=True, timeout=5.0,
     as possible to fetch many values.
     """
     if context is None:
-        context = Context(PV._default_context.broadcaster)
+        context = PV._default_context
 
     pvs = context.get_pvs(*pvlist)
 


### PR DESCRIPTION
`caproto.threading.pyepics_compat.caget_many` inadvertently created a new CA context every time this function was called without an explicitly specified context. With this PR, it instead reuses the default context, like the other functions in the module do.

This closes #824.