### PR TITLE
#839 - Add await for "circuit_manager.disconnect()" co-routine.

### DIFF
--- a/caproto/asyncio/client.py
+++ b/caproto/asyncio/client.py
@@ -436,7 +436,7 @@ class SharedBroadcaster:
                                 "automatically begin attempting to reconnect "
                                 "to a responsive server.",
                                 *address, circuit_manager)
-                            circuit_manager.disconnect()
+                            await circuit_manager.disconnect()
                     checking.pop(address)
 
             await asyncio.sleep(0.5)


### PR DESCRIPTION
Fix "RuntimeWarning: coroutine 'VirtualCircuitManager.disconnect' was never awaited" in `asyncio/client.py` when a server becomes unresponsive.