### PR TITLE
Spoof Beamline: Add ability to define custom logic and fabricate PortName channel

### DIFF
--- a/caproto/ioc_examples/pathological/spoof_beamline.py
+++ b/caproto/ioc_examples/pathological/spoof_beamline.py
@@ -48,6 +48,10 @@ class BlackholeIOC(PVGroup):
 
     You can set up SubGroups for beamline components that interact with each other.
     """
+
+    # Special PVs or SubGroups may be defined here or in a subclass:
+    # custom_pv = pvproperty(value=123)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Copy the original pvdb so we can use it for channels
@@ -124,8 +128,8 @@ Press return if you have acknowledged the above, or Ctrl-C to quit.''')
         default_prefix='',
         desc="PV black hole")
     run_options['interfaces'] = ['127.0.0.1']
-    run(BlackholeIOC().pvdb,
-        **run_options)
+    ioc = BlackholeIOC(prefix="")
+    run(ioc.pvdb, **run_options)
 
 
 if __name__ == '__main__':

--- a/caproto/ioc_examples/pathological/spoof_beamline.py
+++ b/caproto/ioc_examples/pathological/spoof_beamline.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 from caproto import (ChannelChar, ChannelData, ChannelDouble, ChannelEnum,
                      ChannelInteger, ChannelString)
-from caproto.server import ioc_arg_parser, PVGroup, run
+from caproto.server import PVGroup, ioc_arg_parser, run
 
 PLUGIN_TYPE_PVS = [
     (re.compile('image\\d:'), 'NDPluginStdArrays'),
@@ -40,6 +40,7 @@ class ReallyDefaultDict(defaultdict):
             return self[key[:-4]]
         ret = self[key] = self.default_factory(key)
         return ret
+
 
 class BlackholeIOC(PVGroup):
     """
@@ -86,8 +87,7 @@ class BlackholeIOC(PVGroup):
             return ChannelData(value=1)
         elif 'WaitForPlugins' in key:
             return ChannelEnum(value=0, enum_strings=['No', 'Yes'])
-        elif ('file' in key.lower() and 'number' not in key.lower() and
-            'mode' not in key.lower()):
+        elif ('file' in key.lower() and 'number' not in key.lower() and 'mode' not in key.lower()):
             return ChannelChar(value='a' * 250)
         elif ('filenumber' in key.lower()):
             return ChannelInteger(value=0)


### PR DESCRIPTION
This adds two functionalities:
- The ability to add custom interaction between channels
- A default `ChannelString` for `PortName` to handle area detector plugins

An example of the spoof beamline that has custom interaction can be found here: 
https://github.com/thomashopkins32/CMS_profile_collection/blob/master/iocs/spoof_beamline.py#L62-L89