### PR TITLE
Safer expand_macros

### DIFF
--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -1808,9 +1808,13 @@ class pvfunction(SubGroup):
 
 
 def expand_macros(pv, macros):
-    'Expand a PV name with Python {format-style} macros'
-    return pv.format(**macros)
-
+    '''If macros are given, expand a PV name with Python {format-style} macros. 
+    If macros is an empty dictionary, return the PV unchanged.
+    '''
+    if macros:
+        return pv.format(**macros)
+    else:
+        return pv
 
 class PVGroupMeta(type):
     'Metaclass that finds all pvproperties'


### PR DESCRIPTION
Updates expand_macros to only attempt macro substitution if a non-empty dictionary is passed.

In the case where macros are not passed, calling format carries a substantial risk of error, if the string contains instances of "{" or "}" which are not paired, which can easily happen in nested PVGroups that are attempting to follow NSLS-II standard PV name formats.

Needs testing, specifically with actual macros. I have tested the case where you don't want to pass in macros.

We could discuss adding a command-line switch for this, to make it opt-in, and eliminate all risk of modifying the current behavior of Caproto. But I can't imagine what the case is where you're not passing any macros, but `pv.format(**{})` does something that you want.