### PR TITLE
STY: fix flake8 errors

### DIFF
--- a/caproto/server/conversion.py
+++ b/caproto/server/conversion.py
@@ -180,19 +180,20 @@ def pvfunction_to_device_function(name, pvf, *, indent='    '):
     args = ', '.join(format_arg(spec) for spec in pvf.pvspec
                      if spec.attr not in skip_attrs)
     yield f"{indent}def call(self, {args}):"
+    double_indent = indent * 2
     if pvf.__doc__:
-        yield f"{indent*2}'{pvf.__doc__}'"
+        yield f"{double_indent}'{pvf.__doc__}'"
     for pvspec in pvf.pvspec:
         if pvspec.attr not in skip_attrs:
-            yield (f"{indent*2}self.{pvspec.attr}.put({pvspec.attr}, "
+            yield (f"{double_indent}self.{pvspec.attr}.put({pvspec.attr}, "
                    "wait=True)")
 
-    yield f"{indent*2}self.process.put(1, wait=True)"
-    yield f"{indent*2}status = self.status.get(use_monitor=False)"
-    yield f"{indent*2}retval = self.retval.get(use_monitor=False)"
-    yield f"{indent*2}if status != 'Success':"
+    yield f"{double_indent}self.process.put(1, wait=True)"
+    yield f"{double_indent}status = self.status.get(use_monitor=False)"
+    yield f"{double_indent}retval = self.retval.get(use_monitor=False)"
+    yield f"{double_indent}if status != 'Success':"
     yield f"{indent*3}raise RuntimeError(f'RPC function failed: {{status}}')"
-    yield f"{indent*2}return retval"
+    yield f"{double_indent}return retval"
 
 
 def group_to_device(group):

--- a/caproto/server/conversion.py
+++ b/caproto/server/conversion.py
@@ -180,20 +180,21 @@ def pvfunction_to_device_function(name, pvf, *, indent='    '):
     args = ', '.join(format_arg(spec) for spec in pvf.pvspec
                      if spec.attr not in skip_attrs)
     yield f"{indent}def call(self, {args}):"
-    double_indent = indent * 2
+    indent_ = indent * 2
+    indent__ = indent * 3
     if pvf.__doc__:
-        yield f"{double_indent}'{pvf.__doc__}'"
+        yield f"{indent_}'{pvf.__doc__}'"
     for pvspec in pvf.pvspec:
         if pvspec.attr not in skip_attrs:
-            yield (f"{double_indent}self.{pvspec.attr}.put({pvspec.attr}, "
+            yield (f"{indent_}self.{pvspec.attr}.put({pvspec.attr}, "
                    "wait=True)")
 
-    yield f"{double_indent}self.process.put(1, wait=True)"
-    yield f"{double_indent}status = self.status.get(use_monitor=False)"
-    yield f"{double_indent}retval = self.retval.get(use_monitor=False)"
-    yield f"{double_indent}if status != 'Success':"
-    yield f"{indent*3}raise RuntimeError(f'RPC function failed: {{status}}')"
-    yield f"{double_indent}return retval"
+    yield f"{indent_}self.process.put(1, wait=True)"
+    yield f"{indent_}status = self.status.get(use_monitor=False)"
+    yield f"{indent_}retval = self.retval.get(use_monitor=False)"
+    yield f"{indent_}if status != 'Success':"
+    yield f"{indent__}raise RuntimeError(f'RPC function failed: {{status}}')"
+    yield f"{indent_}return retval"
 
 
 def group_to_device(group):

--- a/caproto/tests/test_server.py
+++ b/caproto/tests/test_server.py
@@ -209,15 +209,15 @@ def test_with_caput(backends, prefix, pvdb_from_server_example, server, pv,
 
         clean_func = None
         if isinstance(db_entry, (ca.ChannelInteger, ca.ChannelDouble)):
-            def clean_func(v):
+            def clean_func(v):  # noqa: F811
                 return ast.literal_eval(v)
         elif isinstance(db_entry, (ca.ChannelEnum, )):
-            def clean_func(v):
+            def clean_func(v):  # noqa: F811
                 if ' ' not in v:
                     return v
                 return v.split(' ', 1)[1]
         elif isinstance(db_entry, ca.ChannelByte):
-            def clean_func(v):
+            def clean_func(v):  # noqa: F811
                 if pv.endswith('bytearray'):
                     return v.encode('latin-1')
                 else:
@@ -227,7 +227,7 @@ def test_with_caput(backends, prefix, pvdb_from_server_example, server, pv,
         elif isinstance(db_entry, ca.ChannelString):
             if pv.endswith('stra'):
                 # database holds ['char array'], caput shows [len char array]
-                def clean_func(v):
+                def clean_func(v):  # noqa: F811
                     return [v.split(' ', 1)[1]]
 
         if clean_func is not None:


### PR DESCRIPTION
Per the CI:
```
Run flake8 caproto/
caproto/server/conversion.py:184:24: E226 missing whitespace around arithmetic operator
caproto/server/conversion.py:187:29: E226 missing whitespace around arithmetic operator
caproto/server/conversion.py:190:20: E226 missing whitespace around arithmetic operator
caproto/server/conversion.py:191:20: E226 missing whitespace around arithmetic operator
caproto/server/conversion.py:192:20: E226 missing whitespace around arithmetic operator
caproto/server/conversion.py:193:20: E226 missing whitespace around arithmetic operator
caproto/server/conversion.py:194:20: E226 missing whitespace around arithmetic operator
caproto/server/conversion.py:195:20: E226 missing whitespace around arithmetic operator
caproto/tests/test_server.py:212:13: F811 redefinition of unused 'clean_func' from line 210
```