### PR TITLE
Allow longer PV names

### DIFF
--- a/caproto/_commands.py
+++ b/caproto/_commands.py
@@ -31,7 +31,7 @@ import _ctypes
 
 from . import _dbr as dbr
 from ._backend import backend
-from ._constants import DO_REPLY, MAX_RECORD_LENGTH, NO_REPLY
+from ._constants import DO_REPLY, NO_REPLY
 from ._dbr import (DBR_INT, DBR_TYPES, MAX_STRING_SIZE, AccessRights,
                    ChannelType, float_t, native_type, short_t, special_types,
                    ushort_t)
@@ -58,7 +58,7 @@ from ._status import eca_value_to_status, ensure_eca_value
 from ._utils import (CLIENT, NEED_DATA, REQUEST, RESPONSE, SERVER,
                      CaprotoNotImplementedError, CaprotoTypeError,
                      CaprotoValueError, RemoteProtocolError, ValidationError,
-                     ensure_bytes)
+                     name_to_bytes, padded_len, padded_string_payload)
 
 __all__ = ('AccessRightsResponse', 'ClearChannelRequest',
            'ClearChannelResponse', 'ClientNameRequest',
@@ -127,11 +127,6 @@ def from_buffer(data_type, data_count, buffer):
     return md_payload, data_payload
 
 
-def padded_len(s):
-    "Length of a (byte)string rounded up to the nearest multiple of 8."
-    return 8 * ((len(s) + 7) // 8)
-
-
 def pad_buffers(*buffers):
     '''Get a bytestring for padding a concatenated set of buffers
 
@@ -146,12 +141,6 @@ def pad_buffers(*buffers):
     unpadded_size = sum(bytelen(buf) for buf in buffers)
     pad_buffer = _pad_buffer[unpadded_size % 8]
     return unpadded_size + len(pad_buffer), pad_buffer
-
-
-def padded_string_payload(payload):
-    byte_payload = ensure_bytes(payload)
-    padded_size = padded_len(byte_payload)
-    return padded_size, byte_payload.ljust(padded_size, b'\x00')
 
 
 def bytelen(item):
@@ -612,14 +601,15 @@ class SearchRequest(Message):
     HAS_PAYLOAD = True
 
     def __init__(self, name, cid, version, reply=NO_REPLY):
-        size, payload = padded_string_payload(name)
-        rec, _, field = name.partition('.')
-        _len = len(rec)
-        if _len > MAX_RECORD_LENGTH:
-            raise CaprotoValueError('EPICS 3.14 imposes a {}-character limit '
-                                    'on record names. The record {!r} is {} '
-                                    'characters.'
-                                    ''.format(MAX_RECORD_LENGTH, name, _len))
+        if isinstance(name, bytes):
+            payload = name
+        else:
+            payload = name_to_bytes(name)
+        size = len(payload)
+        if len(payload) % 8:
+            raise CaprotoValueError(
+                "Bytes for channel name must be aligned to 8 bytes boundary."
+            )
         header = SearchRequestHeader(size, reply, version, cid)
         super().__init__(header, b'', payload)
 

--- a/caproto/_constants.py
+++ b/caproto/_constants.py
@@ -13,12 +13,13 @@ try:
 except AttributeError:
     EPICS_EPOCH = datetime.datetime.utcfromtimestamp(EPICS2UNIX_EPOCH)
 
+CA_HEADER_SIZE = 24  # Size of the Channel Access header.
 MAX_STRING_SIZE = 40
 MAX_UNITS_SIZE = 8
 MAX_ENUM_STRING_SIZE = 26
 MAX_ENUM_STATES = 16
-MAX_RECORD_LENGTH = 59  # from 3.14 on
 MAX_UDP_RECV = 0xFFFF - 16
+MAX_UDP_SEND = 1024  # Maximum size for a single search request.
 
 # Max of ethernet and 802.{2,3} MTU 1500 - 20(IP header) - 8(UDP header)
 SEARCH_MAX_DATAGRAM_BYTES = 1472

--- a/caproto/_utils.py
+++ b/caproto/_utils.py
@@ -26,6 +26,7 @@ from contextlib import contextmanager
 from typing import Iterable
 from warnings import warn
 
+from ._constants import CA_HEADER_SIZE, MAX_UDP_SEND
 from ._dbr import SubscriptionType
 from ._version import get_versions
 
@@ -64,6 +65,10 @@ __all__ = (  # noqa F822
     'ensure_bytes',
     'random_ports',
     'bcast_socket',
+    'max_name_len_for_socket',
+    'name_to_bytes',
+    'padded_len',
+    'padded_string_payload',
     'parse_record_field',
     'parse_channel_filter',
     'batch_requests',
@@ -616,6 +621,19 @@ def bcast_socket(socket_module=socket):
 
     sock.setsockopt(socket_module.SOL_SOCKET, socket_module.SO_BROADCAST, 1)
 
+    # We try to ensure that the send buffer size is at least 1024 bytes. The CA
+    # client in EPICS Base does the same.
+    try:
+        send_buffer_size = sock.getsockopt(
+            socket_module.SOL_SOCKET, socket_module.SO_SNDBUF
+        )
+        if send_buffer_size < MAX_UDP_SEND:
+            sock.setsockopt(
+                socket_module.SOL_SOCKET, socket_module.SO_SNDBUF, MAX_UDP_SEND
+            )
+    except (AttributeError, OSError):
+        pass
+
     # for BSD/Darwin only
     try:
         socket_module.SO_REUSEPORT
@@ -624,6 +642,75 @@ def bcast_socket(socket_module=socket):
     else:
         sock.setsockopt(socket_module.SOL_SOCKET, socket_module.SO_REUSEPORT, 1)
     return sock
+
+
+def max_name_len_for_socket(sock, socket_module=socket):
+    """
+    Calculate the maximum name of a CA channel name for the specified socket.
+    This length includes the mandatory terminating null byte.
+
+    Parameters
+    ----------
+    sock: socket
+        Socket for which the length shall be determined.
+    socket_module: module, optional
+        Default is the built-in :mod:`socket` module, but anything with the
+        same interface may be used, such as :mod:`curio.socket`.
+    """
+    try:
+        send_buffer_size = sock.getsockopt(
+            socket_module.SOL_SOCKET, socket_module.SO_SNDBUF
+        )
+    except (AttributeError, OSError):
+        # If we cannot determine the actual size of the send buffer, we assume
+        # a size of 1024 bytes. The CA client in EPICS Base does the same.
+        send_buffer_size = MAX_UDP_SEND
+    # EPICS Base (3.14 up to at least 7.0.6) limit packets to 1024 bytes when
+    # sending search requests, so we do not allow names that would exceed this
+    # length either.
+    send_buffer_size = min(send_buffer_size, MAX_UDP_SEND)
+    # We have to reserve 24 bytes for the CA header.
+    return send_buffer_size - CA_HEADER_SIZE
+
+
+def name_to_bytes(name, max_name_len=None):
+    """
+    Conver a channel name to the (padded) bytes representation.
+
+    Parameters
+    ----------
+    name: str
+        channel name that shall be converted
+    max_name_len: int | None
+        Maximum length of bytes representation (including the terminating) null
+        byte. If this limit is exceeded, a CaprotoValueError is raised. The
+        default is MAX_UDP_SEND - CA_HEADER_SIZE.
+    """
+    if max_name_len is None:
+        max_name_len = MAX_UDP_SEND - CA_HEADER_SIZE
+    size, payload = padded_string_payload(name)
+    if size > max_name_len:
+        raise CaprotoValueError(
+            'The name of a channel name is limited {} bytes (including '
+            'the terminating null byte), but the serialzed form of the '
+            'name {!r} has {} bytes.'.format(max_name_len, name, size)
+        )
+    return payload
+
+
+def padded_len(s):
+    "Length of a (byte)string rounded up to the nearest multiple of 8."
+    return 8 * ((len(s) + 7) // 8)
+
+
+def padded_string_payload(payload):
+    """
+    Convert a string to bytes, padding as necessary in order to make the
+    returned bytes object aligned to an 8-bytes boundary.
+    """
+    byte_payload = ensure_bytes(payload)
+    padded_size = padded_len(byte_payload)
+    return padded_size, byte_payload.ljust(padded_size, b'\x00')
 
 
 if 'pypy' in sys.implementation.name:

--- a/caproto/asyncio/client.py
+++ b/caproto/asyncio/client.py
@@ -23,7 +23,8 @@ import caproto as ca
 
 from .. import _constants as constants
 from .._utils import (ThreadsafeCounter, batch_requests,
-                      get_environment_variables, safe_getsockname)
+                      get_environment_variables, max_name_len_for_socket,
+                      name_to_bytes, safe_getsockname)
 from ..client import common
 from ..client.search_results import (DuplicateSearchResponse, SearchResults,
                                      UnknownSearchResponse)
@@ -506,8 +507,10 @@ class SharedBroadcaster:
         t = time.monotonic()
 
         def _construct_search_requests(items):
+            max_name_len = max_name_len_for_socket(self.udp_sock)
             for search_id, it in items:
-                yield ca.SearchRequest(it.name, search_id,
+                name_as_bytes = name_to_bytes(it.name, max_name_len)
+                yield ca.SearchRequest(name_as_bytes, search_id,
                                        ca.DEFAULT_PROTOCOL_VERSION)
                 it.last_sent = t
 

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -17,7 +17,7 @@ import caproto as ca
 from .._dbr import ChannelType, SubscriptionType, field_types, native_type
 from .._utils import (CaprotoError, CaprotoTimeoutError, ErrorResponseReceived,
                       adapt_old_callback_signature, get_environment_variables,
-                      safe_getsockname)
+                      max_name_len_for_socket, name_to_bytes, safe_getsockname)
 from ..client import common
 from .repeater import spawn_repeater
 
@@ -73,9 +73,13 @@ def search(pv_name, udp_sock, timeout, *, max_retries=2):
 
     logger.debug("Searching for %r....", pv_name)
     search_cid = random.randint(0, 65535)
+    max_name_len = max_name_len_for_socket(udp_sock)
+    pv_name_bytes = name_to_bytes(pv_name, max_name_len)
     commands = (
         ca.VersionRequest(0, ca.DEFAULT_PROTOCOL_VERSION),
-        ca.SearchRequest(pv_name, search_cid, ca.DEFAULT_PROTOCOL_VERSION),
+        ca.SearchRequest(
+            pv_name_bytes, search_cid, ca.DEFAULT_PROTOCOL_VERSION
+        ),
     )
     bytes_to_send = b.send(*commands)
     tags = {'role': 'CLIENT',

--- a/caproto/tests/test_serialization.py
+++ b/caproto/tests/test_serialization.py
@@ -316,7 +316,7 @@ def test_bytelen():
 
 def test_overlong_strings():
     with pytest.raises(ca.CaprotoValueError):
-        ca.SearchRequest(name='a' * (ca.MAX_RECORD_LENGTH + 1), cid=0,
+        ca.SearchRequest(name='a' * 1000, cid=0,
                          version=ca.DEFAULT_PROTOCOL_VERSION)
 
 

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -34,7 +34,8 @@ from .._utils import (CaprotoError, CaprotoKeyError, CaprotoNetworkError,
                       CaprotoRuntimeError, CaprotoTimeoutError,
                       CaprotoTypeError, CaprotoValueError, ThreadsafeCounter,
                       adapt_old_callback_signature, batch_requests,
-                      safe_getsockname, socket_bytes_available)
+                      max_name_len_for_socket, name_to_bytes, safe_getsockname,
+                      socket_bytes_available)
 from ..client import common
 
 ch_logger = logging.getLogger('caproto.ch')
@@ -853,8 +854,10 @@ class SharedBroadcaster:
 
             # filter to just things that need to go out
             def _construct_search_requests(items):
+                max_name_len = max_name_len_for_socket(self.udp_sock)
                 for search_id, it in items:
-                    yield ca.SearchRequest(it[0], search_id,
+                    name_as_bytes = name_to_bytes(it[0], max_name_len)
+                    yield ca.SearchRequest(name_as_bytes, search_id,
                                            ca.DEFAULT_PROTOCOL_VERSION)
                     # reset the last time this was sent
                     it[-2] = t


### PR DESCRIPTION
While the EPICS IOC code in EPICS Base limits record names to 60 bytes by default, this limit does not apply to the Channel Access protocol (and even in EPICS Base, it can easily be lifted by changing a preprocessor macro).

In fact, the CA client in EPICS Base allows for search requests with much larger channel names (usually up to 999 characters long).

This patch updates the code in caproto so that it uses the same limits that are used by EPICS Base, making it compatible with a wider variety of Channel Access servers and the names that they use.

For those who are interested in the details:

EPICS Base defines `MAX_UDP_SIZE` as 1024 in `caProto.h`. In `nciu.cpp`, it checks that names (including the terminating null byte) do not exceed `MAX_UDP_SIZE` minus the size of the `caHdr` data structure (which is 24), so the effective limit is 1000 bytes.
