### PR TITLE
FIX: asyncio server subscription-related failures and (some) test suite instability

### DIFF
--- a/.ci/azure_env.sh
+++ b/.ci/azure_env.sh
@@ -10,7 +10,7 @@ echo '--- azure environment ---'
 env | grep EPIC
 echo '--- azure environment ---'
 
-source "$HOME/miniconda/etc/profile.d/conda.sh"
+source "$HOME/conda/etc/profile.d/conda.sh"
 hash -r
 
 conda activate test_env

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -16,12 +16,12 @@ repos:
     -   id: debug-statements
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.1.1
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
     -   id: isort
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,21 +40,12 @@ jobs:
     displayName: 'Configure the environment'
 
   - bash: |
-      wget -nv https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-      bash miniconda.sh -b -p $HOME/miniconda
-    displayName: 'Install conda'
+      wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+      bash Miniforge3.sh -b -p "${HOME}/conda"
+    displayName: 'Install miniforge'
 
   - bash: |
-      source "$HOME/miniconda/etc/profile.d/conda.sh"
-      hash -r
-      conda config --set always_yes yes --set changeps1 no
-      conda config --set channel_priority strict
-      conda config --add channels conda-forge
-      conda config --remove channels defaults
-    displayName: 'Configure conda'
-
-  - bash: |
-      source "$HOME/miniconda/etc/profile.d/conda.sh"
+      source "${HOME}/conda/etc/profile.d/conda.sh"
       hash -r
       conda info -a
       conda create -q -n test_env python=${PYTHON_VERSION} epics-base

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ jobs:
       source "${HOME}/conda/etc/profile.d/conda.sh"
       hash -r
       conda info -a
-      conda create -q -n test_env python=${PYTHON_VERSION} epics-base
+      conda create -y -q -n test_env python=${PYTHON_VERSION} epics-base
     displayName: 'Create test environment'
 
   - bash: |

--- a/caproto/asyncio/server.py
+++ b/caproto/asyncio/server.py
@@ -69,9 +69,8 @@ class VirtualCircuit(_VirtualCircuit):
     async def get_from_sub_queue(self, timeout=None):
         # Timeouts work very differently between our server implementations,
         # so we do this little stub in its own method.
-        fut = asyncio.ensure_future(self.subscription_queue.get())
         try:
-            return await asyncio.wait_for(fut, timeout)
+            return await asyncio.wait_for(self.subscription_queue.get(), timeout)
         except asyncio.TimeoutError:
             return None
 

--- a/caproto/tests/conftest.py
+++ b/caproto/tests/conftest.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import threading
 import time
+import typing
 import uuid
 from types import SimpleNamespace
 from typing import Callable, Dict
@@ -972,3 +973,13 @@ def pytest_runtest_call(item):
 @pytest.fixture(scope='session', params=list(ca.server.records.records))
 def record_type_name(request):
     return request.param
+
+
+def wait_for(func: typing.Callable[[], bool], timeout: float) -> None:
+    t0 = time.monotonic()
+    while time.monotonic() - t0 < timeout:
+        if func():
+            return
+        time.sleep(max((timeout / 10.), 0.1))
+
+    raise TimeoutError(f"Condition {func} not successful within {timeout}")

--- a/caproto/tests/epics_test_utils.py
+++ b/caproto/tests/epics_test_utils.py
@@ -10,10 +10,6 @@ import datetime
 import subprocess
 
 import asyncio
-import curio
-import curio.subprocess
-
-import trio
 
 import caproto as ca
 
@@ -75,8 +71,10 @@ async def run_epics_base_binary(backend, *args, max_attempts=3):
         return raw_stdout, raw_stderr
 
     if backend == 'curio':
+        import curio
         raw_stdout, raw_stderr = await curio.run_in_thread(runner)
     elif backend == 'trio':
+        import trio
         raw_stdout, raw_stderr = await trio.to_thread.run_sync(runner)
     elif backend == 'asyncio':
         loop = asyncio.get_event_loop()

--- a/caproto/tests/test_events_off.py
+++ b/caproto/tests/test_events_off.py
@@ -45,6 +45,7 @@ def test_issue_797(
     async_lib: str,
     issue_797_pvnames: list[str],
 ):
+    pytest.importorskip(async_lib)
     run_example_ioc(
         "caproto.tests.issue_797_server",
         request=request,

--- a/caproto/tests/test_examples.py
+++ b/caproto/tests/test_examples.py
@@ -43,6 +43,7 @@ def test_thread_client_example(pvdb_from_server_example):
 )
 @pytest.mark.parametrize('async_lib', ['curio', 'trio', 'asyncio'])
 def test_ioc_examples(request, module_name, async_lib):
+    pytest.importorskip(async_lib)
     from caproto.server import PvpropertyReadOnlyData
     info = conftest.run_example_ioc_by_name(
         module_name, async_lib=async_lib, request=request
@@ -212,6 +213,7 @@ def test_enum_linking(request, ioc_name):
 def test_event_read_collision(request, prefix, async_lib):
     # this is testing that monitors do not get pushed into
     # the socket while a ReadResponse is being pushed in parts.
+    pytest.importorskip(async_lib)
     conftest.run_example_ioc(
         'caproto.ioc_examples.big_image_noisy_neighbor',
         request=request,

--- a/caproto/tests/test_examples.py
+++ b/caproto/tests/test_examples.py
@@ -82,8 +82,11 @@ def test_ioc_examples(request, module_name, async_lib):
 
         print(f'Writing {value} to {pv}')
         sync.write(pv, value, timeout=15)
+        try:
+            value = sync.read(pv, timeout=15)
+        except TimeoutError:
+            value = sync.read(pv, timeout=15)
 
-        value = sync.read(pv, timeout=15)
         print(f'Read {pv} = {value}')
 
 

--- a/caproto/tests/test_pyepics_compat2.py
+++ b/caproto/tests/test_pyepics_compat2.py
@@ -61,10 +61,10 @@ def test_put_empty_list(context, ioc):
 
 
 def test_caget_caput(context, ioc):
-    caput(ioc.pvs['waveform'], [1, 2, 3], wait=True)
+    caput(ioc.pvs['waveform'], [1, 2, 3], wait=True, context=context)
 
     def new_value():
-        return list(caget(ioc.pvs['waveform'])) == [1, 2, 3]
+        return list(caget(ioc.pvs['waveform'], context=context)) == [1, 2, 3]
 
     wait_for(new_value, timeout=2)
 

--- a/caproto/tests/test_pyepics_compat2.py
+++ b/caproto/tests/test_pyepics_compat2.py
@@ -4,10 +4,12 @@ not use the pyepics test IOCs and can safely be run in parallel.
 """
 
 import pytest
+
+from caproto.threading.client import Context, SharedBroadcaster
+from caproto.threading.pyepics_compat import get_pv
+
 from .conftest import default_setup_module as setup_module  # noqa
 from .conftest import default_teardown_module as teardown_module  # noqa
-from caproto.threading.pyepics_compat import get_pv
-from caproto.threading.client import (Context, SharedBroadcaster)
 
 
 @pytest.fixture(scope='function')
@@ -50,5 +52,5 @@ def test_put_empty_list(context, ioc):
     assert pv.connected
 
     pv.put([], wait=True)
-    ret = pv.get()
+    ret = pv.get(use_monitor=False)
     assert list(ret) == []

--- a/caproto/tests/test_pyepics_compat2.py
+++ b/caproto/tests/test_pyepics_compat2.py
@@ -6,10 +6,11 @@ not use the pyepics test IOCs and can safely be run in parallel.
 import pytest
 
 from caproto.threading.client import Context, SharedBroadcaster
-from caproto.threading.pyepics_compat import get_pv
+from caproto.threading.pyepics_compat import caget, caput, get_pv
 
 from .conftest import default_setup_module as setup_module  # noqa
 from .conftest import default_teardown_module as teardown_module  # noqa
+from .conftest import wait_for
 
 
 @pytest.fixture(scope='function')
@@ -54,3 +55,12 @@ def test_put_empty_list(context, ioc):
     pv.put([], wait=True)
     ret = pv.get(use_monitor=False)
     assert list(ret) == []
+
+
+def test_caget_caput(context, ioc):
+    caput(ioc.pvs['waveform'], [1, 2, 3], wait=True)
+
+    def new_value():
+        return list(caget(ioc.pvs['waveform'])) == [1, 2, 3]
+
+    wait_for(new_value, timeout=2)

--- a/caproto/tests/test_records.py
+++ b/caproto/tests/test_records.py
@@ -1,12 +1,9 @@
-from functools import partial
-
 import pytest
 
 from caproto import AlarmSeverity, AlarmStatus, ChannelType
 from caproto.sync.client import read, write
 from caproto.threading.pyepics_compat import get_pv
 
-from .conftest import wait_for
 from .test_threading_client import context as _context
 from .test_threading_client import shared_broadcaster as _sb
 
@@ -54,13 +51,21 @@ def test_limit_fields_and_description(request, prefix, context, records_ioc):
 def test_alarms(request, prefix, sevr_target, sevr_value, context, records_ioc):
     pv = records_ioc.pvs["C"]
     PV = get_pv(pv, context=context)
-    get_pv(f'{pv}.{sevr_target}', context=context).put(
-        sevr_value, wait=True)
+    sevr_target_pv = get_pv(f'{pv}.{sevr_target}', context=context)
+    sevr_target_pv.put(sevr_value, wait=True)
 
     def get_severity(postfix):
-        return get_pv(f'{pv}.{postfix}',
-                      context=context).get(
-                          as_string=False)
+        if postfix == sevr_target:
+            postfix_pv = sevr_target_pv
+        else:
+            postfix_pv = get_pv(f'{pv}.{postfix}', context=context)
+
+        return postfix_pv.get(
+            as_string=False,
+            use_monitor=False,
+        )
+
+    assert get_severity(sevr_target) == sevr_value, "Specified severity not set"
 
     checks = (
         ('lower_ctrl_limit', 'lower_alarm_limit',
@@ -76,21 +81,11 @@ def test_alarms(request, prefix, sevr_target, sevr_value, context, records_ioc):
 
     )
 
-    def check_status_severity(a_status: AlarmStatus, a_sevr: AlarmSeverity):
-        ctrl_vars = PV.get_ctrlvars()
-        return ctrl_vars['status'] == a_status and ctrl_vars['severity'] == a_sevr
-
     for minv, maxv, a_status, a_sevr in checks:
         ctrl_vars = PV.get_ctrlvars()
         v = (ctrl_vars[minv] + ctrl_vars[maxv]) / 2
         PV.put(v, wait=True)
 
-        try:
-            wait_for(
-                partial(check_status_severity, a_status, a_sevr),
-                timeout=2.0,
-            )
-        except TimeoutError:
-            ctrl_vars = PV.get_ctrlvars()
-            assert ctrl_vars['status'] == a_status
-            assert ctrl_vars['severity'] == a_sevr
+        ctrl_vars = PV.get_ctrlvars()
+        assert ctrl_vars['status'] == a_status
+        assert ctrl_vars['severity'] == a_sevr

--- a/caproto/tests/test_repeater.py
+++ b/caproto/tests/test_repeater.py
@@ -1,13 +1,14 @@
 import logging
 import pytest
 
-import curio
 
 import caproto as ca
 from .epics_test_utils import run_caget, has_caget
 
 
 REPEATER_PORT = 5065
+
+curio = pytest.importorskip('curio')
 
 
 @pytest.mark.skipif(not has_caget(), reason='no caget')

--- a/caproto/tests/test_server.py
+++ b/caproto/tests/test_server.py
@@ -316,6 +316,7 @@ def test_char_write(request, type_varieties_ioc):
 
 @pytest.mark.parametrize('async_lib', ['asyncio', 'curio', 'trio'])
 def test_write_without_notify(request, prefix, async_lib):
+    pytest.importorskip(async_lib)
     pv = f'{prefix}pi'
     run_example_ioc(
         'caproto.ioc_examples.advanced.type_varieties',
@@ -366,6 +367,7 @@ def test_data_copy(cls, kwargs):
 
 @pytest.mark.parametrize('async_lib', ['asyncio', 'curio', 'trio'])
 def test_process_field(request, prefix, async_lib):
+    pytest.importorskip(async_lib)
     run_example_ioc('caproto.tests.ioc_process', request=request,
                     args=['--prefix', prefix, '--async-lib', async_lib],
                     pv_to_check=f'{prefix}record.PROC')

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -7,7 +7,6 @@ import getpass
 import socket
 import threading
 import time
-import typing
 
 import pytest
 
@@ -21,6 +20,7 @@ from caproto.threading.client import (Batch, Context, ContextDisconnectedError,
 
 from .conftest import default_setup_module as setup_module  # noqa
 from .conftest import default_teardown_module as teardown_module  # noqa
+from .conftest import wait_for
 
 THREAD_TIMEOUT_SCALE = 2
 
@@ -380,16 +380,6 @@ def test_subscription_objects_are_reused(ioc, context):
     time.sleep(0.2)  # Wait for EventAddRequest to be sent and processed.
     actual_cached_subs = set(pv.circuit_manager.subscriptions.values())
     assert actual_cached_subs == set([sub, sub_different])
-
-
-def wait_for(func: typing.Callable[[], bool], timeout: float) -> None:
-    t0 = time.monotonic()
-    while time.monotonic() - t0 < timeout:
-        if func():
-            return
-        time.sleep(max((timeout / 10.), 0.1))
-
-    raise TimeoutError(f"Condition {func} not successful within {timeout}")
 
 
 def test_unsubscribe_all(ioc, context):

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -594,7 +594,7 @@ def test_multithreaded_many_write(ioc, context, thread_count,
     sub.clear()
 
 
-@pytest.mark.xfail
+@pytest.mark.flaky(reruns=3)
 def test_multithreaded_many_subscribe(ioc, context, thread_count,
                                       multi_iterations):
     def _test(thread_id):

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -968,7 +968,7 @@ def get_pv(pvname, *args, context=None, connect=False, timeout=5, **kwargs):
     return pv
 
 
-def caput(pvname, value, wait=False, timeout=60):
+def caput(pvname, value, wait=False, timeout=60, context=None):
     """caput(pvname, value, wait=False, timeout=60)
     simple put to a pv's value.
        >>> caput('xx.VAL',3.0)
@@ -976,13 +976,13 @@ def caput(pvname, value, wait=False, timeout=60):
     to wait for pv to complete processing, use 'wait=True':
        >>> caput('xx.VAL',3.0,wait=True)
     """
-    thispv = get_pv(pvname, connect=True)
+    thispv = get_pv(pvname, connect=True, context=context)
     if thispv.connected:
         return thispv.put(value, wait=wait, timeout=timeout)
 
 
 def caget(pvname, as_string=False, count=None, as_numpy=True,
-          use_monitor=False, timeout=5.0):
+          use_monitor=False, timeout=5.0, context=None):
     """caget(pvname, as_string=False)
     simple get of a pv's value..
        >>> x = caget('xx.VAL')
@@ -996,7 +996,7 @@ def caget(pvname, as_string=False, count=None, as_numpy=True,
        >>> x = caget('MyArray.VAL', count=1000)
     """
     start_time = time.time()
-    thispv = get_pv(pvname, timeout=timeout, connect=True)
+    thispv = get_pv(pvname, timeout=timeout, connect=True, context=context)
     if thispv.connected:
         if as_string:
             thispv.get_ctrlvars()

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -955,8 +955,6 @@ class PV:
 
 
 def get_pv(pvname, *args, context=None, connect=False, timeout=5, **kwargs):
-    if context is None:
-        context = PV._default_context
     pv = PV(pvname, *args, context=context, **kwargs)
     if connect:
         pv.wait_for_connection(timeout=timeout)


### PR DESCRIPTION
### Related issues/PRs
Closes #830
Closes #434 (9f52809b2d2b38c96622d9833220b387c49d2038)
Supersedes #845

### Changes

* Picks up #845 because curio/trio are not fun to work with in 2024
* Fixes an apparently massive bug in server subscriptions causing test instability
   * Debugging led me to [this](https://github.com/caproto/caproto/issues/830#issuecomment-2525303112), and it seems `ensure_future` was the culprit causing the queue items to be dropped when a timeout happened
   * That change is [e75cf00](https://github.com/caproto/caproto/pull/854/commits/e75cf005cbbadffbd520e6ab8b53eb7fbcd75117)
   * Fixes the worst hit Windows IOCs on 3.12, but also improves stability in all other platforms and versions
* Fixes other test suite bugs, primarily `auto_monitor=True`-related race conditions that we should have caught ages ago
* Fixes documentation building
* Fixes Azure tests

### Original text

Anecdotally, this one test I focused on runs on my home Windows machine without failing now:

```
caproto/tests/test_threading_client.py::test_unsubscribe_all[caproto] PASSED  
```

(It's not due to the tweaked `time.sleep` bits - the subscriptions are actually now making it through from the queue to the socket rather than getting dropped)