### PR TITLE
Make PV._default_context a public class method

### DIFF
--- a/caproto/tests/test_pyepics_compat.py
+++ b/caproto/tests/test_pyepics_compat.py
@@ -172,7 +172,8 @@ def pvnames(request, epics_base_ioc, context):
         def __repr__(self):
             return f'<PVNames prefix={epics_base_ioc.prefix}>'
 
-    PV._default_context = context
+    original_default_context = PV.default_context
+    PV.default_context = classmethod(lambda _: context)
 
     def finalize_context():
         print('Cleaning up PV context')
@@ -185,6 +186,7 @@ def pvnames(request, epics_base_ioc, context):
         assert not sb._command_thread.is_alive()
         assert not sb.selector.thread.is_alive()
         assert not sb._retry_unanswered_searches_thread.is_alive()
+        PV.default_context = original_default_context
         print('Done cleaning up PV context')
 
     request.addfinalizer(finalize_context)

--- a/caproto/tests/test_pyepics_compat2.py
+++ b/caproto/tests/test_pyepics_compat2.py
@@ -85,7 +85,7 @@ assert len(threading.enumerate()) > 1
     try:
         subprocess.run([sys.executable, "-c", c], check=True, timeout=5)
     except subprocess.CalledProcessError as err:
-        pytest.fail("Subprocess failed to test intended behavior\n" + str(err.stderr))
+        pytest.fail("Subprocess failed to test intended behavior\n" + str(err))
 
 
 def test_native_endianess(context, ioc):

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -195,7 +195,6 @@ class PV:
                'put_complete')
 
     @classmethod
-    @functools.cache
     def default_context(cls):
         return _make_context()
 
@@ -1041,7 +1040,7 @@ def caget_many(pvlist, as_string=False, count=None, as_numpy=True, timeout=5.0,
     as possible to fetch many values.
     """
     if context is None:
-        context = _make_context()
+        context = PV.default_context()
 
     pvs = context.get_pvs(*pvlist)
 

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -196,7 +196,7 @@ class PV:
 
     @classmethod
     @functools.cache
-    def _default_context(cls):
+    def default_context(cls):
         return _make_context()
 
     def __init__(self, pvname, callback=None, form='time',
@@ -206,7 +206,7 @@ class PV:
                  context=None):
 
         if context is None:
-            context = self._default_context()
+            context = self.default_context()
         if context is None:
             raise CaprotoRuntimeError("must have a valid context")
         self._context = context
@@ -1041,7 +1041,7 @@ def caget_many(pvlist, as_string=False, count=None, as_numpy=True, timeout=5.0,
     as possible to fetch many values.
     """
     if context is None:
-        context = PV._default_context()
+        context = PV.default_context()
 
     pvs = context.get_pvs(*pvlist)
 
@@ -1113,7 +1113,7 @@ def caput_many(pvlist, values, wait=False, connection_timeout=None,
     if len(pvlist) != len(values):
         raise CaprotoValueError("List of PV names must be equal to list of values.")
 
-    # context = PV._default_context
+    # context = PV.default_context()
     # TODO: context.get_pvs(...)
 
     out = []

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -195,7 +195,6 @@ class PV:
                'put_complete')
 
     @classmethod
-    @property
     @functools.cache
     def _default_context(cls):
         return _make_context()
@@ -207,7 +206,7 @@ class PV:
                  context=None):
 
         if context is None:
-            context = self._default_context
+            context = self._default_context()
         if context is None:
             raise CaprotoRuntimeError("must have a valid context")
         self._context = context
@@ -1042,7 +1041,7 @@ def caget_many(pvlist, as_string=False, count=None, as_numpy=True, timeout=5.0,
     as possible to fetch many values.
     """
     if context is None:
-        context = PV._default_context
+        context = PV._default_context()
 
     pvs = context.get_pvs(*pvlist)
 

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -194,8 +194,10 @@ class PV:
                'upper_warning_limit', 'upper_ctrl_limit', 'lower_ctrl_limit',
                'put_complete')
 
-    @functools.cached_property
-    def _default_context(self):
+    @classmethod
+    @property
+    @functools.cache
+    def _default_context(cls):
         return _make_context()
 
     def __init__(self, pvname, callback=None, form='time',


### PR DESCRIPTION
Currently, doing
```
PV._default_context
```
fails because it is actually an instance method rather than a class method. It is used this way in a couple of places:
- https://github.com/caproto/caproto/blob/284568779305335fed069459999a65e933cff93f/caproto/threading/pyepics_compat.py#L1043
- https://github.com/bluesky/ophyd/blob/main/ophyd/_caproto_shim.py#L202

This PR makes it a proper class method with caching.

Here is a small script I wrote to test this:
```python
import time
import functools


@functools.lru_cache(1)
def context():
    time.sleep(5)
    return Context({"name": "test"})

class Context:
    def __init__(self, context):
        self.context = context

    def __str__(self):
        return f"Context: {self.context}"


class TestClass:

    @classmethod
    @property
    @functools.cache
    def _default_cls_context(cls):
        return context()

    @functools.cached_property
    def _default_inst_context(self):
        return context()

    def __init__(self, name):
        self.name = name

    def __str__(self):
        return f"TestClass: {self.name}"

if __name__ == "__main__":
    print("First----------------------------------")
    print(TestClass._default_cls_context.context)
    print("Second----------------------------------")
    print(TestClass._default_cls_context.context)
    print("Done.")

```